### PR TITLE
Add context chips and buttons

### DIFF
--- a/app/components/ChatInput.tsx
+++ b/app/components/ChatInput.tsx
@@ -1,8 +1,10 @@
 "use client";
 import { useState } from "react";
-import { Box, Button, Textarea } from "@chakra-ui/react";
+import { Button, Flex, Textarea } from "@chakra-ui/react";
 import { ArrowUpIcon } from "@phosphor-icons/react";
 import useChatStore from "@/app/store/chatStore";
+import ContextButton, { ChatContextType } from "./ContextButton";
+import ContextTag from "./ContextTag";
 
 function ChatInput() {
   const [inputValue, setInputValue] = useState("");
@@ -10,7 +12,7 @@ function ChatInput() {
 
   const submitPrompt = async () => {
     if (!inputValue.trim() || isLoading) return;
-    
+
     const message = inputValue.trim();
     setInputValue("");
     
@@ -27,51 +29,94 @@ function ChatInput() {
   const getInputState = () => {
     return {
       disabled: isLoading,
-      message: isLoading ? "Sending..." : "Ask a question"
+      message: isLoading ? "Sending..." : "Ask Zeno a question",
     };
   };
 
   const { disabled, message } = getInputState();
   const isButtonDisabled = disabled || !inputValue?.trim();
-
+  const hasContext = true; // placeholder
+  const sampleContext = [
+    //placholder
+    { contextType: "date", content: "2023/11/21 - 2024/07/02" },
+    { contextType: "layer", content: "DIST Alerts" },
+    { contextType: "area", content: "Indonesia" },
+  ];
   return (
-    <Box position="relative" m={0} p={0}>
+    <Flex
+      flexDir="column"
+      position="relative"
+      gap={2}
+      m={0}
+      p={4}
+      bg="bg.subtle"
+      borderRadius="md"
+      borderWidth="1px"
+      className="group"
+      _active={{
+        bg: "white",
+        borderColor: "blue"
+      }}
+      _focusWithin={{
+        bg: "white",
+        borderColor: "blue"
+      }}
+    >
+      {hasContext && (
+        <Flex gap="2" wrap="wrap">
+          {sampleContext.map((c) => (
+            <ContextTag
+              key={c.content}
+              contextType={c.contextType as ChatContextType}
+              content={c.content}
+              closeable
+            />
+          ))}
+        </Flex>
+      )}
       <Textarea
-        aria-label="Ask a question"
+        aria-label="Ask Zeno a question"
         placeholder={message}
         fontSize="sm"
         autoresize
         maxH="10lh"
-        pr="12"
-        bg="bg.subtle"
+        border="none"
+        p={0}
         value={inputValue}
         onChange={(e) => setInputValue(e.target.value)}
         onKeyUp={handleKeyUp}
         disabled={disabled}
         _disabled={{
-          opacity: 1
+          opacity: 1,
+        }}
+        _focus={{
+          outline: "none",
         }}
       />
-      <Button
-        position="absolute"
-        right="2"
-        bottom="0.5"
-        transform="translateY(-50%)"
-        padding="0"
-        borderRadius="full"
-        colorPalette="blue"
-        _disabled={{
-          opacity: 0.75,
-        }}
-        type="button"
-        size="xs"
-        onClick={submitPrompt}
-        disabled={isButtonDisabled}
-        loading={isLoading}
-      >
-        <ArrowUpIcon />
-      </Button>
-    </Box>
+      <Flex justifyContent="space-between" alignItems="center" w="full">
+        <Flex gap="2">
+          <ContextButton contextType="area" />
+          <ContextButton contextType="layer" />
+          <ContextButton contextType="date" />
+        </Flex>
+        <Button
+          p="0"
+          ml="auto"
+          borderRadius="full"
+          colorPalette="blue"
+          _disabled={{
+            opacity: 0.75,
+          }}
+          type="button"
+          size="xs"
+          onClick={submitPrompt}
+          disabled={isButtonDisabled}
+          loading={isLoading}
+        >
+          <ArrowUpIcon />
+        </Button>
+      </Flex>
+    </Flex>
   );
 }
 

--- a/app/components/ContextButton.tsx
+++ b/app/components/ContextButton.tsx
@@ -1,0 +1,28 @@
+import { Button } from "@chakra-ui/react";
+import {
+  CalendarBlankIcon,
+  PolygonIcon,
+  StackSimpleIcon,
+} from "@phosphor-icons/react";
+
+export const ChatContextOptions = {
+  area: { icon: <PolygonIcon />, label: "Area" },
+  layer: { icon: <StackSimpleIcon />, label: "Data Layer" },
+  date: { icon: <CalendarBlankIcon />, label: "Date" },
+} as const;
+
+export type ChatContextType = keyof typeof ChatContextOptions;
+
+interface ContextButtonProps {
+  contextType?: ChatContextType;
+}
+
+function ContextButton({ contextType = "area" }: ContextButtonProps) {
+  return (
+    <Button size="xs" variant="surface" borderRadius="full" py="1" h="auto">
+      {ChatContextOptions[contextType].icon}
+      {ChatContextOptions[contextType].label}
+    </Button>
+  );
+}
+export default ContextButton;

--- a/app/components/ContextTag.tsx
+++ b/app/components/ContextTag.tsx
@@ -1,0 +1,33 @@
+import { Tag } from "@chakra-ui/react";
+import { ChatContextOptions, ChatContextType } from "./ContextButton";
+
+interface ContextTagProps {
+  contextType?: ChatContextType;
+  content?: string;
+  closeable?: boolean;
+}
+
+function ContextTag({
+  contextType = "area",
+  content = "Beirut, Lebanon",
+  closeable = false,
+}: ContextTagProps) {
+  return (
+    <Tag.Root
+      variant="solid"
+      bg="bg"
+      color="fg.muted"
+      borderWidth={closeable ? "1px" : "none"}
+      borderColor={closeable ? "border" : "transparent"}
+    >
+      <Tag.StartElement>{ChatContextOptions[contextType].icon}</Tag.StartElement>
+      <Tag.Label>{content}</Tag.Label>
+      {closeable && (
+        <Tag.EndElement>
+          <Tag.CloseTrigger />
+        </Tag.EndElement>
+      )}
+    </Tag.Root>
+  );
+}
+export default ContextTag;

--- a/app/components/MessageBubble.tsx
+++ b/app/components/MessageBubble.tsx
@@ -1,16 +1,19 @@
 "use client";
-import { Box, Text, Badge, Flex, IconButton } from "@chakra-ui/react";
+import { Box, Badge, Flex, IconButton } from "@chakra-ui/react";
 import { Tooltip } from "./ui/tooltip";
 import { ChatMessage } from "@/app/types/chat";
 import WidgetMessage from "./WidgetMessage";
 import Markdown from "react-markdown";
 import {
+  ArrowBendDownRightIcon,
   ArrowsCounterClockwiseIcon,
   CopyIcon,
   ThumbsDownIcon,
   ThumbsUpIcon,
 } from "@phosphor-icons/react";
 import LclLogo from "./LclLogo";
+import ContextTag from "./ContextTag";
+import { ChatContextType } from "./ContextButton";
 interface MessageBubbleProps {
   message: ChatMessage;
   isConsecutive?: boolean; // Whether this message is consecutive to the previous one of the same type
@@ -20,7 +23,14 @@ function MessageBubble({ message, isConsecutive = false }: MessageBubbleProps) {
   const isUser = message.type === "user";
   const isWidget = message.type === "widget";
   const isError = message.type === "error";
-
+  const hasContext = isUser && true; // placeholder
+  const sampleContext = [ //placholder
+    { contextType: "area", content: "Beirut, Lebanon" },
+    { contextType: "date", content: "2025/01/01 - 2025/03/19" },
+    { contextType: "layer", content: "FIRMS" },
+    { contextType: "area", content: "Svalbard" },
+    { contextType: "layer", content: "Fire alerts (VIRS)" },
+  ];
   // For widget messages, render them in a full-width container
   if (isWidget && message.widgets) {
     return (
@@ -37,6 +47,9 @@ function MessageBubble({ message, isConsecutive = false }: MessageBubbleProps) {
       mb={isConsecutive ? 1 : 4} // Reduced margin for consecutive messages
     >
       <Box
+        display="flex"
+        flexDir="column"
+        alignItems={isUser ? "flex-end" : "flex-start"}
         w={isUser ? "fit-content" : "100%"}
         maxW={isUser ? "80%" : "none"}
         bg={isError ? "red.50" : isUser ? "gray.100" : "transparent"}
@@ -50,23 +63,33 @@ function MessageBubble({ message, isConsecutive = false }: MessageBubbleProps) {
         borderColor={isError ? "red.200" : "transparent"}
       >
         {isError && <Badge colorPalette="red">Error</Badge>}
+        {hasContext &&
+          <Flex gap="2" wrap="wrap" mb="1" >
+            <Flex gap="1" fontSize="xs" color="fg.muted">
+              <ArrowBendDownRightIcon /> Context:
+            </Flex>
+            {sampleContext.map((c) => (
+              <ContextTag key={c.content} contextType={c.contextType as ChatContextType} content={c.content} />
+            ))}
+          </Flex>}
         <Markdown>{message.message}</Markdown>
+        {!isUser && (
         <Flex
           alignItems="center"
+          w="full"
           justifyContent="space-between"
           gap="2"
           transition="all 0.32s ease-in-out"
           opacity={0.5}
           _hover={{ opacity: 1 }}
         >
-          {!isUser && <LclLogo width={11} avatarOnly />}
-          <Text
+          <Flex
             fontSize="xs"
-            opacity={0.7}
-            mt={1}
+            color="fg.muted"
+            gap="2"
             textAlign={isUser ? "right" : "left"}
-            mr="auto"
-          >
+            >
+            <LclLogo width={11} avatarOnly />
             {new Date(message.timestamp).toLocaleString([], {
               hour: "2-digit",
               minute: "2-digit",
@@ -77,32 +100,31 @@ function MessageBubble({ message, isConsecutive = false }: MessageBubbleProps) {
               day: "2-digit",
               month: "short",
             })}
-          </Text>
-          {!isUser && (
-            <Flex>
-              <Tooltip content="Copy response">
-                <IconButton variant="ghost" size="xs">
-                  <CopyIcon />
-                </IconButton>
-              </Tooltip>
-              <Tooltip content="Good response">
-                <IconButton variant="ghost" size="xs">
-                  <ThumbsUpIcon />
-                </IconButton>
-              </Tooltip>
-              <Tooltip content="Bad response">
-                <IconButton variant="ghost" size="xs">
-                  <ThumbsDownIcon />
-                </IconButton>
-              </Tooltip>
-              <Tooltip content="Regenerate response">
-                <IconButton variant="ghost" size="xs">
-                  <ArrowsCounterClockwiseIcon />
-                </IconButton>
-              </Tooltip>
-            </Flex>
-          )}
+          </Flex>
+          <Flex>
+            <Tooltip content="Copy response">
+              <IconButton variant="ghost" size="xs">
+                <CopyIcon />
+              </IconButton>
+            </Tooltip>
+            <Tooltip content="Good response">
+              <IconButton variant="ghost" size="xs">
+                <ThumbsUpIcon />
+              </IconButton>
+            </Tooltip>
+            <Tooltip content="Bad response">
+              <IconButton variant="ghost" size="xs">
+                <ThumbsDownIcon />
+              </IconButton>
+            </Tooltip>
+            <Tooltip content="Regenerate response">
+              <IconButton variant="ghost" size="xs">
+                <ArrowsCounterClockwiseIcon />
+              </IconButton>
+            </Tooltip>
+          </Flex>
         </Flex>
+        )}
       </Box>
     </Box>
   );


### PR DESCRIPTION
This PR adds:
- context buttons to the input area to trigger the context modal menu
- context chips for use in:
    - input area when added (with `closeable` prop to remove)
    - user chat when applied
- changes to input area for addition of context chips + buttons

![image](https://github.com/user-attachments/assets/48601c88-5fab-472c-8f11-30f2436b0436)
