### PR TITLE
API health status component

### DIFF
--- a/app/sidebar.tsx
+++ b/app/sidebar.tsx
@@ -168,11 +168,10 @@ export function Sidebar() {
             ))}
           </Stack>
         )}
-        <Badge colorPalette="green">
-          <Status.Root colorPalette="green">
-            <Status.Indicator />
-          </Status.Root>
-        </Badge>
+        <Status.Root colorPalette="green" m="4">
+          <Status.Indicator />
+          API Status: Good
+        </Status.Root>
         <Separator my="4" />
         {hasOlderThreads && (
           <Stack gap="1" flex="1" mt="2">

--- a/app/sidebar.tsx
+++ b/app/sidebar.tsx
@@ -12,17 +12,12 @@ import {
   Stack,
   Text,
   Link as ChLink,
-  Badge,
   Status,
 } from "@chakra-ui/react";
 import Link from "next/link";
 
 import { Tooltip } from "./components/ui/tooltip";
-import {
-  NotePencilIcon,
-  SidebarSimpleIcon,
-  LightningIcon,
-} from "@phosphor-icons/react";
+import { NotePencilIcon, SidebarSimpleIcon } from "@phosphor-icons/react";
 import useSidebarStore from "./store/sidebarStore";
 import useChatStore from "./store/chatStore";
 

--- a/app/sidebar.tsx
+++ b/app/sidebar.tsx
@@ -12,11 +12,17 @@ import {
   Stack,
   Text,
   Link as ChLink,
+  Badge,
+  Status,
 } from "@chakra-ui/react";
 import Link from "next/link";
 
 import { Tooltip } from "./components/ui/tooltip";
-import { NotePencilIcon, SidebarSimpleIcon } from "@phosphor-icons/react";
+import {
+  NotePencilIcon,
+  SidebarSimpleIcon,
+  LightningIcon,
+} from "@phosphor-icons/react";
 import useSidebarStore from "./store/sidebarStore";
 import useChatStore from "./store/chatStore";
 
@@ -162,6 +168,11 @@ export function Sidebar() {
             ))}
           </Stack>
         )}
+        <Badge colorPalette="green">
+          <Status.Root colorPalette="green">
+            <Status.Indicator />
+          </Status.Root>
+        </Badge>
         <Separator my="4" />
         {hasOlderThreads && (
           <Stack gap="1" flex="1" mt="2">
@@ -179,7 +190,6 @@ export function Sidebar() {
             ))}
           </Stack>
         )}
-
         <ChLink
           href="#"
           _hover={{ textDecor: "none", layerStyle: "fill.muted" }}


### PR DESCRIPTION
Closes https://github.com/wri/project-zeno-next/issues/17

This stubs an API health status indicator in the sidebar.

<img width="253" height="835" alt="image" src="https://github.com/user-attachments/assets/c1b2765e-e366-49f6-9adc-f5351f01ea43" />

This is WIP. It doesn't check the actual health status of the API.
