### PR TITLE
Remove consecutive message actions

### DIFF
--- a/app/components/MessageBubble.tsx
+++ b/app/components/MessageBubble.tsx
@@ -88,7 +88,7 @@ function MessageBubble({ message, isConsecutive = false }: MessageBubbleProps) {
         <Box css={{ "& > p:not(:last-of-type)": {mb: 2}, "& > h1, & > h2, & > h3, & > h4, & > h5, & > h6": { borderBottom: "1px solid", borderColor: "bg.muted", pb: 2 } }}>
           <Markdown remarkPlugins={[ remarkBreaks ]}>{message.message}</Markdown>
         </Box>
-        {!isUser && (
+        {!isUser && !isConsecutive &&(
         <Flex
           alignItems="center"
           w="full"


### PR DESCRIPTION
Closes #38.

I believe this has been discussed, but I think the current, "always-on" message action bar is overly space-consuming and often offers actions that are unlikely to be useful (copying system messages, rating interim responses, etc). This is a nit, but wanted to provide a comparison and potential change. Defer to @01painadam and @faustoperez on your judgement.

| Current | Proposed Change | 
| -- | -- |
| <img width="500" alt="Image" src="https://github.com/user-attachments/assets/cab2123a-847c-411c-82cf-8b34225d1ec4" /> | <img width="500" alt="Image" src="https://github.com/user-attachments/assets/55765500-f5da-4061-b1d5-81ad91e4ac64" />|