### PR TITLE
Remove new conversation options

### DIFF
--- a/app/ChatPanelHeader.tsx
+++ b/app/ChatPanelHeader.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useId, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import {
   Flex,
   IconButton,
@@ -23,7 +23,6 @@ import useSidebarStore from "./store/sidebarStore";
 import useChatStore from "./store/chatStore";
 
 function ChatPanelHeader() {
-  const triggerId = useId();
   const router = useRouter();
   const {
     sideBarVisible,
@@ -126,38 +125,16 @@ function ChatPanelHeader() {
         </Button>
       )}
       {!sideBarVisible && (
-        <Menu.Root ids={{ trigger: triggerId }}>
-          <Tooltip
-            content="New conversation"
-            showArrow
-            ids={{ trigger: triggerId }}
-          >
-            <Menu.Trigger asChild>
-              <IconButton variant="ghost" size="sm">
-                <NotePencilIcon />
-              </IconButton>
-            </Menu.Trigger>
-          </Tooltip>
-          <Portal>
-            <Menu.Positioner>
-              <Menu.Content>
-                <Menu.Item
-                  value="New blank conversation"
-                  color="fg.muted"
-                  asChild
-                >
-                  <Link href="/">Blank Conversation</Link>
-                </Menu.Item>
-                <Menu.Item
-                  value="New conversation from template"
-                  color="fg.muted"
-                >
-                  From Template
-                </Menu.Item>
-              </Menu.Content>
-            </Menu.Positioner>
-          </Portal>
-        </Menu.Root>
+        <Tooltip
+          content="New conversation"
+          showArrow
+        >
+          <IconButton asChild variant="ghost" size="sm">
+            <Link href="/">
+              <NotePencilIcon />
+            </Link>
+          </IconButton>
+        </Tooltip>
       )}
 
       <ThreadRenameDialog

--- a/app/sidebar.tsx
+++ b/app/sidebar.tsx
@@ -6,8 +6,6 @@ import {
   HStack,
   IconButton,
   LinkProps,
-  Menu,
-  Portal,
   Separator,
   Stack,
   Text,
@@ -90,33 +88,12 @@ export function Sidebar() {
         bg="bg.muted"
         boxShadow="xs"
       >
-        <Menu.Root>
-          <Menu.Trigger asChild>
-            <Button variant="solid" colorPalette="blue" size="sm">
-              New Conversation
-              <NotePencilIcon />
-            </Button>
-          </Menu.Trigger>
-          <Portal>
-            <Menu.Positioner>
-              <Menu.Content>
-                <Menu.Item
-                  value="New blank conversation"
-                  color="fg.muted"
-                  asChild
-                >
-                  <Link href="/">Blank Conversation</Link>
-                </Menu.Item>
-                <Menu.Item
-                  value="New conversation from template"
-                  color="fg.muted"
-                >
-                  From Template
-                </Menu.Item>
-              </Menu.Content>
-            </Menu.Positioner>
-          </Portal>
-        </Menu.Root>
+        <Button asChild variant="solid" colorPalette="blue" size="sm">
+          <Link href="/">
+            New Conversation
+            <NotePencilIcon />
+          </Link>
+        </Button>
         <Tooltip
           content="Close sidebar"
           positioning={{ placement: "right" }}


### PR DESCRIPTION
Removes menu dropdown and option for "new conversation from template" for MVP.

NB: We can revert this when conversation templates are ready.

Contributes to #21 