### PR TITLE
Map area tag style changes

### DIFF
--- a/app/components/Map.tsx
+++ b/app/components/Map.tsx
@@ -27,11 +27,6 @@ function Map() {
   const { context } = useContextStore();
   const areas = context.filter((c) => c.contextType === "area");
 
-  // Color mode values - moved outside callback
-  const markerBg =
-    useColorModeValue("whiteAlpha.900", "blackAlpha.900") || "white";
-  const markerBorderColor = useColorModeValue("gray.200", "gray.600") || "gray";
-
   const onMapLoad = () => {
     if (mapRef.current) {
       const map = mapRef.current.getMap();
@@ -119,8 +114,6 @@ function Map() {
             key={feature.id}
             feature={feature}
             areas={areas}
-            markerBg={markerBg}
-            markerBorderColor={markerBorderColor}
           />
         ))}
 

--- a/app/components/MapFeature.tsx
+++ b/app/components/MapFeature.tsx
@@ -6,12 +6,10 @@ import {
   useMap,
   MapMouseEvent,
 } from "react-map-gl/maplibre";
-import { Box, Text, IconButton } from "@chakra-ui/react";
+import { Tag } from "@chakra-ui/react";
 import { ChatContextOptions } from "./ContextButton";
 import { Feature, Polygon, GeoJsonProperties, GeoJSON } from "geojson";
-import { ContextItem } from "@/app/store/contextStore";
-import useContextStore from "@/app/store/contextStore";
-import { XIcon } from "@phosphor-icons/react";
+import useContextStore, { ContextItem } from "@/app/store/contextStore";
 import bbox from "@turf/bbox";
 
 interface MapFeatureProps {
@@ -20,8 +18,6 @@ interface MapFeatureProps {
     data: GeoJSON;
   };
   areas: ContextItem[];
-  markerBg: string;
-  markerBorderColor: string;
 }
 
 // Create a rectangle polygon from bbox coordinates
@@ -50,8 +46,6 @@ function createBboxPolygon(
 function MapFeature({
   feature,
   areas,
-  markerBg,
-  markerBorderColor,
 }: MapFeatureProps) {
   const { current: map } = useMap();
   const { addContext, removeContext } = useContextStore();
@@ -269,43 +263,34 @@ function MapFeature({
           latitude={bboxCoords[3]}
           anchor="bottom-left"
         >
-          <Box
-            bg={markerBg}
-            px={1}
+          <Tag.Root
+            colorPalette={areaContext ? "blue" : "gray"}
+            px={2}
             py={1}
-            mb={1}
-            borderColor={markerBorderColor}
-            display="flex"
-            alignItems="center"
-            gap={1}
+            size="md"
+            variant={isHovered ? "surface" : "subtle"}
+            roundedBottom="none"
             onMouseEnter={handleLabelMouseEnter}
             onMouseLeave={handleLabelMouseLeave}
           >
-            {areaContext ? (
-              <>
-                <Box color={fillColor}>{ChatContextOptions.area.icon}</Box>
-                <Text fontSize="xs" fontWeight="medium" color={fillColor}>
-                  {feature.id}
-                </Text>
-                {/* Show X button on hover if in context */}
-                {isHovered && (
-                  <IconButton
-                    size="xs"
-                    variant="ghost"
-                    color={fillColor}
-                    onClick={handleRemoveFromContext}
-                    aria-label="Remove from context"
-                  >
-                    <XIcon size={12} />
-                  </IconButton>
-                )}
-              </>
-            ) : (
-              <Text fontSize="xs" fontWeight="medium" color={fillColor}>
-                {feature.id}
-              </Text>
+            {areaContext && (
+              <Tag.StartElement>
+                {ChatContextOptions.area.icon}
+              </Tag.StartElement>
             )}
-          </Box>
+            <Tag.Label fontWeight="medium">{feature.id}</Tag.Label>
+            {/* Show X button on hover if in context */}
+            {areaContext && (
+              <Tag.EndElement>
+                <Tag.CloseTrigger
+                  opacity={isHovered ? 1 : 0.25}
+                  cursor="pointer"
+                  onClick={handleRemoveFromContext}
+                  aria-label="Remove from context"
+                />
+              </Tag.EndElement>
+            )}
+          </Tag.Root>
         </Marker>
       )}
     </>


### PR DESCRIPTION
Uses the native Chakra UI `Tag` component for styling. This reduces the need for multiple components and also tightens up the styling some.

This also reduces the need for style props and passing mode-dependent colors.

Some noted changes:
- Selected color is currently not 100% matching design but this is dependent on a change to the theme.
- I've added the "Remove" `X` button in at all times to avoid layout shifts; just reducing opacity when unhovered. Updated in design as well

<img width="350" alt="image" src="https://github.com/user-attachments/assets/834bb9cf-d377-4b50-9576-cb0b5e4e547f" />
<img width="350" alt="image" src="https://github.com/user-attachments/assets/56038d2c-0d57-4deb-ae17-8f8ef8aa7727" />
