### PR TITLE
feat: pass user selected AOI to the backend by id

### DIFF
--- a/app/api/chat/read-data-stream.ts
+++ b/app/api/chat/read-data-stream.ts
@@ -1,7 +1,7 @@
 export async function readDataStream({ abortController, reader, onData }: {
   abortController: AbortController;
   reader: ReadableStreamDefaultReader<Uint8Array>;
-  onData: (data: string, isFinal: boolean) => void;
+  onData: (data: string, isFinal: boolean) => void | Promise<void>;
 }) {
   // Process the simplified streaming response
   const utf8Decoder = new TextDecoder("utf-8");
@@ -19,7 +19,7 @@ export async function readDataStream({ abortController, reader, onData }: {
       buffer = buffer.slice(lineBreakIndex + 1); // Remove processed line
 
       if (line) {
-        onData(line, false);
+        await onData(line, false);
       }
     }
 
@@ -30,6 +30,6 @@ export async function readDataStream({ abortController, reader, onData }: {
 
   // Handle any remaining data in the buffer
   if (buffer.trim() && !abortController.signal.aborted) {
-    onData(buffer, true);
+    await onData(buffer, true);
   }
 }

--- a/app/api/chat/route.ts
+++ b/app/api/chat/route.ts
@@ -8,6 +8,7 @@ import {
   StreamMessage,
 } from "@/app/types/chat";
 import { readDataStream } from "./read-data-stream";
+import { API_CONFIG } from "@/app/config/api";
 
 // Function to parse LangChain message into simplified format
 // messageType is either "agent" or "tools"
@@ -104,7 +105,7 @@ export async function POST(request: NextRequest) {
     }
 
     const body: ChatAPIRequest = await request.json();
-    const { query, query_type, thread_id } = body;
+    const { query, query_type, thread_id, ui_context } = body;
 
     if (!query || typeof query !== "string") {
       return NextResponse.json(
@@ -159,7 +160,7 @@ export async function POST(request: NextRequest) {
       });
     } else {
       // Normal flow - call the real Zeno API
-      response = await fetch("https://api.zeno-staging.ds.io/api/chat", {
+      response = await fetch(API_CONFIG.ENDPOINTS.CHAT, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
@@ -169,6 +170,7 @@ export async function POST(request: NextRequest) {
           query,
           query_type,
           thread_id,
+          ...(ui_context && { ui_context }),
         }),
         signal: abortController.signal,
       });

--- a/app/api/proxy/[...path]/route.ts
+++ b/app/api/proxy/[...path]/route.ts
@@ -1,8 +1,9 @@
 import { cookies } from "next/headers";
 import { NextRequest, NextResponse } from "next/server";
+import { API_CONFIG } from "@/app/config/api";
 
 const TOKEN_NAME = "auth_token";
-const BASE_URL = "https://api.zeno-staging.ds.io/api";
+const BASE_URL = API_CONFIG.API_BASE_URL;
 const METHODS_WITH_BODY = ["POST", "PUT"];
 
 async function getAuthToken(): Promise<string | null> {

--- a/app/api/threads/[id]/route.ts
+++ b/app/api/threads/[id]/route.ts
@@ -4,6 +4,7 @@ import JSON5 from "json5";
 import { parseStreamMessage } from "../../chat/route";
 import { readDataStream } from "../../chat/read-data-stream";
 import { LangChainResponse, StreamMessage } from "@/app/types/chat";
+import { API_CONFIG } from "@/app/config/api";
 
 const TOKEN_NAME = "auth_token";
 
@@ -30,7 +31,7 @@ export async function GET(
     }, 60000); // 60 second timeout
 
     const response = await fetch(
-      `https://api.zeno-staging.ds.io/api/threads/${id}`,
+      `${API_CONFIG.ENDPOINTS.THREADS}/${id}`,
       {
         headers: {
           "Content-Type": "application/json",
@@ -199,7 +200,7 @@ export async function PATCH(
     const body = await request.json();
 
     const response = await fetch(
-      `https://api.zeno-staging.ds.io/api/threads/${id}`,
+      `${API_CONFIG.ENDPOINTS.THREADS}/${id}`,
       {
         method: "PATCH",
         headers: {
@@ -238,7 +239,7 @@ export async function DELETE(
     }
 
     const response = await fetch(
-      `https://api.zeno-staging.ds.io/api/threads/${id}`,
+      `${API_CONFIG.ENDPOINTS.THREADS}/${id}`,
       {
         method: "DELETE",
         headers: {

--- a/app/api/threads/route.ts
+++ b/app/api/threads/route.ts
@@ -1,5 +1,6 @@
 import { cookies } from "next/headers";
 import { NextResponse } from "next/server";
+import { API_CONFIG } from "@/app/config/api";
 
 const TOKEN_NAME = "auth_token";
 
@@ -12,7 +13,7 @@ export async function GET() {
       return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
     }
 
-    const response = await fetch("https://api.zeno-staging.ds.io/api/threads", {
+    const response = await fetch(API_CONFIG.ENDPOINTS.THREADS, {
       headers: {
         "Content-Type": "application/json",
         Authorization: `Bearer ${token}`,

--- a/app/config/api.ts
+++ b/app/config/api.ts
@@ -1,0 +1,11 @@
+const API_HOST = process.env.NEXT_PUBLIC_API_HOST || 'https://api.zeno-staging.ds.io';
+
+export const API_CONFIG = {
+  API_HOST,
+  API_BASE_URL: `${API_HOST}/api`,
+  ENDPOINTS: {
+    CHAT: `${API_HOST}/api/chat`,
+    METADATA: `${API_HOST}/api/metadata`,
+    THREADS: `${API_HOST}/api/threads`
+  }
+} as const;

--- a/app/store/contextStore.ts
+++ b/app/store/contextStore.ts
@@ -5,6 +5,14 @@ export interface ContextItem {
   id: string;
   contextType: ChatContextType;
   content: string | object;
+  // For AOI context, store additional details needed for ui_context
+  aoiData?: {
+    name: string;
+    gadm_id?: string;
+    src_id?: string;
+    subtype?: string;
+    source?: string;
+  };
 }
 
 interface ContextState {

--- a/app/store/sidebarStore.ts
+++ b/app/store/sidebarStore.ts
@@ -1,4 +1,5 @@
 import { create } from "zustand";
+import { API_CONFIG } from "@/app/config/api";
 
 interface ThreadEntry {
   agent_id: "UniGuana";
@@ -126,7 +127,7 @@ const useSidebarStore = create<SidebarState>((set, get) => ({
 
   fetchApiStatus: async () => {
     try {
-      const response = await fetch("https://api.zeno-staging.ds.io/docs"); // shouldn't hard code this
+      const response = await fetch(`${API_CONFIG.API_HOST}/docs`);
       if (response.status === 200) {
         set({ apiStatus: "OK" });
       } else {

--- a/app/types/chat.ts
+++ b/app/types/chat.ts
@@ -38,6 +38,22 @@ export interface ChatAPIRequest {
   query: string;
   query_type: string;
   thread_id: string;
+  ui_context?: {
+    aoi_selected?: {
+      aoi: {
+        name: string;
+        gadm_id?: string;
+        src_id?: string;
+        subtype?: string;
+      };
+      aoi_name: string;
+      subregion_aois?: null;
+      subregion?: null;
+      subtype?: string;
+    };
+    dataset_selected?: object;
+    daterange_selected?: object;
+  };
 }
 
 // Simplified message that our API sends to the client
@@ -57,7 +73,10 @@ export interface StreamMessage {
 
 export interface AOI {
   name: string;
-  geometry: FeatureCollection;
+  src_id: string;
+  source: string;
+  subtype: string;
+  geometry?: FeatureCollection; // Optional since it may not be included in the initial response
 }
 
 // LangChain content structure (for internal API use)

--- a/app/utils/geometryClient.ts
+++ b/app/utils/geometryClient.ts
@@ -1,0 +1,44 @@
+import { FeatureCollection } from "geojson";
+
+export interface GeometryResponse {
+  geometry: FeatureCollection;
+  [key: string]: unknown;
+}
+
+export interface SourceToIdMapping {
+  [source: string]: string;
+}
+
+/**
+ * Fetches geometry data for a given source and src_id
+ * @param source - The data source (e.g., 'gadm', 'kba', 'wdpa', 'landmark')
+ * @param srcId - The source-specific ID
+ * @returns Promise resolving to geometry data
+ */
+export async function fetchGeometry(
+  source: string,
+  srcId: string
+): Promise<GeometryResponse> {
+  const response = await fetch(`/api/proxy/geometry/${source}/${srcId}`);
+  
+  if (!response.ok) {
+    throw new Error(`Failed to fetch geometry: ${response.status} ${response.statusText}`);
+  }
+  
+  return response.json();
+}
+
+/**
+ * Fetches the source to ID field mapping
+ * @returns Promise resolving to the mapping object
+ */
+export async function fetchSourceToIdMapping(): Promise<SourceToIdMapping> {
+  const response = await fetch(`/api/proxy/metadata`);
+  
+  if (!response.ok) {
+    throw new Error(`Failed to fetch metadata: ${response.status} ${response.statusText}`);
+  }
+  
+  const data = await response.json();
+  return data.layer_id_mapping;
+}


### PR DESCRIPTION
Also:
- removes hardcoded staging backend url and makes backend url configurable for easy use with local backend

Since I've been working closely with the backend and the LLM tools lately and understand how geometry ids are handled there -- I thought it'll be useful to start this PR to make sure id handling on the frontend doesn't become too much of a blocker.

depends on https://github.com/wri/project-zeno/pull/270. Addresses https://github.com/wri/project-zeno-next/issues/28.

cc @kamicut 

Here's how this looks right now:


https://github.com/user-attachments/assets/496e8c15-9481-4bf2-bc3b-cc55b247d070


