### PR TITLE
Connect custom areas to context

### DIFF
--- a/app/components/Map.tsx
+++ b/app/components/Map.tsx
@@ -115,14 +115,14 @@ function Map() {
           <MapFeature key={feature.id} feature={feature} areas={areas} />
         ))}
 
-        {selectAreaLayer && (
+        {selectAreaLayer && selectAreaLayer !== "Custom" && (
           <SelectAreaLayer
             key={selectAreaLayer}
             layerId={selectAreaLayer}
             beforeId={undefined}
           />
         )}
-        <CustomAreasLayer />
+        {selectAreaLayer === "Custom" && <CustomAreasLayer />}
         <MapAreaControls />
 
         <AttributionControl

--- a/app/components/Map.tsx
+++ b/app/components/Map.tsx
@@ -14,7 +14,7 @@ import { PlusIcon } from "@phosphor-icons/react";
 import { useColorModeValue } from "./ui/color-mode";
 import useMapStore from "@/app/store/mapStore";
 import MapAreaControls from "./MapAreaControls";
-import SelectAreaLayer from "./SelectAreaLayer";
+import SelectAreaLayer from "./map/layers/SelectAreaLayer";
 import useContextStore from "@/app/store/contextStore";
 import CustomAreasLayer from "./map/layers/CustomAreasLayer";
 import MapFeature from "./MapFeature";

--- a/app/components/map/layers/CustomAreasLayer.tsx
+++ b/app/components/map/layers/CustomAreasLayer.tsx
@@ -125,12 +125,17 @@ function CustomAreasLayer() {
           id="custom-areas-fill"
           type="fill"
           paint={{
-            "fill-color": "#f59e0b",
+            "fill-color": [
+              "case",
+              ["boolean", ["feature-state", "hover"], false],
+              "#fbbf24",
+              "#f59e0b",
+            ],
             "fill-opacity": [
               "case",
               ["boolean", ["feature-state", "hover"], false],
-              0.6,
-              0.4,
+              0.7,
+              0.2,
             ],
           }}
           filter={["==", ["geometry-type"], "Polygon"]}
@@ -139,25 +144,26 @@ function CustomAreasLayer() {
           id="custom-areas-line"
           type="line"
           paint={{
-            "line-color": "#d97706",
-            "line-width": 3,
+            "line-color": [
+              "case",
+              ["boolean", ["feature-state", "hover"], false],
+              "#f59e0b",
+              "#d97706",
+            ],
+            "line-width": [
+              "case",
+              ["boolean", ["feature-state", "hover"], false],
+              4,
+              3,
+            ],
+            "line-opacity": [
+              "case",
+              ["boolean", ["feature-state", "hover"], false],
+              1,
+              0.8,
+            ],
           }}
-          filter={[
-            "in",
-            ["geometry-type"],
-            ["literal", ["Polygon", "LineString"]],
-          ]}
-        />
-        <Layer
-          id="custom-areas-circle"
-          type="circle"
-          paint={{
-            "circle-color": "#d97706",
-            "circle-radius": 8,
-            "circle-stroke-color": "#ffffff",
-            "circle-stroke-width": 2,
-          }}
-          filter={["==", ["geometry-type"], "Point"]}
+          filter={["==", ["geometry-type"], "Polygon"]}
         />
       </Source>
       {hoverInfo && <AreaTooltip hoverInfo={hoverInfo} />}

--- a/app/components/map/layers/CustomAreasLayer.tsx
+++ b/app/components/map/layers/CustomAreasLayer.tsx
@@ -1,7 +1,7 @@
 import { Layer, Source, MapMouseEvent } from "react-map-gl/maplibre";
 import { FeatureCollection, Polygon } from "geojson";
 import { useCustomAreasList } from "@/app/hooks/useCustomAreasList";
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import useMapStore from "@/app/store/mapStore";
 import useContextStore from "@/app/store/contextStore";
 import AreaTooltip, { HoverInfo } from "@/app/components/ui/AreaTooltip";
@@ -14,24 +14,27 @@ function CustomAreasLayer() {
   const { addContext } = useContextStore();
   const [hoverInfo, setHoverInfo] = useState<HoverInfo>();
 
-  const handleClick = (e: MapMouseEvent) => {
-    if (e.features && e.features.length > 0) {
-      const feature = e.features.find(
-        (f) => f.source === CUSTOM_AREAS_SOURCE_ID
-      );
-      if (feature) {
-        const { name } = feature.properties;
-        addContext({
-          contextType: "area",
-          content: name,
-          aoiData: {
-            name,
-            source: "custom",
-          },
-        });
+  const handleClick = useCallback(
+    (e: MapMouseEvent) => {
+      if (e.features && e.features.length > 0) {
+        const feature = e.features.find(
+          (f) => f.source === CUSTOM_AREAS_SOURCE_ID
+        );
+        if (feature) {
+          const { name } = feature.properties;
+          addContext({
+            contextType: "area",
+            content: name,
+            aoiData: {
+              name,
+              source: "custom",
+            },
+          });
+        }
       }
-    }
-  };
+    },
+    [addContext]
+  );
 
   useEffect(() => {
     if (!mapRef) return;
@@ -86,7 +89,7 @@ function CustomAreasLayer() {
       map.off("mouseenter", "custom-areas-fill", handleMouseEnter);
       map.off("mouseleave", "custom-areas-fill", handleMouseLeave);
     };
-  }, [mapRef]);
+  }, [mapRef, handleClick]);
 
   if (isLoading) {
     return null;

--- a/app/components/map/layers/CustomAreasLayer.tsx
+++ b/app/components/map/layers/CustomAreasLayer.tsx
@@ -3,12 +3,14 @@ import { FeatureCollection, Polygon } from "geojson";
 import { useCustomAreasList } from "@/app/hooks/useCustomAreasList";
 import { useEffect } from "react";
 import useMapStore from "@/app/store/mapStore";
+import useContextStore from "@/app/store/contextStore";
 
 const CUSTOM_AREAS_SOURCE_ID = "custom-areas-source";
 
 function CustomAreasLayer() {
   const { customAreas, isLoading, error } = useCustomAreasList();
   const { mapRef } = useMapStore();
+  const { addContext } = useContextStore();
 
   const handleClick = (e: MapMouseEvent) => {
     if (e.features && e.features.length > 0) {
@@ -16,7 +18,15 @@ function CustomAreasLayer() {
         (f) => f.source === CUSTOM_AREAS_SOURCE_ID
       );
       if (feature) {
-        console.log("Clicked custom area:", feature.properties);
+        const { name } = feature.properties;
+        addContext({
+          contextType: "area",
+          content: name,
+          aoiData: {
+            name,
+            source: "custom",
+          },
+        });
       }
     }
   };

--- a/app/components/map/layers/SelectAreaLayer.tsx
+++ b/app/components/map/layers/SelectAreaLayer.tsx
@@ -1,11 +1,5 @@
 import { useEffect, useState } from "react";
-import {
-  Layer,
-  MapMouseEvent,
-  Popup,
-  Source,
-  useMap,
-} from "react-map-gl/maplibre";
+import { Layer, MapMouseEvent, Source, useMap } from "react-map-gl/maplibre";
 import { union } from "@turf/union";
 import "../../../theme/popup.css";
 
@@ -26,16 +20,11 @@ import {
   MultiPolygon,
   Polygon,
 } from "geojson";
+import AreaTooltip, { HoverInfo } from "../../ui/AreaTooltip";
 
 interface SourceLayerProps {
   layerId: LayerId;
   beforeId?: string;
-}
-
-interface HoverInfo {
-  lng: number;
-  lat: number;
-  name: string;
 }
 
 interface Metadata {
@@ -253,20 +242,10 @@ function SelectAreaLayer({ layerId, beforeId }: SourceLayerProps) {
         />
       </Source>
       {hoverInfo && (
-        <Popup
-          longitude={hoverInfo.lng}
-          latitude={hoverInfo.lat}
-          offset={[0, -20] as [number, number]}
-          closeButton={false}
-          anchor="left"
-        >
-          <p className="area-name">
-            <b>{hoverInfo.name}</b>
-          </p>
-          <p className="hint">{`Click to select ${singularizeDatasetName(
-            datasetName
-          )}. Esc to exit.`}</p>
-        </Popup>
+        <AreaTooltip
+          hoverInfo={hoverInfo}
+          areaName={singularizeDatasetName(datasetName)}
+        />
       )}
     </>
   );

--- a/app/components/map/layers/SelectAreaLayer.tsx
+++ b/app/components/map/layers/SelectAreaLayer.tsx
@@ -203,6 +203,10 @@ function SelectAreaLayer({ layerId, beforeId }: SourceLayerProps) {
     nameKeys,
     setSelectAreaLayer,
     metadata,
+    addContext,
+    addGeoJsonFeature,
+    layerId,
+    url,
   ]);
 
   return (

--- a/app/components/map/layers/SelectAreaLayer.tsx
+++ b/app/components/map/layers/SelectAreaLayer.tsx
@@ -7,12 +7,12 @@ import {
   useMap,
 } from "react-map-gl/maplibre";
 import { union } from "@turf/union";
-import "../theme/popup.css";
+import "../../../theme/popup.css";
 
-import { LayerId, LayerName, selectLayerOptions } from "../types/map";
-import useContextStore from "../store/contextStore";
-import useMapStore from "../store/mapStore";
-import { API_CONFIG } from "../config/api";
+import { LayerId, LayerName, selectLayerOptions } from "../../../types/map";
+import useContextStore from "../../../store/contextStore";
+import useMapStore from "../../../store/mapStore";
+import { API_CONFIG } from "../../../config/api";
 import {
   Feature,
   FeatureCollection,
@@ -52,9 +52,13 @@ function singularizeDatasetName(name: LayerName): string {
 }
 
 // Helper function to get src_id based on metadata
-function getSrcId(layerId: LayerId, featureProps: any, metadata: any): string | undefined {
+function getSrcId(
+  layerId: LayerId,
+  featureProps: any,
+  metadata: any
+): string | undefined {
   const layerKey = layerId.toLowerCase();
-  
+
   if (layerKey === "gadm") {
     // Special case for GADM: use gid{adm_level}
     const admLevel = featureProps?.adm_level;
@@ -64,7 +68,7 @@ function getSrcId(layerId: LayerId, featureProps: any, metadata: any): string | 
     }
     return featureProps?.gadm_id;
   }
-  
+
   // For other layers, use the mapping from metadata
   const idField = metadata.layer_id_mapping[layerKey];
   if (idField && featureProps?.[idField]) {
@@ -73,18 +77,26 @@ function getSrcId(layerId: LayerId, featureProps: any, metadata: any): string | 
 }
 
 // Helper function to get subtype based on metadata
-function getSubtype(layerId: LayerId, featureProps: any, metadata: any): string | undefined {
+function getSubtype(
+  layerId: LayerId,
+  featureProps: any,
+  metadata: any
+): string | undefined {
   const layerKey = layerId.toLowerCase();
-  
+
   if (layerKey === "gadm") {
     // Special case for GADM: use adm_level to determine subtype
     const admLevel = featureProps?.adm_level;
-    if (admLevel !== undefined && admLevel !== null && metadata.gadm_subtype_mapping) {
+    if (
+      admLevel !== undefined &&
+      admLevel !== null &&
+      metadata.gadm_subtype_mapping
+    ) {
       const gidKey = `GID_${admLevel}`;
       return metadata.gadm_subtype_mapping[gidKey];
     }
   }
-  
+
   // For other layers, use subregion_to_subtype_mapping
   if (metadata.subregion_to_subtype_mapping?.[layerKey]) {
     return metadata.subregion_to_subtype_mapping[layerKey];
@@ -121,10 +133,10 @@ function SelectAreaLayer({ layerId, beforeId }: SourceLayerProps) {
         setMetadata(data);
         console.log("Fetched metadata:", data);
       } catch (error) {
-        console.error('Failed to fetch metadata:', error);
+        console.error("Failed to fetch metadata:", error);
       }
     };
-    
+
     fetchMetadata();
   }, []);
 
@@ -210,14 +222,16 @@ function SelectAreaLayer({ layerId, beforeId }: SourceLayerProps) {
             }
             // Extract AOI data for ui_context
             const featureProps = feature.properties;
-            const layerConfig = selectLayerOptions.find(opt => opt.id === layerId);
-            
+            const layerConfig = selectLayerOptions.find(
+              (opt) => opt.id === layerId
+            );
+
             // Get dynamic src_id and subtype using metadata
             const dynamicSrcId = getSrcId(layerId, featureProps, metadata);
             const dynamicSubtype = getSubtype(layerId, featureProps, metadata);
 
             const idField = metadata?.layer_id_mapping?.[layerId.toLowerCase()];
-            
+
             addContext({
               contextType: "area",
               content: aoiName,
@@ -251,7 +265,15 @@ function SelectAreaLayer({ layerId, beforeId }: SourceLayerProps) {
         document.removeEventListener("keyup", onKeyUp);
       };
     }
-  }, [map, fillLayerName, sourceId, sourceLayer, nameKeys, setSelectAreaLayer, metadata]);
+  }, [
+    map,
+    fillLayerName,
+    sourceId,
+    sourceLayer,
+    nameKeys,
+    setSelectAreaLayer,
+    metadata,
+  ]);
 
   return (
     <>

--- a/app/components/map/layers/SelectAreaLayer.tsx
+++ b/app/components/map/layers/SelectAreaLayer.tsx
@@ -9,10 +9,16 @@ import {
 import { union } from "@turf/union";
 import "../../../theme/popup.css";
 
-import { LayerId, LayerName, selectLayerOptions } from "../../../types/map";
+import { LayerId, selectLayerOptions } from "../../../types/map";
 import useContextStore from "../../../store/contextStore";
 import useMapStore from "../../../store/mapStore";
 import { API_CONFIG } from "../../../config/api";
+import {
+  getAoiName,
+  getSrcId,
+  getSubtype,
+  singularizeDatasetName,
+} from "../../../utils/areaHelpers";
 import {
   Feature,
   FeatureCollection,
@@ -32,75 +38,10 @@ interface HoverInfo {
   name: string;
 }
 
-function getAoiName(
-  nameKeys: readonly string[],
-  properties: { [key: string]: string }
-): string {
-  return nameKeys.reduce(
-    (acc: string, key: string, idx: number) =>
-      properties[key] ? `${properties[key]}${idx > 0 ? ", " : ""}${acc}` : acc,
-    ""
-  );
-}
-
-function singularizeDatasetName(name: LayerName): string {
-  if (name.endsWith("s")) {
-    return name.slice(0, -1);
-  }
-
-  return name;
-}
-
-// Helper function to get src_id based on metadata
-function getSrcId(
-  layerId: LayerId,
-  featureProps: any,
-  metadata: any
-): string | undefined {
-  const layerKey = layerId.toLowerCase();
-
-  if (layerKey === "gadm") {
-    // Special case for GADM: use gid{adm_level}
-    const admLevel = featureProps?.adm_level;
-    if (admLevel !== undefined && admLevel !== null) {
-      const gidKey = `gid_${admLevel}`;
-      return featureProps?.[gidKey] || featureProps?.gadm_id || "";
-    }
-    return featureProps?.gadm_id;
-  }
-
-  // For other layers, use the mapping from metadata
-  const idField = metadata.layer_id_mapping[layerKey];
-  if (idField && featureProps?.[idField]) {
-    return featureProps[idField];
-  }
-}
-
-// Helper function to get subtype based on metadata
-function getSubtype(
-  layerId: LayerId,
-  featureProps: any,
-  metadata: any
-): string | undefined {
-  const layerKey = layerId.toLowerCase();
-
-  if (layerKey === "gadm") {
-    // Special case for GADM: use adm_level to determine subtype
-    const admLevel = featureProps?.adm_level;
-    if (
-      admLevel !== undefined &&
-      admLevel !== null &&
-      metadata.gadm_subtype_mapping
-    ) {
-      const gidKey = `GID_${admLevel}`;
-      return metadata.gadm_subtype_mapping[gidKey];
-    }
-  }
-
-  // For other layers, use subregion_to_subtype_mapping
-  if (metadata.subregion_to_subtype_mapping?.[layerKey]) {
-    return metadata.subregion_to_subtype_mapping[layerKey];
-  }
+interface Metadata {
+  layer_id_mapping: Record<string, string>;
+  gadm_subtype_mapping?: Record<string, string>;
+  subregion_to_subtype_mapping?: Record<string, string>;
 }
 
 function SelectAreaLayer({ layerId, beforeId }: SourceLayerProps) {
@@ -108,7 +49,7 @@ function SelectAreaLayer({ layerId, beforeId }: SourceLayerProps) {
   const { addGeoJsonFeature, setSelectAreaLayer } = useMapStore();
   const { current: map } = useMap();
   const [hoverInfo, setHoverInfo] = useState<HoverInfo>();
-  const [metadata, setMetadata] = useState<any>(null);
+  const [metadata, setMetadata] = useState<Metadata | null>(null);
 
   const selectAreaLayerConfig = selectLayerOptions.find(
     ({ id }) => id === layerId

--- a/app/components/ui/AreaTooltip.tsx
+++ b/app/components/ui/AreaTooltip.tsx
@@ -1,0 +1,35 @@
+import { Popup } from "react-map-gl/maplibre";
+
+export interface HoverInfo {
+  lng: number;
+  lat: number;
+  name: string;
+}
+
+interface AreaTooltipProps {
+  hoverInfo: HoverInfo | undefined;
+  areaName?: string;
+}
+
+function AreaTooltip({ hoverInfo, areaName }: AreaTooltipProps) {
+  if (!hoverInfo) return null;
+
+  const displayName = areaName || hoverInfo.name;
+
+  return (
+    <Popup
+      longitude={hoverInfo.lng}
+      latitude={hoverInfo.lat}
+      offset={[0, -20] as [number, number]}
+      closeButton={false}
+      anchor="left"
+    >
+      <p className="area-name">
+        <b>{displayName}</b>
+      </p>
+      <p className="hint">Click to select {displayName}. Esc to exit.</p>
+    </Popup>
+  );
+}
+
+export default AreaTooltip;

--- a/app/store/chatStore.ts
+++ b/app/store/chatStore.ts
@@ -29,6 +29,21 @@ interface ChatActions {
   fetchThread: (threadId: string) => Promise<void>;
 }
 
+interface UiContext {
+  aoi_selected?: {
+    aoi: {
+      name: string;
+      gadm_id?: string;
+      src_id?: string;
+      subtype?: string;
+    };
+    aoi_name: string;
+    subregion_aois: null;
+    subregion: null;
+    subtype?: string;
+  };
+}
+
 const initialState: ChatState = {
   messages: [
     {
@@ -40,7 +55,7 @@ const initialState: ChatState = {
     },
   ],
   isLoading: false,
-  currentThreadId: null
+  currentThreadId: null,
 };
 
 // Helper function to process stream messages and add them to chat
@@ -135,10 +150,13 @@ const useChatStore = create<ChatState & ChatActions>((set, get) => ({
     setLoading(true);
 
     // Build ui_context from current context
-    const ui_context: any = {};
-    
+
+    const ui_context: UiContext = {};
+
     // Find area context and convert to aoi_selected format
-    const areaContext = context.find(ctx => ctx.contextType === "area" && ctx.aoiData);
+    const areaContext = context.find(
+      (ctx) => ctx.contextType === "area" && ctx.aoiData
+    );
     if (areaContext && areaContext.aoiData) {
       ui_context.aoi_selected = {
         aoi: {

--- a/app/store/mapStore.ts
+++ b/app/store/mapStore.ts
@@ -6,7 +6,6 @@ import { LayerId } from "../types/map";
 import { DrawAreaSlice, createDrawAreaSlice } from "./drawAreaSlice";
 import { UploadAreaSlice, createUploadAreaSlice } from "./uploadAreaSlice";
 import { StateCreator } from "zustand";
-import { AOI } from "../types/chat";
 
 interface GeoJsonFeature {
   id: string;
@@ -39,9 +38,6 @@ interface MapSlice {
     maxRetries?: number
   ) => void;
 
-  customAreas: AOI[];
-  addCustomArea: (area: AOI) => void;
-
   selectionMode: SelectionMode | undefined;
   setSelectionMode: (mode: SelectionMode | undefined) => void;
   clearSelectionMode: () => void;
@@ -57,15 +53,7 @@ const createMapSlice: StateCreator<MapState, [], [], MapSlice> = (
   geoJsonFeatures: [],
   selectAreaLayer: null,
   selectedAreas: [],
-  customAreas: [],
   selectionMode: undefined,
-
-  addCustomArea: (area) => {
-    set((state) => ({
-      customAreas: [...state.customAreas, area],
-    }));
-    get().clearSelectionMode();
-  },
 
   reset: () => {
     set({

--- a/app/types/map.ts
+++ b/app/types/map.ts
@@ -4,30 +4,34 @@ export const selectLayerOptions = Object.freeze([
     name: "Administrative Areas",
     url: "https://tiles.globalforestwatch.org/gadm_administrative_boundaries/v4.1.85/default/{z}/{x}/{y}.pbf",
     sourceLayer: "gadm_administrative_boundaries",
-    nameKeys: ["name_0", "name_1", "name_2"]
+    nameKeys: ["name_0", "name_1", "name_2"],
   },
   {
     id: "KBA",
     name: "Key Biodiversity Areas",
     url: "https://tiles.globalforestwatch.org/birdlife_key_biodiversity_areas/latest/default/{z}/{x}/{y}.pbf",
     sourceLayer: "birdlife_key_biodiversity_areas",
-    nameKeys: ["intname"]
+    nameKeys: ["intname"],
   },
   {
     id: "WDPA",
     name: "Protected Areas",
     url: "https://tiles.globalforestwatch.org/wdpa_protected_areas/latest/default/{z}/{x}/{y}.pbf",
     sourceLayer: "wdpa_protected_areas",
-    nameKeys: ["name"]
+    nameKeys: ["name"],
   },
   {
     id: "LandMark",
     name: "Indigenous Lands",
     url: "https://tiles.globalforestwatch.org/landmark_indigenous_and_community_lands/latest/default/{z}/{x}/{y}.pbf",
     sourceLayer: "landmark_indigenous_and_community_lands",
-    nameKeys: ["name"]
+    nameKeys: ["name"],
+  },
+  {
+    id: "Custom",
+    name: "Custom Areas",
   },
 ] as const);
 
-export type LayerId = typeof selectLayerOptions[number]['id'];
-export type LayerName = typeof selectLayerOptions[number]['name'];
+export type LayerId = (typeof selectLayerOptions)[number]["id"];
+export type LayerName = (typeof selectLayerOptions)[number]["name"];

--- a/app/utils/areaHelpers.ts
+++ b/app/utils/areaHelpers.ts
@@ -1,5 +1,17 @@
 import { LayerId, LayerName } from "../types/map";
 
+interface FeatureProperties {
+  [key: string]: unknown;
+  adm_level?: number;
+  gadm_id?: string;
+}
+
+interface Metadata {
+  layer_id_mapping: Record<string, string>;
+  gadm_subtype_mapping?: Record<string, string>;
+  subregion_to_subtype_mapping?: Record<string, string>;
+}
+
 export function getAoiName(
   nameKeys: readonly string[],
   properties: { [key: string]: string }
@@ -20,8 +32,8 @@ export function singularizeDatasetName(name: LayerName): string {
 
 export function getSrcId(
   layerId: LayerId,
-  featureProps: any,
-  metadata: any
+  featureProps: FeatureProperties,
+  metadata: Metadata
 ): string | undefined {
   const layerKey = layerId.toLowerCase();
 
@@ -36,14 +48,14 @@ export function getSrcId(
 
   const idField = metadata.layer_id_mapping[layerKey];
   if (idField && featureProps?.[idField]) {
-    return featureProps[idField];
+    return String(featureProps[idField]);
   }
 }
 
 export function getSubtype(
   layerId: LayerId,
-  featureProps: any,
-  metadata: any
+  featureProps: FeatureProperties,
+  metadata: Metadata
 ): string | undefined {
   const layerKey = layerId.toLowerCase();
 

--- a/app/utils/areaHelpers.ts
+++ b/app/utils/areaHelpers.ts
@@ -1,0 +1,65 @@
+import { LayerId, LayerName } from "../types/map";
+
+export function getAoiName(
+  nameKeys: readonly string[],
+  properties: { [key: string]: string }
+): string {
+  return nameKeys.reduce(
+    (acc: string, key: string, idx: number) =>
+      properties[key] ? `${properties[key]}${idx > 0 ? ", " : ""}${acc}` : acc,
+    ""
+  );
+}
+
+export function singularizeDatasetName(name: LayerName): string {
+  if (name.endsWith("s")) {
+    return name.slice(0, -1);
+  }
+  return name;
+}
+
+export function getSrcId(
+  layerId: LayerId,
+  featureProps: any,
+  metadata: any
+): string | undefined {
+  const layerKey = layerId.toLowerCase();
+
+  if (layerKey === "gadm") {
+    const admLevel = featureProps?.adm_level;
+    if (admLevel !== undefined && admLevel !== null) {
+      const gidKey = `gid_${admLevel}`;
+      return featureProps?.[gidKey] || featureProps?.gadm_id || "";
+    }
+    return featureProps?.gadm_id;
+  }
+
+  const idField = metadata.layer_id_mapping[layerKey];
+  if (idField && featureProps?.[idField]) {
+    return featureProps[idField];
+  }
+}
+
+export function getSubtype(
+  layerId: LayerId,
+  featureProps: any,
+  metadata: any
+): string | undefined {
+  const layerKey = layerId.toLowerCase();
+
+  if (layerKey === "gadm") {
+    const admLevel = featureProps?.adm_level;
+    if (
+      admLevel !== undefined &&
+      admLevel !== null &&
+      metadata.gadm_subtype_mapping
+    ) {
+      const gidKey = `GID_${admLevel}`;
+      return metadata.gadm_subtype_mapping[gidKey];
+    }
+  }
+
+  if (metadata.subregion_to_subtype_mapping?.[layerKey]) {
+    return metadata.subregion_to_subtype_mapping[layerKey];
+  }
+}


### PR DESCRIPTION
**Contributes to #27**

The goal of this PR is to enable **custom areas** as part of the context system.

### Changes included:

* Added 'Custom Area' option to the pick AOI tool
* Custom Area layer interactions:
  * Clicking an area adds it to the context chip display
  * Hovering an area updates its style
* Small refactor in `<SelectAreaLayer/>`
* Fixed lint issues

### Preview:

![custom-area-context](https://github.com/user-attachments/assets/a9d78f42-b431-4098-b15d-7b4a48778b6b)

### Notes:

* We might want to refactor `SelectAreaLayer` to act as a wrapper for `CustomAreasLayer`, but I’m not sure that belongs in this PR
* This doesn't send the custom area to the backend API yet

@kamicut @LanesGood @danielfdsilva This is a work in progress, feel free to leave questions or suggestions.