### PR TITLE
Capture null & undefined langchain messages

### DIFF
--- a/app/api/shared/parse-stream-message.ts
+++ b/app/api/shared/parse-stream-message.ts
@@ -10,8 +10,8 @@ export function parseStreamMessage(
   langChainMessage: LangChainUpdate,
   messageType: "agent" | "tools" | "human"
 ): StreamMessage | null {
-  // Validate input structure
-  if (!langChainMessage?.messages[0]?.kwargs) {
+  // Validate input structure (captures null & undefined messages)
+  if (!langChainMessage?.messages?.[0]?.kwargs)  {
     return null;
   }
 


### PR DESCRIPTION
Quick fix to address instances where langchain messages from the API are null or undefined. 