### PR TITLE
Aborts fetch on unmount to prevent Strict Mode errors

### DIFF
--- a/app/(chat)/threads/[id]/page.tsx
+++ b/app/(chat)/threads/[id]/page.tsx
@@ -14,7 +14,14 @@ export default function SingleThread() {
 
   useEffect(() => {
     if (id) {
-      fetchThread(id as string);
+      const abortController = new AbortController();
+      fetchThread(id as string, abortController);
+
+      return () => {
+        // Cleanup function to abort the fetch if the component unmounts.
+        // This happens during development because of React Strict Mode.
+        abortController.abort();
+      };
     }
   }, [id, fetchThread]);
 


### PR DESCRIPTION
Fix #145 

The duplicate messages were happening because the fetchThreads method was being called twice. This is due to [React's StrictMode](https://react.dev/reference/react/StrictMode#fixing-bugs-found-by-re-running-effects-in-development), which during development runs `useEffect` hooks twice. This hook in particular was not performing a cleanup.