### PR TITLE
Add typewriter text effect [ DO NOT MERGE ]

### DIFF
--- a/app/components/ChatMessages.tsx
+++ b/app/components/ChatMessages.tsx
@@ -9,6 +9,11 @@ function ChatMessages() {
   const containerRef = useRef<HTMLDivElement>(null);
   const { messages, isLoading, isFetchingThread } = useChatStore();
 
+  const lastAssistantIdx = messages
+  .map((msg, idx) => (msg.type === "assistant" ? idx : -1))
+  .filter(idx => idx !== -1)
+  .pop();
+
   // Auto-scroll to bottom when new messages are added
   useEffect(() => {
     if (containerRef.current) {
@@ -51,6 +56,7 @@ function ChatMessages() {
             key={message.id} 
             message={message} 
             isConsecutive={isConsecutive}
+            isLatestAssistant={index === lastAssistantIdx}
           />
         );
       })}

--- a/app/components/ChatMessages.tsx
+++ b/app/components/ChatMessages.tsx
@@ -3,10 +3,11 @@ import { useEffect, useRef } from "react";
 import { Box } from "@chakra-ui/react";
 import useChatStore from "@/app/store/chatStore";
 import MessageBubble from "./MessageBubble";
+import ThinkingMessage from "./ThinkingMessage";
 
 function ChatMessages() {
   const containerRef = useRef<HTMLDivElement>(null);
-  const { messages } = useChatStore();
+  const { messages, isLoading } = useChatStore();
 
   // Auto-scroll to bottom when new messages are added
   useEffect(() => {
@@ -35,6 +36,9 @@ function ChatMessages() {
     }
   }, []);
 
+  const lastMessage = messages[messages.length - 1];
+  const showThinking = isLoading && lastMessage?.type === "user";
+
   return (
     <Box ref={containerRef} fontSize="sm">
       {messages.map((message, index) => {
@@ -50,6 +54,7 @@ function ChatMessages() {
           />
         );
       })}
+      {showThinking && <ThinkingMessage />}
     </Box>
   );
 }

--- a/app/components/ChatMessages.tsx
+++ b/app/components/ChatMessages.tsx
@@ -42,7 +42,10 @@ function ChatMessages() {
   }, []);
 
   const lastMessage = messages[messages.length - 1];
-  const showThinking = isLoading && lastMessage?.type === "user" && !isFetchingThread;
+  // Always show realtime thinking when a user message is in-flight
+  const showThinking = isLoading && lastMessage?.type === "user";
+  // Show historical fetch skeleton only when we're fetching and no messages are displayed yet
+  const showFetching = isFetchingThread && messages.length === 0 && !isLoading;
 
   return (
     <Box ref={containerRef} fontSize="sm">
@@ -60,7 +63,7 @@ function ChatMessages() {
           />
         );
       })}
-      {isFetchingThread && <ThinkingMessage label="Fetching conversation" />}
+      {showFetching && <ThinkingMessage label="Fetching conversation" />}
       {showThinking && <ThinkingMessage />}
     </Box>
   );

--- a/app/components/ChatMessages.tsx
+++ b/app/components/ChatMessages.tsx
@@ -7,7 +7,7 @@ import ThinkingMessage from "./ThinkingMessage";
 
 function ChatMessages() {
   const containerRef = useRef<HTMLDivElement>(null);
-  const { messages, isLoading } = useChatStore();
+  const { messages, isLoading, isFetchingThread } = useChatStore();
 
   // Auto-scroll to bottom when new messages are added
   useEffect(() => {
@@ -37,7 +37,7 @@ function ChatMessages() {
   }, []);
 
   const lastMessage = messages[messages.length - 1];
-  const showThinking = isLoading && lastMessage?.type === "user";
+  const showThinking = isLoading && lastMessage?.type === "user" && !isFetchingThread;
 
   return (
     <Box ref={containerRef} fontSize="sm">
@@ -54,6 +54,7 @@ function ChatMessages() {
           />
         );
       })}
+      {isFetchingThread && <ThinkingMessage label="Fetching conversation" />}
       {showThinking && <ThinkingMessage />}
     </Box>
   );

--- a/app/components/MessageBubble.tsx
+++ b/app/components/MessageBubble.tsx
@@ -109,6 +109,8 @@ function MessageBubble({ message, isConsecutive = false, isLatestAssistant = fal
           {message.type === "assistant" && isLatestAssistant ? (
             <TypewriterText
               text={message.message}
+              //skip if fetching thread
+              skipAnimation={message.source === 'historical'}
               render={(displayed) => (
                 <Markdown remarkPlugins={[remarkBreaks]}>{displayed}</Markdown>
               )}

--- a/app/components/MessageBubble.tsx
+++ b/app/components/MessageBubble.tsx
@@ -106,19 +106,17 @@ function MessageBubble({ message, isConsecutive = false, isLatestAssistant = fal
             },
           }}
         >
-          {message.type === "assistant" ? (
-            isLatestAssistant ? (
-              <TypewriterText
-                text={message.message}
-                render={displayed => (
-                  <Markdown remarkPlugins={[remarkBreaks]}>{displayed}</Markdown>
-                )}
-              />
-            ) : (
-              <Markdown remarkPlugins={[remarkBreaks]}>{message.message}</Markdown>
-            )
+          {message.type === "assistant" && isLatestAssistant ? (
+            <TypewriterText
+              text={message.message}
+              render={(displayed) => (
+                <Markdown remarkPlugins={[remarkBreaks]}>{displayed}</Markdown>
+              )}
+            />
           ) : (
-            <Markdown remarkPlugins={[remarkBreaks]}>{message.message}</Markdown>
+            <Markdown remarkPlugins={[remarkBreaks]}>
+              {message.message}
+            </Markdown>
           )}
         </Box>
         {!isUser && !isConsecutive && (

--- a/app/components/MessageBubble.tsx
+++ b/app/components/MessageBubble.tsx
@@ -97,30 +97,30 @@ function MessageBubble({ message, isConsecutive = false, isLatestAssistant = fal
           </Flex>
         )}
         <Box
-  css={{
-    "& > p:not(:last-of-type)": { mb: 2 },
-    "& > h1, & > h2, & > h3, & > h4, & > h5, & > h6": {
-      borderBottom: "1px solid",
-      borderColor: "bg.muted",
-      pb: 2,
-    },
-  }}
->
-  {message.type === "assistant" ? (
-    isLatestAssistant ? (
-      <TypewriterText
-        text={message.message}
-        render={displayed => (
-          <Markdown remarkPlugins={[remarkBreaks]}>{displayed}</Markdown>
-        )}
-      />
-    ) : (
-      <Markdown remarkPlugins={[remarkBreaks]}>{message.message}</Markdown>
-    )
-  ) : (
-    <Markdown remarkPlugins={[remarkBreaks]}>{message.message}</Markdown>
-  )}
-</Box>
+          css={{
+            "& > p:not(:last-of-type)": { mb: 2 },
+            "& > h1, & > h2, & > h3, & > h4, & > h5, & > h6": {
+              borderBottom: "1px solid",
+              borderColor: "bg.muted",
+              pb: 2,
+            },
+          }}
+        >
+          {message.type === "assistant" ? (
+            isLatestAssistant ? (
+              <TypewriterText
+                text={message.message}
+                render={displayed => (
+                  <Markdown remarkPlugins={[remarkBreaks]}>{displayed}</Markdown>
+                )}
+              />
+            ) : (
+              <Markdown remarkPlugins={[remarkBreaks]}>{message.message}</Markdown>
+            )
+          ) : (
+            <Markdown remarkPlugins={[remarkBreaks]}>{message.message}</Markdown>
+          )}
+        </Box>
         {!isUser && !isConsecutive && (
           <Flex
             alignItems="center"

--- a/app/components/MessageBubble.tsx
+++ b/app/components/MessageBubble.tsx
@@ -17,13 +17,15 @@ import { ChatContextType } from "./ContextButton";
 import { ContextItem } from "../store/contextStore";
 import { useEffect, useState } from "react";
 import remarkBreaks from "remark-breaks";
+import TypewriterText from "./TypewriterText";
 
 interface MessageBubbleProps {
   message: ChatMessage;
   isConsecutive?: boolean; // Whether this message is consecutive to the previous one of the same type
+  isLatestAssistant?: boolean;
 }
 
-function MessageBubble({ message, isConsecutive = false }: MessageBubbleProps) {
+function MessageBubble({ message, isConsecutive = false, isLatestAssistant = false }: MessageBubbleProps) {
   const [formattedTimestamp, setFormattedTimestamp] = useState("");
 
   useEffect(() => {
@@ -57,7 +59,7 @@ function MessageBubble({ message, isConsecutive = false }: MessageBubbleProps) {
     <Box
       display="flex"
       justifyContent={isUser ? "flex-end" : "flex-start"}
-      mb={isConsecutive ? 1 : 4} // Reduced margin for consecutive messages
+      mb={isConsecutive ? 1 : 4}
     >
       <Box
         display="flex"
@@ -95,17 +97,30 @@ function MessageBubble({ message, isConsecutive = false }: MessageBubbleProps) {
           </Flex>
         )}
         <Box
-          css={{
-            "& > p:not(:last-of-type)": { mb: 2 },
-            "& > h1, & > h2, & > h3, & > h4, & > h5, & > h6": {
-              borderBottom: "1px solid",
-              borderColor: "bg.muted",
-              pb: 2,
-            },
-          }}
-        >
-          <Markdown remarkPlugins={[remarkBreaks]}>{message.message}</Markdown>
-        </Box>
+  css={{
+    "& > p:not(:last-of-type)": { mb: 2 },
+    "& > h1, & > h2, & > h3, & > h4, & > h5, & > h6": {
+      borderBottom: "1px solid",
+      borderColor: "bg.muted",
+      pb: 2,
+    },
+  }}
+>
+  {message.type === "assistant" ? (
+    isLatestAssistant ? (
+      <TypewriterText
+        text={message.message}
+        render={displayed => (
+          <Markdown remarkPlugins={[remarkBreaks]}>{displayed}</Markdown>
+        )}
+      />
+    ) : (
+      <Markdown remarkPlugins={[remarkBreaks]}>{message.message}</Markdown>
+    )
+  ) : (
+    <Markdown remarkPlugins={[remarkBreaks]}>{message.message}</Markdown>
+  )}
+</Box>
         {!isUser && !isConsecutive && (
           <Flex
             alignItems="center"

--- a/app/components/ThinkingMessage.tsx
+++ b/app/components/ThinkingMessage.tsx
@@ -1,4 +1,4 @@
-import { Box, Flex, Skeleton, SkeletonText, Spinner } from "@chakra-ui/react";
+import { Box, Flex, SkeletonText, Spinner } from "@chakra-ui/react";
 
 export default function ThinkingMessage() {
 

--- a/app/components/ThinkingMessage.tsx
+++ b/app/components/ThinkingMessage.tsx
@@ -1,0 +1,58 @@
+import { Box, Flex, Skeleton } from "@chakra-ui/react";
+import { todo } from "node:test";
+
+export default function ThinkingMessage() {
+  //@todo("Define 'nice' skeleton structure")
+  // Each sub-array is a line, each value is a word width in px. More consistency vs random widths.
+  // This allows us to create a more structured skeleton that resembles the actual message layout.
+  // We could generate a few examples and randomly select from them. Simpler but feels "random".
+  const skeletonWordWidths = [
+    [40, 40, 40, 24, 32], // "Lorem ipsum dolor sit amet
+    [88, 80, 32],  // consectetur adipiscing elit"
+  ];
+
+  return (
+    <Box width="100%">
+      <Flex alignItems="center" gap={2} mb={2}>
+        <span>Thinking</span>
+        <span className="thinking-ellipsis">
+          <span>.</span>
+          <span>.</span>
+          <span>.</span>
+        </span>
+      </Flex>
+      {skeletonWordWidths.map((line, lineIdx) => {
+        const total = line.reduce((sum, w) => sum + w, 0);
+        return (
+          <Flex key={lineIdx} gap={2} mb={1} width="90%">
+            {line.map((width, wordIdx) => (
+              <Skeleton
+                key={wordIdx}
+                height="18px"
+                width={`${(width / total) * 100}%`}
+                borderRadius="md"
+              />
+            ))}
+          </Flex>
+        );
+      })}
+      <style jsx>{`
+        .thinking-ellipsis span {
+          opacity: 0.2;
+          animation: blink 1.4s infinite both;
+          font-weight: bold;
+        }
+        .thinking-ellipsis span:nth-child(2) {
+          animation-delay: 0.2s;
+        }
+        .thinking-ellipsis span:nth-child(3) {
+          animation-delay: 0.4s;
+        }
+        @keyframes blink {
+          0%, 80%, 100% { opacity: 0.2; }
+          40% { opacity: 1; }
+        }
+      `}</style>
+    </Box>
+  );
+}

--- a/app/components/ThinkingMessage.tsx
+++ b/app/components/ThinkingMessage.tsx
@@ -1,58 +1,13 @@
-import { Box, Flex, Skeleton } from "@chakra-ui/react";
-import { todo } from "node:test";
+import { Box, Flex, Skeleton, SkeletonText, Spinner } from "@chakra-ui/react";
 
 export default function ThinkingMessage() {
-  //@todo("Define 'nice' skeleton structure")
-  // Each sub-array is a line, each value is a word width in px. More consistency vs random widths.
-  // This allows us to create a more structured skeleton that resembles the actual message layout.
-  // We could generate a few examples and randomly select from them. Simpler but feels "random".
-  const skeletonWordWidths = [
-    [40, 40, 40, 24, 32], // "Lorem ipsum dolor sit amet
-    [88, 80, 32],  // consectetur adipiscing elit"
-  ];
 
   return (
     <Box width="100%">
-      <Flex alignItems="center" gap={2} mb={2}>
-        <span>Thinking</span>
-        <span className="thinking-ellipsis">
-          <span>.</span>
-          <span>.</span>
-          <span>.</span>
-        </span>
-      </Flex>
-      {skeletonWordWidths.map((line, lineIdx) => {
-        const total = line.reduce((sum, w) => sum + w, 0);
-        return (
-          <Flex key={lineIdx} gap={2} mb={1} width="90%">
-            {line.map((width, wordIdx) => (
-              <Skeleton
-                key={wordIdx}
-                height="18px"
-                width={`${(width / total) * 100}%`}
-                borderRadius="md"
-              />
-            ))}
-          </Flex>
-        );
-      })}
-      <style jsx>{`
-        .thinking-ellipsis span {
-          opacity: 0.2;
-          animation: blink 1.4s infinite both;
-          font-weight: bold;
-        }
-        .thinking-ellipsis span:nth-child(2) {
-          animation-delay: 0.2s;
-        }
-        .thinking-ellipsis span:nth-child(3) {
-          animation-delay: 0.4s;
-        }
-        @keyframes blink {
-          0%, 80%, 100% { opacity: 0.2; }
-          40% { opacity: 1; }
-        }
-      `}</style>
-    </Box>
+       <Flex alignItems="center" gap={2} mb={2}>
+        <Spinner size="sm" opacity={0.25} />Thinking
+       </Flex>      
+       <SkeletonText variant="shine" noOfLines={5} rounded="xl" />
+     </Box>
   );
 }

--- a/app/components/ThinkingMessage.tsx
+++ b/app/components/ThinkingMessage.tsx
@@ -1,11 +1,15 @@
 import { Box, Flex, SkeletonText, Spinner } from "@chakra-ui/react";
 
-export default function ThinkingMessage() {
+interface ThinkingMessageProps {
+  label?: string;
+}
+
+export default function ThinkingMessage({ label = "Thinking" }: ThinkingMessageProps) {
 
   return (
     <Box width="100%">
        <Flex alignItems="center" gap={2} mb={2}>
-        <Spinner size="sm" opacity={0.25} />Thinking
+       <Spinner size="sm" opacity={0.25} />{label}
        </Flex>      
        <SkeletonText variant="shine" noOfLines={5} rounded="xl" />
      </Box>

--- a/app/components/TypewriterText.tsx
+++ b/app/components/TypewriterText.tsx
@@ -1,0 +1,32 @@
+import { useEffect, useState } from "react";
+
+interface TypewriterTextProps {
+  text: string;
+  speed?: number;
+  render?: (text: string) => React.ReactNode;
+  onDone?: () => void;
+}
+
+export default function TypewriterText({ text, speed = 20, render, onDone }: TypewriterTextProps) {
+  const [displayed, setDisplayed] = useState("");
+
+  useEffect(() => {
+    setDisplayed("");
+    let i = 0;
+    const interval = setInterval(() => {
+      setDisplayed(text.slice(0, i + 1));
+      i++;
+      if (i === text.length) {
+        clearInterval(interval);
+        if (onDone) onDone();
+      }
+    }, speed);
+    return () => clearInterval(interval);
+  }, [text, speed, onDone]);
+
+  return (
+    <>
+      {render ? render(displayed) : <span>{displayed}</span>}
+    </>
+  );
+}

--- a/app/components/TypewriterText.tsx
+++ b/app/components/TypewriterText.tsx
@@ -5,12 +5,19 @@ interface TypewriterTextProps {
   speed?: number;
   render?: (text: string) => React.ReactNode;
   onDone?: () => void;
+  skipAnimation?: boolean;
 }
 
-export default function TypewriterText({ text, speed = 10, render, onDone }: TypewriterTextProps) {
+export default function TypewriterText({ text, speed = 10, render, onDone, skipAnimation = false }: TypewriterTextProps) {
   const [displayed, setDisplayed] = useState("");
 
   useEffect(() => {
+    if (skipAnimation) {
+      setDisplayed(text);
+      if (onDone) onDone();
+      return;
+    }
+
     setDisplayed("");
     let i = 0;
     const interval = setInterval(() => {
@@ -21,8 +28,10 @@ export default function TypewriterText({ text, speed = 10, render, onDone }: Typ
         if (onDone) onDone();
       }
     }, speed);
-    return () => clearInterval(interval);
-  }, [text, speed, onDone]);
+    return () => {
+      clearInterval(interval);
+    };
+  }, [text, speed, onDone, skipAnimation]);
 
   return (
     <>

--- a/app/components/TypewriterText.tsx
+++ b/app/components/TypewriterText.tsx
@@ -7,7 +7,7 @@ interface TypewriterTextProps {
   onDone?: () => void;
 }
 
-export default function TypewriterText({ text, speed = 20, render, onDone }: TypewriterTextProps) {
+export default function TypewriterText({ text, speed = 10, render, onDone }: TypewriterTextProps) {
   const [displayed, setDisplayed] = useState("");
 
   useEffect(() => {

--- a/app/store/chat-tools/pickDataset.ts
+++ b/app/store/chat-tools/pickDataset.ts
@@ -4,8 +4,12 @@ export function pickDatasetTool(
   streamMessage: StreamMessage,
   addMessage: (message: Omit<ChatMessage, "id" | "timestamp">) => void
 ) {
+  // Example: include dataset name and description if present
+  const dataset_name = streamMessage.dataset?.dataset_name || "Unknown dataset";
+  const reasoning = streamMessage.dataset?.reason || "Unknown reasoning";
+
   addMessage({
     type: "assistant",
-    message: `Dataset picker tool executed.`,
+    message: `Dataset picker tool executed: selected ${dataset_name}.\n\nReason: ${reasoning}\n`,
   });
 }

--- a/app/store/chat-tools/pickDataset.ts
+++ b/app/store/chat-tools/pickDataset.ts
@@ -10,6 +10,6 @@ export function pickDatasetTool(
 
   addMessage({
     type: "assistant",
-    message: `Dataset picker tool executed: selected ${dataset_name}.\n\nReason: ${reasoning}\n`,
+    message: `Dataset picker tool executed: selected ${dataset_name}. ${reasoning}\n`,
   });
 }

--- a/app/store/chat-tools/pullData.ts
+++ b/app/store/chat-tools/pullData.ts
@@ -4,8 +4,12 @@ export function pullDataTool(
   streamMessage: StreamMessage,
   addMessage: (message: Omit<ChatMessage, "id" | "timestamp">) => void
 ) {
+
+  // Example: include dataset name and description if present
+  const content = streamMessage?.content || "Unknown dataset";
+
   addMessage({
     type: "assistant",
-    message: `Data pull tool executed.`,
+    message: `${content}\n`,
   });
 }

--- a/app/store/chatStore.ts
+++ b/app/store/chatStore.ts
@@ -19,6 +19,7 @@ import useSidebarStore from "./sidebarStore";
 interface ChatState {
   messages: ChatMessage[];
   isLoading: boolean;
+  isFetchingThread: boolean;
   currentThreadId: string | null;
 }
 
@@ -64,6 +65,7 @@ Ask a question and let’s see what we can do for nature.`,
     },
   ],
   isLoading: false,
+  isFetchingThread: false,
   currentThreadId: null,
 };
 
@@ -285,6 +287,9 @@ const useChatStore = create<ChatState & ChatActions>((set, get) => ({
   fetchThread: async (threadId: string) => {
     const { setLoading, addMessage } = get();
 
+    // Mark that we are fetching a historical thread; used to suppress thinking UI
+    set({ isFetchingThread: true });
+
     setLoading(true);
     // Set up abort controller for client-side timeout
     const abortController = new AbortController();
@@ -355,6 +360,7 @@ const useChatStore = create<ChatState & ChatActions>((set, get) => ({
       set({ currentThreadId: threadId });
       clearTimeout(timeoutId);
       setLoading(false);
+      set({ isFetchingThread: false });
     }
   },
 }));

--- a/app/types/chat.ts
+++ b/app/types/chat.ts
@@ -8,6 +8,7 @@ export interface ChatMessage {
   timestamp: string;
   widgets?: InsightWidget[]; // For widget messages
   context?: ContextItem[];
+  source?: 'historical' | 'realtime'; // historical messages when past conversations are fetched
 }
 
 // Widget types for insights


### PR DESCRIPTION
This PR add a typewriter effect to decrease perceived user wait times. 

New Features:
- Typewriter effect for messages in 'realtime' (read: 'live') conversations
- typewriter disabled on load of old conversations

![typewriter-2025-8-18](https://github.com/user-attachments/assets/586a4142-9e35-4844-ab4b-24dc59720b64)

As a consequence of adding the above, some pretty significant changes are made to messages so that the typewrite effect is disabled on load of past conversations. This will need serious review.

TL;DR - changes

1. The fetchThread function in the chatStore was refactored. Instead of adding messages to the state as they arrive, it now collects all incoming messages into a temporary array. Once the stream is complete, it performs a single, atomic update to the store, adding all messages and setting isFetchingThread to false in the same operation. This prevents multiple re-renders and ensures a clean "all-at-once" display of the conversation. **Note that this does slowdown render of messages in realtime chats. Should we consider not batching is this case?** 
2. A new optional property, source: 'historical' | 'realtime', was added to the ChatMessage type. All messages loaded via fetchThread  are now marked as 'historical'. The  MessageBubble component now uses this immutable message.source property to determine whether to skip the typewriter animation. 
