### PR TITLE
Reasoning Component

### DIFF
--- a/app/components/ChatMessages.tsx
+++ b/app/components/ChatMessages.tsx
@@ -36,6 +36,9 @@ function ChatMessages() {
     }
   }, []);
 
+  // Show reasoning after the last user message when loading
+  const lastUserMessageIndex = messages.findLastIndex(msg => msg.type === "user");
+
   return (
     <Box ref={containerRef} fontSize="sm">
       {messages.map((message, index) => {
@@ -44,14 +47,16 @@ function ChatMessages() {
         const isConsecutive = previousMessage?.type === message.type;
 
         return (
-          <MessageBubble
-            key={message.id}
-            message={message}
-            isConsecutive={isConsecutive}
-          />
+          <>
+            <MessageBubble
+              key={message.id}
+              message={message}
+              isConsecutive={isConsecutive}
+            />
+            {isLoading && index === lastUserMessageIndex && <Reasoning />}
+          </>
         );
       })}
-      {isLoading && <Reasoning />}
     </Box>
   );
 }

--- a/app/components/ChatMessages.tsx
+++ b/app/components/ChatMessages.tsx
@@ -3,22 +3,23 @@ import { useEffect, useRef } from "react";
 import { Box } from "@chakra-ui/react";
 import useChatStore from "@/app/store/chatStore";
 import MessageBubble from "./MessageBubble";
+import Reasoning from "./Reasoning";
 
 function ChatMessages() {
   const containerRef = useRef<HTMLDivElement>(null);
-  const { messages } = useChatStore();
+  const { messages, isLoading } = useChatStore();
 
-  // Auto-scroll to bottom when new messages are added
+  // Auto-scroll to bottom when new messages are added or loading state changes
   useEffect(() => {
     if (containerRef.current) {
       const container = containerRef.current;
       container.scrollTop = container.scrollHeight;
     }
-  }, [messages]);
+  }, [messages, isLoading]);
 
   useEffect(() => {
     if (containerRef.current) {
-      const observer = new ResizeObserver(entries => {
+      const observer = new ResizeObserver((entries) => {
         const e = entries[0];
         const parentElement = e.target.parentElement;
         const elementHeight = e.contentRect.height;
@@ -41,15 +42,16 @@ function ChatMessages() {
         // Check if this message is consecutive to the previous one of the same type
         const previousMessage = index > 0 ? messages[index - 1] : null;
         const isConsecutive = previousMessage?.type === message.type;
-        
+
         return (
-          <MessageBubble 
-            key={message.id} 
-            message={message} 
+          <MessageBubble
+            key={message.id}
+            message={message}
             isConsecutive={isConsecutive}
           />
         );
       })}
+      {isLoading && <Reasoning />}
     </Box>
   );
 }

--- a/app/components/Reasoning.tsx
+++ b/app/components/Reasoning.tsx
@@ -1,0 +1,32 @@
+"use client";
+import { Box, Collapsible, Flex, Text, Spinner } from "@chakra-ui/react";
+
+function Reasoning() {
+  return (
+    <Collapsible.Root>
+      <Collapsible.Trigger>
+        <Flex justifyContent="flex-start" alignItems="center" gap="3" mb={4}>
+          <Spinner size="sm" color="fg.muted" />
+          <Text fontSize="sm" color="fg.muted">
+            Reasoning
+          </Text>
+        </Flex>
+      </Collapsible.Trigger>
+      <Collapsible.Content>
+        <Box
+          bg="gray.200"
+          borderRadius="sm"
+          paddingTop="8px"
+          paddingBottom="8px"
+          paddingLeft={3}
+          paddingRight={3}
+          gap={2}
+        >
+          Placeholder text for reasoning steps.
+        </Box>
+      </Collapsible.Content>
+    </Collapsible.Root>
+  );
+}
+
+export default Reasoning;

--- a/app/components/Reasoning.tsx
+++ b/app/components/Reasoning.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { Box, Collapsible, Flex, Text, Spinner } from "@chakra-ui/react";
+import { CaretDownIcon, CaretRightIcon } from "@phosphor-icons/react";
 
 function Reasoning() {
   return (
@@ -10,11 +11,12 @@ function Reasoning() {
           <Text fontSize="sm" color="fg.muted">
             Reasoning
           </Text>
+          <CaretRightIcon />
         </Flex>
       </Collapsible.Trigger>
       <Collapsible.Content>
         <Box
-          bg="gray.200"
+          bg="bg.muted"
           borderRadius="sm"
           paddingTop="8px"
           paddingBottom="8px"

--- a/app/components/Reasoning.tsx
+++ b/app/components/Reasoning.tsx
@@ -1,17 +1,19 @@
 "use client";
 import { Box, Collapsible, Flex, Text, Spinner } from "@chakra-ui/react";
 import { CaretDownIcon, CaretRightIcon } from "@phosphor-icons/react";
+import { useState } from "react";
 
 function Reasoning() {
+  const [isOpen, setIsOpen] = useState(false);
   return (
-    <Collapsible.Root>
+    <Collapsible.Root open={isOpen} onOpenChange={setIsOpen}>
       <Collapsible.Trigger>
         <Flex justifyContent="flex-start" alignItems="center" gap="3" mb={4}>
           <Spinner size="sm" color="fg.muted" />
           <Text fontSize="sm" color="fg.muted">
             Reasoning
           </Text>
-          <CaretRightIcon />
+          {isOpen ? <CaretDownIcon /> : <CaretRightIcon />}
         </Flex>
       </Collapsible.Trigger>
       <Collapsible.Content>

--- a/app/components/Reasoning.tsx
+++ b/app/components/Reasoning.tsx
@@ -4,7 +4,7 @@ import { CaretDownIcon, CaretRightIcon } from "@phosphor-icons/react";
 import { useState } from "react";
 
 function Reasoning() {
-  const [isOpen, setIsOpen] = useState(false);
+  const [isOpen, setIsOpen] = useState(true);
   return (
     <Collapsible.Root open={isOpen} onOpenChange={setIsOpen}>
       <Collapsible.Trigger>
@@ -25,6 +25,8 @@ function Reasoning() {
           paddingLeft={3}
           paddingRight={3}
           gap={2}
+          fontFamily="mono"
+          fontSize="xs"
         >
           Placeholder text for reasoning steps.
         </Box>

--- a/app/components/Reasoning.tsx
+++ b/app/components/Reasoning.tsx
@@ -2,11 +2,25 @@
 import { Box, Collapsible, Flex, Text, Spinner } from "@chakra-ui/react";
 import { CaretDownIcon, CaretRightIcon } from "@phosphor-icons/react";
 import { useState } from "react";
+import useChatStore from "@/app/store/chatStore";
+
+// Helper function to format tool names for display
+function formatToolName(toolName: string): string {
+  const toolNameMap: Record<string, string> = {
+    generate_insights: "Generating insights",
+    "pick-aoi": "Picking area of interest",
+    "pick-dataset": "Selecting dataset",
+    "pull-data": "Pulling data",
+  };
+
+  return toolNameMap[toolName] || `Processing ${toolName}`;
+}
 
 function Reasoning() {
-  const [isOpen, setIsOpen] = useState(true);
+  const [isOpen, setIsOpen] = useState(false);
+  const { toolSteps } = useChatStore();
   return (
-    <Collapsible.Root open={isOpen} onOpenChange={setIsOpen}>
+    <Collapsible.Root open={isOpen} onOpenChange={(e) => setIsOpen(e.open)}>
       <Collapsible.Trigger>
         <Flex justifyContent="flex-start" alignItems="center" gap="3" mb={4}>
           <Spinner size="sm" color="fg.muted" />
@@ -28,7 +42,15 @@ function Reasoning() {
           fontFamily="mono"
           fontSize="xs"
         >
-          Placeholder text for reasoning steps.
+          {toolSteps.length === 0 ? (
+            <Text color="fg.muted">Processing request...</Text>
+          ) : (
+            toolSteps.map((toolName, index) => (
+              <Text key={`${toolName}-${index}`} color="fg.muted" mb={1}>
+                • {formatToolName(toolName)}
+              </Text>
+            ))
+          )}
         </Box>
       </Collapsible.Content>
     </Collapsible.Root>

--- a/app/components/Reasoning.tsx
+++ b/app/components/Reasoning.tsx
@@ -38,6 +38,7 @@ function Reasoning() {
           paddingBottom="8px"
           paddingLeft={3}
           paddingRight={3}
+          marginBottom={4}
           gap={2}
           fontFamily="mono"
           fontSize="xs"

--- a/app/store/chat-tools/generateInsights.ts
+++ b/app/store/chat-tools/generateInsights.ts
@@ -34,18 +34,18 @@ export function generateInsightsTool(
         type: "widget",
         message: "Charts generated",
         widgets: widgets,
-        timestamp: streamMessage.timestamp
+        timestamp: streamMessage.timestamp,
       });
     }
   } catch (error) {
     console.error("Error processing generate_insights:", error);
 
     addMessage({
-      type: "assistant",
+      type: "error",
       message: `Generate insights tool executed but failed to parse data: ${
         error instanceof Error ? error.message : JSON.stringify(error)
       }}`,
-        timestamp: streamMessage.timestamp
+      timestamp: streamMessage.timestamp,
     });
   }
 }

--- a/app/store/chat-tools/pickAoi.ts
+++ b/app/store/chat-tools/pickAoi.ts
@@ -48,19 +48,11 @@ export async function pickAoiTool(
         content: aoiName,
       });
     }
-
-    addMessage({
-      type: "assistant",
-      message: `Location found and displayed on map: ${
-        aoiName || "Unknown location"
-      }`,
-      timestamp: streamMessage.timestamp,
-    });
   } catch (error) {
     console.error("Error processing pick-aoi artifact:", error);
 
     addMessage({
-      type: "assistant",
+      type: "error",
       message: `AOI tool executed but failed to display on map: ${
         streamMessage.content || "Unknown location"
       }. Error: ${error instanceof Error ? error.message : "Unknown error"}`,

--- a/app/store/chat-tools/pickDataset.ts
+++ b/app/store/chat-tools/pickDataset.ts
@@ -30,19 +30,12 @@ export function pickDatasetTool(
         widgets: [datasetWidget],
         timestamp: streamMessage.timestamp,
       });
-    } else {
-      // Fallback for datasets without tile_url
-      addMessage({
-        type: "assistant",
-        message: `Dataset found: ${streamMessage.content || "Unknown dataset"}`,
-        timestamp: streamMessage.timestamp,
-      });
     }
   } catch (error) {
     console.error("Error processing pick-dataset tool:", error);
 
     addMessage({
-      type: "assistant",
+      type: "error",
       message: `Dataset tool executed but encountered an error: ${
         streamMessage.content || "Unknown error"
       }`,

--- a/app/store/chat-tools/pullData.ts
+++ b/app/store/chat-tools/pullData.ts
@@ -1,6 +1,11 @@
 import { ChatMessage, StreamMessage } from "@/app/types/chat";
 
 export function pullDataTool(
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   streamMessage: StreamMessage,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   addMessage: (message: Omit<ChatMessage, "id">) => void
-) {}
+) {
+  // Tool execution is now handled by the reasoning component
+  // No message needed here
+}

--- a/app/store/chat-tools/pullData.ts
+++ b/app/store/chat-tools/pullData.ts
@@ -3,10 +3,4 @@ import { ChatMessage, StreamMessage } from "@/app/types/chat";
 export function pullDataTool(
   streamMessage: StreamMessage,
   addMessage: (message: Omit<ChatMessage, "id">) => void
-) {
-  addMessage({
-    type: "assistant",
-    message: `Data pull tool executed.`,
-    timestamp: streamMessage.timestamp,
-  });
-}
+) {}

--- a/app/store/chatStore.ts
+++ b/app/store/chatStore.ts
@@ -109,12 +109,6 @@ async function processStreamMessage(
     // Handling for pull-data tool
     else if (streamMessage.name === "pull-data") {
       return pullDataTool(streamMessage, addMessage);
-    } else {
-      addMessage({
-        type: "assistant",
-        message: `Tool: ${streamMessage.name || "Unknown"}`,
-        timestamp: streamMessage.timestamp,
-      });
     }
   }
 }
@@ -143,8 +137,14 @@ const useChatStore = create<ChatState & ChatActions>((set, get) => ({
   },
 
   sendMessage: async (message: string, queryType: QueryType = "query") => {
-    const { addMessage, setLoading, currentThreadId, generateNewThread, addToolStep, clearToolSteps } =
-      get();
+    const {
+      addMessage,
+      setLoading,
+      currentThreadId,
+      generateNewThread,
+      addToolStep,
+      clearToolSteps,
+    } = get();
     const { context } = useContextStore.getState();
 
     // Generate thread ID if this is the first message
@@ -176,7 +176,7 @@ const useChatStore = create<ChatState & ChatActions>((set, get) => ({
           gadm_id: areaContext.aoiData.gadm_id,
           src_id: areaContext.aoiData.src_id,
           subtype: areaContext.aoiData.subtype,
-          source: areaContext.aoiData.source
+          source: areaContext.aoiData.source,
         },
         aoi_name: areaContext.aoiData.name,
         subregion_aois: null,


### PR DESCRIPTION
Closes #60 

This PR adds a reasoning component to the chat.

When the chat state is `isLoading`, a new collapsible component is shown. When clicked, a list of tools returned by the API is shown as a list.

https://github.com/user-attachments/assets/56a0fffd-d07c-4a87-896a-5c603ba02a0d

Duplicative tool-related messages from the `chat-tools/` directory have been removed from the thread (and only shown in the reasoning component). Error messages from these tools have been changed from type `assistant` to `error`, thus visualizing them differently.

<img width="552" height="548" alt="image" src="https://github.com/user-attachments/assets/62f7079e-4e66-4121-a249-ffbb79b76aca" />

Other points:
1. Only the tool name value is used from the API response. These are mapped to human-readable names (e.g.,  `pick-aoi` -> `Picking area of interest`)
2. The reasoning component is only shown when the chat state is `isLoading`, and always at the bottom of the chat window.
3. The reasoning steps are not stored or saved anywhere.
4. The reasoning time isn't calculated or stored.