### PR TITLE
Hotfix/truncate chat header title

### DIFF
--- a/app/ChatPanelHeader.tsx
+++ b/app/ChatPanelHeader.tsx
@@ -108,14 +108,46 @@ function ChatPanelHeader() {
         <ThreadActionsMenu
           thread={{ id: currentThreadId, name: currentThreadName }}
         >
-          <Button variant="ghost" size="sm" mr="auto">
-            {currentThreadName}
-            <CaretDownIcon />
+          <Button
+            variant="ghost"
+            size="sm"
+            flex="1"
+            minW={0}
+            justifyContent="flex-start"
+          >
+            <Flex align="center" gap={1} w="100%" minW={0}>
+              <Text
+                as="span"
+                flex="1"
+                minW={0}
+                whiteSpace="nowrap"
+                overflow="hidden"
+                textOverflow="ellipsis"
+              >
+                {currentThreadName}
+              </Text>
+              <CaretDownIcon />
+            </Flex>
           </Button>
         </ThreadActionsMenu>
       ) : (
-        <Button variant="ghost" size="sm" mr="auto">
-          {currentThreadName}
+        <Button
+          variant="ghost"
+          size="sm"
+          flex="1"
+          minW={0}
+          justifyContent="flex-start"
+        >
+          <Text
+            as="span"
+            flex="1"
+            minW={0}
+            whiteSpace="nowrap"
+            overflow="hidden"
+            textOverflow="ellipsis"
+          >
+            {currentThreadName}
+          </Text>
         </Button>
       )}
 

--- a/app/ChatPanelHeader.tsx
+++ b/app/ChatPanelHeader.tsx
@@ -111,7 +111,9 @@ function ChatPanelHeader() {
           <Button
             variant="ghost"
             size="sm"
-            flex="1"
+            flexShrink="1"
+            mr="auto"
+            px={2}
             minW={0}
             justifyContent="flex-start"
           >
@@ -119,12 +121,12 @@ function ChatPanelHeader() {
               <Tooltip content={currentThreadName} showArrow>
                 <Text
                   as="span"
-                  flexShrink="1"
-                  mr="auto"
+                  flex="1"
                   minW={0}
                   whiteSpace="nowrap"
                   overflow="hidden"
                   textOverflow="ellipsis"
+                  fontWeight="normal"
                 >
                   {currentThreadName}
                 </Text>
@@ -137,7 +139,9 @@ function ChatPanelHeader() {
         <Button
           variant="ghost"
           size="sm"
-          flex="1"
+          flexShrink="1"
+          mr="auto"
+          px={2}
           minW={0}
           justifyContent="flex-start"
         >
@@ -149,6 +153,7 @@ function ChatPanelHeader() {
               whiteSpace="nowrap"
               overflow="hidden"
               textOverflow="ellipsis"
+              fontWeight="normal"
             >
               {currentThreadName}
             </Text>
@@ -160,7 +165,18 @@ function ChatPanelHeader() {
       {widgetAnchors.length === 0 ? (
         <Tooltip content="Ask a question to generate insights" showArrow>
           <span style={{ display: "inline-flex" }}>
-            <Button variant="ghost" size="sm" disabled>
+            <Button
+              variant="ghost"
+              color="primary.fg"
+              borderColor="primary.subtle"
+              rounded="sm"
+              h={6}
+              bgGradient="to-br"
+              gradientFrom="primary.200/25"
+              gradientTo="secondary.300/25"
+              size="xs"
+              disabled
+            >
               Go to insight
               <CaretDownIcon />
             </Button>
@@ -169,15 +185,24 @@ function ChatPanelHeader() {
       ) : (
         <Menu.Root>
           <Menu.Trigger asChild>
-          <Button
+            <Button
               variant="ghost"
+              color="primary.fg"
+              borderColor="primary.subtle"
+              rounded="sm"
+              h={6}
               bgGradient="to-br"
-              gradientFrom="primary.300/25"
-              gradientTo="secondary.300/25"
-              size="sm"
+              gradientFrom="primary.200/30"
+              gradientTo="secondary.300/30"
+              fontWeight="semibold"
+              _hover={{
+                gradientFrom: "primary.400/30",
+                gradientTo: "secondary.400/30",
+              }}
+              size="xs"
             >
               Go to insight
-              <CaretDownIcon />
+              <CaretDownIcon size="12" weight="bold" />
             </Button>
           </Menu.Trigger>
           <Portal>

--- a/app/ChatPanelHeader.tsx
+++ b/app/ChatPanelHeader.tsx
@@ -119,7 +119,8 @@ function ChatPanelHeader() {
               <Tooltip content={currentThreadName} showArrow>
                 <Text
                   as="span"
-                  flex="1"
+                  flexShrink="1"
+                  mr="auto"
                   minW={0}
                   whiteSpace="nowrap"
                   overflow="hidden"

--- a/app/ChatPanelHeader.tsx
+++ b/app/ChatPanelHeader.tsx
@@ -116,16 +116,18 @@ function ChatPanelHeader() {
             justifyContent="flex-start"
           >
             <Flex align="center" gap={1} w="100%" minW={0}>
-              <Text
-                as="span"
-                flex="1"
-                minW={0}
-                whiteSpace="nowrap"
-                overflow="hidden"
-                textOverflow="ellipsis"
-              >
-                {currentThreadName}
-              </Text>
+              <Tooltip content={currentThreadName} showArrow>
+                <Text
+                  as="span"
+                  flex="1"
+                  minW={0}
+                  whiteSpace="nowrap"
+                  overflow="hidden"
+                  textOverflow="ellipsis"
+                >
+                  {currentThreadName}
+                </Text>
+              </Tooltip>
               <CaretDownIcon />
             </Flex>
           </Button>
@@ -138,16 +140,18 @@ function ChatPanelHeader() {
           minW={0}
           justifyContent="flex-start"
         >
-          <Text
-            as="span"
-            flex="1"
-            minW={0}
-            whiteSpace="nowrap"
-            overflow="hidden"
-            textOverflow="ellipsis"
-          >
-            {currentThreadName}
-          </Text>
+          <Tooltip content={currentThreadName} showArrow>
+            <Text
+              as="span"
+              flex="1"
+              minW={0}
+              whiteSpace="nowrap"
+              overflow="hidden"
+              textOverflow="ellipsis"
+            >
+              {currentThreadName}
+            </Text>
+          </Tooltip>
         </Button>
       )}
 


### PR DESCRIPTION
Fix for an overflow issue in the chat header.

**Old behaviour:**
<img width="1816" height="270" alt="image" src="https://github.com/user-attachments/assets/8675e9e3-d02f-4e30-b0dd-436e00c637bc" />
Long titles would cause the "Go to insight" dropdown and new conversation button to overflow outside of view.

**New behaviour:**
<img width="815" height="191" alt="Screenshot 2025-08-25 at 11 24 22 AM" src="https://github.com/user-attachments/assets/5147134d-e7d9-47b8-a6b4-f346681ea981" />
Long titles are truncated with ellipses (`...`) and a tooltip has been added to show the full title.

@LanesGood @faustoperez are we happy with this implementation? I wasnt sure about the tooltip size and position.

BONUS: a bit fancier, see [this PR](https://github.com/wri/project-zeno-next/pull/157) which adds a ticker effect using Maquee