### PR TITLE
Replace base URL with new threadID when available

### DIFF
--- a/app/app/page.tsx
+++ b/app/app/page.tsx
@@ -4,11 +4,21 @@ import { useEffect } from "react";
 import useChatStore from "@/app/store/chatStore";
 
 export default function Home() {
-  const { reset: resetChatStore } = useChatStore();
+  const { reset: resetChatStore, currentThreadId } = useChatStore();
 
   useEffect(() => {
     resetChatStore();
   }, [resetChatStore]);
 
+  useEffect(() => { // Update URL as soon as threadID is available
+    if (currentThreadId) {
+      const newUrl = `/app/threads/${currentThreadId}`;
+      window.history.replaceState(
+        { ...window.history.state, as: newUrl, url: newUrl },
+        "",
+        newUrl
+      );
+    }
+  }, [currentThreadId]);
   return null; // The layout handles all the UI
 }


### PR DESCRIPTION
Adds threadID to URL as soon as new conversation gets an ID.

The main impetus for this change is to enable the "New conversation" button for users who are currently chatting in a new conversation (see #162)

Closes #162 