### PR TITLE
Restrict area uploads to GeoJSON only

### DIFF
--- a/app/constants/custom-areas.ts
+++ b/app/constants/custom-areas.ts
@@ -1,4 +1,4 @@
-export const ACCEPTED_FILE_TYPES = [".geojson", ".shp", ".zip"];
+export const ACCEPTED_FILE_TYPES = [".geojson"];
 export const MAX_FILE_SIZE_MB = 1;
 export const MAX_FILE_SIZE = MAX_FILE_SIZE_MB * 1024 * 1024;
 


### PR DESCRIPTION
The API supports GeoJSON features only. See https://github.com/wri/project-zeno-next/pull/163#issuecomment-3227395311.

cc @LanesGood @sunu 