### PR TITLE
Filter layer widgets from Go to insights

### DIFF
--- a/app/ChatPanelHeader.tsx
+++ b/app/ChatPanelHeader.tsx
@@ -51,12 +51,14 @@ function ChatPanelHeader() {
   const widgetAnchors = useMemo(() => {
     return messages.flatMap((m) =>
       m.type === "widget" && m.widgets
-        ? m.widgets.map((w, idx) => ({
-          id: `widget-${m.id}-${idx}`,
-          title: w.title || `Widget ${idx + 1}`,
-          type: w.type,
-          timestamp: m.timestamp,
-        }))
+        ? m.widgets
+            .filter((w) => w.type !== "dataset-card")
+            .map((w, idx) => ({
+              id: `widget-${m.id}-${idx}`,
+              title: w.title || `Insight ${idx + 1}`,
+              type: w.type,
+              timestamp: m.timestamp,
+            }))
         : []
     );
   }, [messages]);


### PR DESCRIPTION
The new data layer cards are message.type === widget so they show up in the Go to insight drop-down.

<img width="2084" height="802" alt="image" src="https://github.com/user-attachments/assets/c616f1d1-b92e-48b8-8708-cc31244649fe" />

This PR filters these out and updates the default title if one is not present