### PR TITLE
Set dataset card as active by default

### DIFF
--- a/app/components/widgets/DatasetCardWidget.tsx
+++ b/app/components/widgets/DatasetCardWidget.tsx
@@ -21,17 +21,15 @@ export default function DatasetCardWidget({ dataset }: DatasetCardWidgetProps) {
   console.log("dataset", dataset);
 
   useEffect(() => {
-    if (!isInContext) {
-      addContext({
-        contextType: "layer",
-        content: dataset.dataset_name,
-        datasetId: dataset.dataset_id,
-        tileUrl: dataset.tile_url,
-        layerName: dataset.dataset_name,
-      });
-    }
+    addContext({
+      contextType: "layer",
+      content: dataset.dataset_name,
+      datasetId: dataset.dataset_id,
+      tileUrl: dataset.tile_url,
+      layerName: dataset.dataset_name,
+    });
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []); // Run only once on mount
+  }, [dataset.dataset_id]); // Rerun if dataset changes
 
   const handleAddToMap = () => {
     if (!isInContext) {

--- a/app/components/widgets/DatasetCardWidget.tsx
+++ b/app/components/widgets/DatasetCardWidget.tsx
@@ -18,7 +18,6 @@ export default function DatasetCardWidget({ dataset }: DatasetCardWidgetProps) {
   );
   const isInContext = Boolean(existingLayerContext);
 
-  console.log("dataset", dataset);
 
   useEffect(() => {
     addContext({

--- a/app/components/widgets/DatasetCardWidget.tsx
+++ b/app/components/widgets/DatasetCardWidget.tsx
@@ -20,15 +20,17 @@ export default function DatasetCardWidget({ dataset }: DatasetCardWidgetProps) {
 
 
   useEffect(() => {
-    addContext({
-      contextType: "layer",
-      content: dataset.dataset_name,
-      datasetId: dataset.dataset_id,
-      tileUrl: dataset.tile_url,
-      layerName: dataset.dataset_name,
-    });
+    if (!isInContext) {
+      addContext({
+        contextType: "layer",
+        content: dataset.dataset_name,
+        datasetId: dataset.dataset_id,
+        tileUrl: dataset.tile_url,
+        layerName: dataset.dataset_name,
+      });
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [dataset.dataset_id]); // Rerun if dataset changes
+  }, []); // Run only once on mount
 
   const handleAddToMap = () => {
     if (!isInContext) {

--- a/app/components/widgets/DatasetCardWidget.tsx
+++ b/app/components/widgets/DatasetCardWidget.tsx
@@ -1,4 +1,5 @@
 import { DatasetInfo } from "@/app/types/chat";
+import { useEffect } from "react";
 import useContextStore from "@/app/store/contextStore";
 import { DatasetCard } from "@/app/components/DatasetCard";
 import { DATASET_CARDS } from "@/app/constants/datasets";
@@ -16,6 +17,21 @@ export default function DatasetCardWidget({ dataset }: DatasetCardWidgetProps) {
       (c.datasetId === dataset.dataset_id || c.content === dataset.dataset_name)
   );
   const isInContext = Boolean(existingLayerContext);
+
+  console.log("dataset", dataset);
+
+  useEffect(() => {
+    if (!isInContext) {
+      addContext({
+        contextType: "layer",
+        content: dataset.dataset_name,
+        datasetId: dataset.dataset_id,
+        tileUrl: dataset.tile_url,
+        layerName: dataset.dataset_name,
+      });
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []); // Run only once on mount
 
   const handleAddToMap = () => {
     if (!isInContext) {

--- a/app/store/contextStore.ts
+++ b/app/store/contextStore.ts
@@ -42,54 +42,39 @@ const initialState: ContextState = {
 
 const useContextStore = create<ContextState & ContextActions>((set) => ({
   ...initialState,
-    addContext: (item) =>
+  addContext: (item) =>
     set((state) => {
-      let newContext = [...state.context];
-
-      // If adding a layer, remove all other layers first
-      if (item.contextType === "layer") {
-        const existingLayers = newContext.filter(
-          (c) => c.contextType === "layer"
-        );
-        const { removeTileLayer } = useMapStore.getState();
-        existingLayers.forEach((layer) => {
-          if (typeof layer.datasetId === "number") {
-            removeTileLayer(`dataset-${layer.datasetId}`);
-          }
-        });
-        newContext = newContext.filter((c) => c.contextType !== "layer");
-      }
-
-      // Check for duplicates for non-layer context types
-      const exists = newContext.some(
+      // Check if item with same contextType and content already exists
+      const exists = state.context.some(
         (existingItem) =>
           existingItem.contextType === item.contextType &&
           JSON.stringify(existingItem.content) === JSON.stringify(item.content)
       );
 
       if (exists) {
-        return { context: newContext };
+        return state; // Don't add if it already exists
       }
 
-      // Add the new item
-      const newItem = { ...item, id: `${item.contextType}-${Date.now()}` };
-      newContext.push(newItem);
-
-      // If it's a layer, add it to the map
+      // If adding a dataset layer context, ensure the map layer is added
       if (
-        newItem.contextType === "layer" &&
-        typeof newItem.datasetId === "number" &&
-        newItem.tileUrl
+        item.contextType === "layer" &&
+        typeof item.datasetId === "number" &&
+        item.tileUrl
       ) {
         useMapStore.getState().addTileLayer({
-          id: `dataset-${newItem.datasetId}`,
-          name: newItem.layerName || String(newItem.datasetId),
-          url: newItem.tileUrl,
+          id: `dataset-${item.datasetId}`,
+          name: item.layerName || String(item.datasetId),
+          url: item.tileUrl,
           visible: true,
         });
       }
 
-      return { context: newContext };
+      return {
+        context: [
+          ...state.context,
+          { ...item, id: `${item.contextType}-${Date.now()}` },
+        ],
+      };
     }),
   removeContext: (id) =>
     set((state) => {


### PR DESCRIPTION
When a dataset card is returned in chat, the map layer is set active by default. 

<img width="1200" height="586" alt="Screenshot 2025-08-27 at 5 23 09 PM" src="https://github.com/user-attachments/assets/f82ed146-5435-4fe1-9394-1ac052470054" />

cc: @faustoperez since we discussed this