### PR TITLE
Add drawn custom area to map context immediately after drawing

### DIFF
--- a/app/store/drawAreaSlice.ts
+++ b/app/store/drawAreaSlice.ts
@@ -35,7 +35,7 @@ export interface DrawAreaSlice {
     | ((data: CreateCustomAreaRequest) => Promise<CreateCustomAreaResponse>)
     | null;
   startDrawing: () => void;
-  confirmDrawing: () => void;
+  confirmDrawing: () => Promise<CreateCustomAreaResponse | undefined>;
   cancelDrawing: () => void;
   initializeTerraDraw: (map: Map) => void;
   endDrawing: () => void;
@@ -204,11 +204,13 @@ export const createDrawAreaSlice: StateCreator<
     };
 
     const createAreaFn = get().createAreaFn;
+    let result;
     if (createAreaFn) {
-      await createAreaFn(requestData);
+      result = await createAreaFn(requestData);
     }
 
     get().endDrawing();
+    return result;
   },
 
   cancelDrawing: () => {


### PR DESCRIPTION
Closes #140 - adds drawn areas to the map and context after confirming a successfully drawn area. Follows the pattern of #195.

NB - The fixes for drawing in #255 are needed to test this PR.