### PR TITLE
Update welcome message and remove welcome modal

### DIFF
--- a/app/app/(chat)/layout.tsx
+++ b/app/app/(chat)/layout.tsx
@@ -26,7 +26,7 @@ import useSidebarStore from "@/app/store/sidebarStore";
 import { useLegendHook } from "@/app/components/legend/useLegendHook";
 import { Legend } from "@/app/components/legend/Legend";
 const GA_ID = process.env.NEXT_PUBLIC_GOOGLE_ANALYTICS_ID;
-
+const LANDING_PAGE_VERSION = process.env.NEXT_PUBLIC_LANDING_PAGE_VERSION;
 export default function DashboardLayout({
   children,
 }: {
@@ -65,7 +65,7 @@ export default function DashboardLayout({
       bg="bg"
     >
       {cookieConsent && GA_ID && <GoogleAnalytics gaId={GA_ID} />}
-      <WelcomeModal />
+      {LANDING_PAGE_VERSION === "public" && <WelcomeModal />}
       {GA_ID && <CookieConsent />}
       <UploadAreaDialog />
       <Box hideBelow="md">

--- a/app/components/ChatMessages.tsx
+++ b/app/components/ChatMessages.tsx
@@ -1,13 +1,21 @@
 "use client";
 import { Fragment, useEffect, useRef } from "react";
-import { Box } from "@chakra-ui/react";
+import { Box, Link, Text } from "@chakra-ui/react";
 import useChatStore from "@/app/store/chatStore";
 import MessageBubble from "./MessageBubble";
 import Reasoning from "./Reasoning";
+import { InfoIcon } from "@phosphor-icons/react";
 
+const LANDING_PAGE_VERSION = process.env.NEXT_PUBLIC_LANDING_PAGE_VERSION;
+
+const SAMPLE_PROMPTS = [
+  "Show me recent forest loss due to firest in protected areas",
+  "I want to monitor restoration progress in my region. What datasets should I use?",
+  "Where are the most disturbances to nature happening now?",
+];
 function ChatMessages() {
   const containerRef = useRef<HTMLDivElement>(null);
-  const { messages, isLoading } = useChatStore();
+  const { messages, isLoading, sendMessage } = useChatStore();
 
   // Auto-scroll to bottom when new messages are added or loading state changes
   useEffect(() => {
@@ -37,7 +45,9 @@ function ChatMessages() {
   }, []);
 
   // Show reasoning after the last user message when loading
-  const lastUserMessageIndex = messages.findLastIndex(msg => msg.type === "user");
+  const lastUserMessageIndex = messages.findLastIndex(
+    (msg) => msg.type === "user"
+  );
 
   return (
     <Box ref={containerRef} fontSize="sm">
@@ -48,11 +58,62 @@ function ChatMessages() {
 
         return (
           <Fragment key={message.id}>
-            <MessageBubble
-              message={message}
-              isConsecutive={isConsecutive}
-            />
+            {/* Disclaimer above first message in closed mode */}
+            {index === 0 && LANDING_PAGE_VERSION !== "public" && (
+              <Box
+                background="secondary.subtle"
+                p={2}
+                rounded="sm"
+                border="1px solid"
+                borderColor="secondary.300"
+                fontSize="xs"
+                display="flex"
+                gap={2}
+                my={4}
+              >
+                <InfoIcon
+                  weight="fill"
+                  style={{ flexShrink: 0 }}
+                  size="16"
+                  fill="var(--chakra-colors-secondary-600)"
+                />
+                <Text>
+                  This is an <strong>experimental preview</strong> of Global
+                  Nature Watch. Our AI assistant may make mistakes, please
+                  verify outputs with primary sources. Feedback is welcome at{" "}
+                  <Link
+                    color="primary.solid"
+                    textDecor="underline"
+                    href="mailto:xyz@landandcarbonlab.org"
+                  >
+                    xyz@landandcarbonlab.org.
+                  </Link>
+                </Text>
+              </Box>
+            )}
+            <MessageBubble message={message} isConsecutive={isConsecutive} />
             {isLoading && index === lastUserMessageIndex && <Reasoning />}
+
+            {/* Prompt options for first message */}
+            {index === 0 && LANDING_PAGE_VERSION !== "public" && (
+              <Box display="flex" gap={2} flexWrap="nowrap" mb={4}>
+                {SAMPLE_PROMPTS.map((text, i) => (
+                  <Box
+                    key={i}
+                    p={2}
+                    rounded="lg"
+                    border="1px solid"
+                    borderColor="border.emphasized"
+                    fontSize="xs"
+                    transition="all 0.24s ease"
+                    _hover={{ cursor: "pointer", bg: "bg.subtle", borderColor: "secondary.solid" }}
+                    onClick={() => sendMessage(text)}
+                  >
+                    {text}
+                  </Box>
+                ))}
+              </Box>
+            )}
           </Fragment>
         );
       })}

--- a/app/components/MessageBubble.tsx
+++ b/app/components/MessageBubble.tsx
@@ -131,6 +131,14 @@ function MessageBubble({ message, isConsecutive = false }: MessageBubbleProps) {
                 borderColor: "bg.muted",
                 pb: 2,
               },
+              "& a": {
+                textDecoration: "underline",
+                color: "primary.solid",
+                transition: "all 0.24s ease",
+              },
+              "& a:hover" : {
+                opacity: 0.64
+              },
             }}
           >
             <Markdown remarkPlugins={[remarkBreaks]}>

--- a/app/store/chatStore.ts
+++ b/app/store/chatStore.ts
@@ -55,10 +55,12 @@ const initialState: ChatState = {
     {
       id: "1",
       type: "system",
-      message: `Hi, I'm your Global Nature Watch assistant.
-I help you explore how our planet's land and ecosystems are changing, powered by trusted, open-source data from Land & Carbon Lab and Global Forest Watch.
-
-Ask a question and let's see what we can do for nature.`,
+      message:
+      `**Welcome to Global Nature Watch!**
+      &nbsp;
+      Hi, I'm your nature monitoring assistant, powered by open data from [Global Forest Watch](https://globalforestwatch.org) and [Land and Carbon Lab](https://landcarbonlab.org).
+      &nbsp;
+      Ask me anything about land cover change, forest loss or biodiversity risks in places you care about.`,
       timestamp: new Date().toISOString(),
     },
   ],


### PR DESCRIPTION
This PR
- Updates welcome message
- includes sample prompts in chat
- Removes welcome modal in closed and limited modes

To explore:
- Should this welcome message and disclaimer go away after x number of messages?
- Should they go away after a sample prompt is clicked?
- Are these the right sample prompts, or should we use ones from the welcome-prompts.json file?
- Is the condition on the welcome modal removal correct? (only renders when in public landing page mode)

This does take up a lot of space
<img width="1012" height="1582" alt="Screenshot 2025-09-13 at 1 28 02 AM" src="https://github.com/user-attachments/assets/f51e4647-4f52-496e-b519-994f0c9d253b" />

Closes #226 