### PR TITLE
Pii disclaimers

### DIFF
--- a/app/ChatPanel.tsx
+++ b/app/ChatPanel.tsx
@@ -130,6 +130,8 @@ function ChatPanel() {
               fontSize="xs"
               color="fg.subtle"
               hideBelow="md"
+              whiteSpace="pre"
+              overflowX="auto"
             >
               AI may make mistakes. Verify outputs and don&apos;t share sensitive personal information.
             </Text>

--- a/app/ChatPanel.tsx
+++ b/app/ChatPanel.tsx
@@ -129,12 +129,9 @@ function ChatPanel() {
             <Text
               fontSize="xs"
               color="fg.subtle"
-              whiteSpace="pre"
-              overflowX="auto"
               hideBelow="md"
             >
-              AI can make mistakes. Please verify any outputs before using them
-              in your work.
+              AI may make mistakes. Verify outputs and don&apos;t share sensitive personal information.
             </Text>
           </Box>
         </Flex>

--- a/app/ChatPanel.tsx
+++ b/app/ChatPanel.tsx
@@ -126,15 +126,28 @@ function ChatPanel() {
               ))}
 
             <ChatInput isChatDisabled={promptsExhausted} />
-            <Text
+            <Flex
               fontSize="xs"
               color="fg.subtle"
               hideBelow="md"
               whiteSpace="pre"
               overflowX="auto"
+              gap={2}
             >
-              AI may make mistakes. Verify outputs and don&apos;t share sensitive personal information.
-            </Text>
+              <Text>
+                AI makes mistakes. Verify outputs and don&apos;t share sensitive or
+                personal information.
+              </Text>
+              <ChLink
+                href="https://www.wri.org/about/privacy-policy?sitename=landcarbonlab.org&osanoid=5a6c3f87-bd10-4df7-80c7-375ce6a77691"
+                target="_blank"
+                rel="noopener noreferrer"
+                textDecoration="underline"
+                color="fg.subtle"
+              >
+                Privacy Policy
+              </ChLink>
+            </Flex>
           </Box>
         </Flex>
       </Flex>

--- a/app/ChatPanel.tsx
+++ b/app/ChatPanel.tsx
@@ -138,15 +138,6 @@ function ChatPanel() {
                 AI makes mistakes. Verify outputs and don&apos;t share sensitive or
                 personal information.
               </Text>
-              <ChLink
-                href="https://www.wri.org/about/privacy-policy?sitename=landcarbonlab.org&osanoid=5a6c3f87-bd10-4df7-80c7-375ce6a77691"
-                target="_blank"
-                rel="noopener noreferrer"
-                textDecoration="underline"
-                color="fg.subtle"
-              >
-                Privacy Policy
-              </ChLink>
             </Flex>
           </Box>
         </Flex>

--- a/app/ChatPanel.tsx
+++ b/app/ChatPanel.tsx
@@ -135,8 +135,8 @@ function ChatPanel() {
               gap={2}
             >
               <Text>
-                AI makes mistakes. Verify outputs and don&apos;t share sensitive or
-                personal information.
+                AI makes mistakes. Verify outputs and do not share
+                any sensitive or personal information.
               </Text>
             </Flex>
           </Box>

--- a/app/components/Map.tsx
+++ b/app/components/Map.tsx
@@ -14,6 +14,9 @@ import {
   Code,
   Box,
   useBreakpointValue,
+  Flex,
+  Link as ChLink,
+  Text,
 } from "@chakra-ui/react";
 import { PlusIcon } from "@phosphor-icons/react";
 import useMapStore from "@/app/store/mapStore";
@@ -140,17 +143,41 @@ function Map({ disableMapAreaControls }: { disableMapAreaControls?: boolean }) {
             <NavigationControl showCompass={false} position="bottom-left" />
           </>
         )}
-        <Code
+        <Flex
           pos="absolute"
           bottom="4"
-          right="0"
+          right="4"
           p="2"
           fontSize="xs"
+          color="fg.subtle"
           bg="transparent"
           hideBelow="md"
+          alignItems="center"
+          gap={2}
         >
-          lat, lon: {mapCenter[1].toFixed(3)}, {mapCenter[0].toFixed(3)}
-        </Code>
+          <ChLink
+            href="https://www.wri.org/about/privacy-policy?sitename=landcarbonlab.org&osanoid=5a6c3f87-bd10-4df7-80c7-375ce6a77691"
+            target="_blank"
+            rel="noopener noreferrer"
+            textDecoration="underline"
+            color="fg.subtle"
+          >
+            Privacy Policy
+          </ChLink>
+          <Text color="fg.subtle">•</Text>
+          <ChLink
+            href="https://www.wri.org/about/wri-data-platforms-tos"
+            target="_blank"
+            rel="noopener noreferrer"
+            textDecoration="underline"
+            color="fg.subtle"
+          >
+            Terms of Service
+          </ChLink>
+          <Code bg="transparent" p={0} color="fg.subtle" ml={2}>
+            lat, lon: {mapCenter[1].toFixed(3)}, {mapCenter[0].toFixed(3)}
+          </Code>
+        </Flex>
       </MapGl>
     </Box>
   );

--- a/app/config/onboarding.ts
+++ b/app/config/onboarding.ts
@@ -32,7 +32,11 @@ const ALL_FIELD_KEYS: readonly OnboardingFieldKey[] = [
 // By default, all fields except marketing/opt-in checkboxes are required.
 export const DEFAULT_REQUIRED_ONBOARDING_FIELDS: readonly OnboardingFieldKey[] =
   ALL_FIELD_KEYS.filter(
-    (k) => k !== "receiveNewsEmails" && k !== "helpTestFeatures"
+    (k) =>
+      k !== "receiveNewsEmails" &&
+      k !== "helpTestFeatures" &&
+      k !== "expertise" &&
+      k !== "jobTitle"
   ) as OnboardingFieldKey[];
 
 /**

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -341,7 +341,7 @@ export default function UserSettingsPage() {
         </Button>
       </Flex>
       <Box maxH="100%" overflowY="auto">
-        <Container maxW="4xl" display="flex" flexDirection="column" py={10}>
+        <Container maxW="4xl" display="flex" flexDirection="column" py={16}>
           {/* Header Section */}
           <Flex
             justifyContent="space-between"
@@ -402,7 +402,16 @@ export default function UserSettingsPage() {
             <GridItem>
               <Field.Root id="email">
                 <Field.Label>Email address</Field.Label>
-                <Input type="email" value={form.email} readOnly disabled />
+                <Input
+                  type="email"
+                  value={form.email}
+                  readOnly
+                  _readOnly={{
+                    bg: "bg.subtle",
+                    color: "fg.muted",
+                    cursor: "not-allowed",
+                  }}
+                />
               </Field.Root>
             </GridItem>
           </Grid>
@@ -467,7 +476,11 @@ export default function UserSettingsPage() {
                 >
                   <Select.HiddenSelect />
                   <Select.Label>Role</Select.Label>
-                  <Select.Control>
+                  <Select.Control
+                    _disabled={{
+                      bg: "bg.subtle",
+                    }}
+                  >
                     <Select.Trigger>
                       <Select.ValueText placeholder="Select Role" />
                     </Select.Trigger>

--- a/app/onboarding/page.tsx
+++ b/app/onboarding/page.tsx
@@ -599,8 +599,26 @@ export default function OnboardingPage() {
             </Flex>
             <Separator mt={4} />
           </Box>
-
-          <Flex alignItems="center" gap={3} mt={8}>
+          <Box
+            mt={4}
+            p={4}
+            borderWidth="1px"
+            borderRadius="md"
+            bg="lime.100"
+            borderColor="lime.400"
+            color="gray.700"
+          >
+            <Flex align="center">
+              <Text fontSize="sm">
+                We use the information you provide to improve the service and
+                personalize your experience. This tool is experimental and
+                features may change or be removed over time. Please do not share
+                sensitive personal information that could be used to identify you
+                or put your privacy at risk.
+              </Text>
+            </Flex>
+          </Box>
+          <Flex alignItems="center" justifyContent="space-between" mt={4}>
             <Checkbox.Root
               checked={form.termsAccepted}
               onCheckedChange={(e) =>
@@ -609,12 +627,13 @@ export default function OnboardingPage() {
             >
               <Checkbox.HiddenInput />
               <Checkbox.Control />
-              <Checkbox.Label>
+              <Checkbox.Label fontWeight="normal">
                 I accept the{" "}
                 <Link
                   href="https://www.wri.org/about/legal/general-terms-use"
                   target="_blank"
                   rel="noopener noreferrer"
+                  textDecoration="underline"
                 >
                   Terms of Use
                 </Link>{" "}
@@ -623,6 +642,7 @@ export default function OnboardingPage() {
                   href="https://www.wri.org/about/privacy-policy"
                   target="_blank"
                   rel="noopener noreferrer"
+                  textDecoration="underline"
                 >
                   Privacy Policy
                 </Link>
@@ -634,21 +654,20 @@ export default function OnboardingPage() {
                 )}
               </Checkbox.Label>
             </Checkbox.Root>
-          </Flex>
-
-          <Flex mt={8} gap={4}>
-            <Button
-              type="submit"
-              colorPalette="primary"
-              disabled={!isValid || isSubmitting}
-              loading={isSubmitting}
-              loadingText="Finalizing profile..."
-            >
-              Continue
-            </Button>
-            <Text color="fg.muted" fontSize="xs" alignSelf="center">
-              You can edit these details later in Settings.
-            </Text>
+            <Flex gap={4}>
+              <Button variant="outline" onClick={() => router.push("/")}>
+                Go back
+              </Button>
+              <Button
+                type="submit"
+                colorPalette="primary"
+                disabled={!isValid || isSubmitting}
+                loading={isSubmitting}
+                loadingText="Finalizing profile..."
+              >
+                Complete profile
+              </Button>
+            </Flex>
           </Flex>
         </form>
       </Container>

--- a/app/onboarding/page.tsx
+++ b/app/onboarding/page.tsx
@@ -18,12 +18,15 @@ import {
   Checkbox,
   createListCollection,
   Link,
+  Badge,
 } from "@chakra-ui/react";
 import { useRouter } from "next/navigation";
 import { PatchProfileRequestSchema } from "@/app/schemas/api/auth/profile/patch";
 import { isOnboardingFieldRequired } from "@/app/config/onboarding";
 import { getOnboardingFormSchema } from "@/app/onboarding/schema";
 import { showApiError } from "@/app/hooks/useErrorHandler";
+import LclLogo from "../components/LclLogo";
+import { ArrowLeftIcon } from "@phosphor-icons/react";
 
 type ProfileConfig = {
   sectors: Record<string, string>;
@@ -237,9 +240,30 @@ export default function OnboardingPage() {
   };
 
   return (
-    <Box minH="100vh" bg="bg" py={10}>
+    <Box minH="100vh" bg="bg" py={24}>
       <Container maxW="3xl">
-      <Heading as="h1" size="2xl" mb={2} fontWeight="normal">
+        <Flex justifyContent="space-between" mb={12}>
+          <Flex gap="2" alignItems="center" >
+            <LclLogo width={16} avatarOnly fill="var(--chakra-colors-primary-fg)" />
+            <Heading as="h1" size="md" color="primary.fg">
+              Global Nature Watch
+            </Heading>
+            <Badge
+              colorPalette="primary"
+              bg="primary.800"
+              letterSpacing="wider"
+              variant="solid"
+              size="xs"
+            >
+              BETA
+            </Badge>
+          </Flex>
+          <Button colorPalette="primary" variant="ghost" onClick={() => router.push("/")}>
+            <ArrowLeftIcon />
+            Go back
+          </Button>
+        </Flex>
+        <Heading as="h1" size="2xl" mb={2} fontWeight="normal">
           Complete your{" "}
           <Text as="span" fontWeight="bold">
             Global Nature Watch
@@ -247,12 +271,15 @@ export default function OnboardingPage() {
           user profile
         </Heading>
         <Text color="fg.muted" fontSize="sm" mb={10}>
-          We use this information to make Global Nature Watch more useful to you.
-          This tool is experimental, and your and knowing you better helps us improve.
-          Features may change or be removed over time.
+          We use this information to make Global Nature Watch more useful to
+          you. This tool is experimental, and your and knowing you better helps
+          us improve. Features may change or be removed over time.
         </Text>
         <form onSubmit={handleSubmit}>
-          <Grid templateColumns={{ base: "1fr", md: "repeat(2, 1fr)" }} gap={12}>
+          <Grid
+            templateColumns={{ base: "1fr", md: "repeat(2, 1fr)" }}
+            gap={12}
+          >
             <GridItem>
               <Field.Root id="first-name" required={fieldRequired("firstName")}>
                 <Field.Label>
@@ -308,6 +335,11 @@ export default function OnboardingPage() {
                   onChange={(e) =>
                     setForm((p) => ({ ...p, email: e.target.value }))
                   }
+                  _readOnly={{
+                    bg: "bg.subtle",
+                    color: "fg.muted",
+                    cursor: "not-allowed",
+                  }}
                 />
               </Field.Root>
             </GridItem>
@@ -371,7 +403,7 @@ export default function OnboardingPage() {
                       </Text>
                     )}
                   </Select.Label>
-                  <Select.Control>
+                  <Select.Control _disabled={{ bg: "bg.subtle" }}>
                     <Select.Trigger>
                       <Select.ValueText placeholder="Select Role" />
                     </Select.Trigger>
@@ -402,9 +434,7 @@ export default function OnboardingPage() {
             </GridItem>
             <GridItem>
               <Field.Root id="job-title" required={fieldRequired("jobTitle")}>
-                <Field.Label>
-                  Job title
-                </Field.Label>
+                <Field.Label>Job title</Field.Label>
                 <Input
                   type="text"
                   value={form.jobTitle}
@@ -478,9 +508,7 @@ export default function OnboardingPage() {
               <Field.Root id="expertise" required={fieldRequired("expertise")}>
                 <Select.Root collection={expertises} size="sm">
                   <Select.HiddenSelect />
-                  <Select.Label>
-                    Level of technical expertise
-                  </Select.Label>
+                  <Select.Label>Level of technical expertise</Select.Label>
                   <Select.Control>
                     <Select.Trigger>
                       <Select.ValueText placeholder="Select Level" />
@@ -629,9 +657,6 @@ export default function OnboardingPage() {
               </Checkbox.Label>
             </Checkbox.Root>
             <Flex gap={4}>
-              <Button variant="outline" onClick={() => router.push("/")}>
-                Go back
-              </Button>
               <Button
                 type="submit"
                 colorPalette="primary"

--- a/app/onboarding/page.tsx
+++ b/app/onboarding/page.tsx
@@ -604,8 +604,8 @@ export default function OnboardingPage() {
             p={4}
             borderWidth="1px"
             borderRadius="md"
-            bg="lime.100"
-            borderColor="lime.400"
+            bg="secondary.subtle"
+            borderColor="secondary.solid"
             color="gray.700"
           >
             <Flex align="center">

--- a/app/onboarding/page.tsx
+++ b/app/onboarding/page.tsx
@@ -238,17 +238,16 @@ export default function OnboardingPage() {
 
   return (
     <Box minH="100vh" bg="bg" py={10}>
-      <Container maxW="4xl">
+      <Container maxW="3xl">
         <Heading as="h1" size="2xl" mb={2} fontWeight="normal">
           Complete your Global Nature Watch profile
         </Heading>
         <Text color="fg.muted" fontSize="sm" mb={10}>
           We use this information to make Global Nature Watch more useful for
-          you. Your privacy is important to us and we’ll never share your
-          information without your consent.
+          you. This tool is experimental and knowing you better helps us improve.
         </Text>
         <form onSubmit={handleSubmit}>
-          <Grid templateColumns={{ base: "1fr", md: "repeat(2, 1fr)" }} gap={6}>
+          <Grid templateColumns={{ base: "1fr", md: "repeat(2, 1fr)" }} gap={12}>
             <GridItem>
               <Field.Root id="first-name" required={fieldRequired("firstName")}>
                 <Field.Label>
@@ -312,7 +311,7 @@ export default function OnboardingPage() {
             </GridItem>
             <GridItem>
               <Field.Root id="sector" required={fieldRequired("sector")}>
-                <Select.Root collection={sectors} size="sm" width="320px">
+                <Select.Root collection={sectors} size="sm">
                   <Select.HiddenSelect />
                   <Select.Label>
                     Sector
@@ -356,7 +355,6 @@ export default function OnboardingPage() {
                 <Select.Root
                   collection={roles}
                   size="sm"
-                  width="320px"
                   disabled={!form.sector}
                 >
                   <Select.HiddenSelect />
@@ -401,11 +399,6 @@ export default function OnboardingPage() {
               <Field.Root id="job-title" required={fieldRequired("jobTitle")}>
                 <Field.Label>
                   Job title
-                  {fieldRequired("jobTitle") && (
-                    <Text as="span" color="red.500" ml={1}>
-                      *
-                    </Text>
-                  )}
                 </Field.Label>
                 <Input
                   type="text"
@@ -437,7 +430,7 @@ export default function OnboardingPage() {
             </GridItem>
             <GridItem>
               <Field.Root id="country" required={fieldRequired("country")}>
-                <Select.Root collection={countries} size="sm" width="320px">
+                <Select.Root collection={countries} size="sm">
                   <Select.HiddenSelect />
                   <Select.Label>
                     Country
@@ -478,15 +471,10 @@ export default function OnboardingPage() {
             </GridItem>
             <GridItem>
               <Field.Root id="expertise" required={fieldRequired("expertise")}>
-                <Select.Root collection={expertises} size="sm" width="320px">
+                <Select.Root collection={expertises} size="sm">
                   <Select.HiddenSelect />
                   <Select.Label>
                     Level of technical expertise
-                    {fieldRequired("expertise") && (
-                      <Text as="span" color="red.500" ml={1}>
-                        *
-                      </Text>
-                    )}
                   </Select.Label>
                   <Select.Control>
                     <Select.Trigger>
@@ -520,7 +508,7 @@ export default function OnboardingPage() {
             <GridItem colSpan={{ base: 1, md: 2 }}>
               <Field.Root id="topics" required={fieldRequired("topics")}>
                 <Field.Label>
-                  What area(s) are you most interested in?
+                  What topic(s) are you most interested in?
                   {fieldRequired("topics") && (
                     <Text as="span" color="red.500" ml={1}>
                       *

--- a/app/onboarding/page.tsx
+++ b/app/onboarding/page.tsx
@@ -592,25 +592,6 @@ export default function OnboardingPage() {
             </Flex>
             <Separator mt={4} />
           </Box>
-          <Box
-            mt={4}
-            p={4}
-            borderWidth="1px"
-            borderRadius="md"
-            bg="secondary.subtle"
-            borderColor="secondary.solid"
-            color="gray.700"
-          >
-            <Flex align="center">
-              <Text fontSize="sm">
-                We use the information you provide to improve the service and
-                personalize your experience. This tool is experimental and
-                features may change or be removed over time. Please do not share
-                sensitive personal information that could be used to identify you
-                or put your privacy at risk.
-              </Text>
-            </Flex>
-          </Box>
           <Flex alignItems="center" justifyContent="space-between" mt={4}>
             <Checkbox.Root
               checked={form.termsAccepted}

--- a/app/onboarding/page.tsx
+++ b/app/onboarding/page.tsx
@@ -239,12 +239,17 @@ export default function OnboardingPage() {
   return (
     <Box minH="100vh" bg="bg" py={10}>
       <Container maxW="3xl">
-        <Heading as="h1" size="2xl" mb={2} fontWeight="normal">
-          Complete your Global Nature Watch profile
+      <Heading as="h1" size="2xl" mb={2} fontWeight="normal">
+          Complete your{" "}
+          <Text as="span" fontWeight="bold">
+            Global Nature Watch
+          </Text>{" "}
+          user profile
         </Heading>
         <Text color="fg.muted" fontSize="sm" mb={10}>
-          We use this information to make Global Nature Watch more useful for
-          you. This tool is experimental and knowing you better helps us improve.
+          We use this information to make Global Nature Watch more useful to you.
+          This tool is experimental, and your and knowing you better helps us improve.
+          Features may change or be removed over time.
         </Text>
         <form onSubmit={handleSubmit}>
           <Grid templateColumns={{ base: "1fr", md: "repeat(2, 1fr)" }} gap={12}>
@@ -625,7 +630,7 @@ export default function OnboardingPage() {
                 >
                   Terms of Use
                 </Link>{" "}
-                and{" "}
+                and I acknowledge the privacy practices described in the{" "}
                 <Link
                   href="https://www.wri.org/about/privacy-policy"
                   target="_blank"

--- a/app/theme/index.tsx
+++ b/app/theme/index.tsx
@@ -92,6 +92,10 @@ export const config = defineConfig({
         orange: { ...defaultColors.orange, 500: { value: "#FF9916" } },
         yellow: { ...defaultColors.yellow, 500: { value: "#FFD80B" } },
         green: { ...defaultColors.green, 500: { value: "#00A651" } },
+        lime: {
+          100: { value: "#F7FBD9" },
+          400: { value: "#E3F37F" },
+        },
         mint: {
           50: { value: "#e2fff8" },
           100: { value: "#b6fde9" },


### PR DESCRIPTION
Making various copy edits for PII disclaimers (note: still waiting for the final copy so keeping this a draft for now)

BONUS: align /onboading with [designs](https://www.figma.com/design/N20cpSWt9kWZWILQOcsdIT/WRI_LCL_ProjectZeno?node-id=3693-13519&t=jdOW5h2BBt6dSHT2-4).
- Added a `go back` option so users can nav back to the landing page (the only exit option currently is to close tab).
- Added disclaimer block

<img width="581" height="719" alt="image" src="https://github.com/user-attachments/assets/f93475b1-342e-4082-a1a7-7c9c2d6312b9" />
