### PR TITLE
Ensure that only one map is rendered

### DIFF
--- a/app/app/(chat)/layout.tsx
+++ b/app/app/(chat)/layout.tsx
@@ -6,6 +6,7 @@ import {
   Drawer,
   Portal,
   IconButton,
+  useBreakpointValue,
 } from "@chakra-ui/react";
 import { Suspense, useEffect, useState } from "react";
 import { GoogleAnalytics } from "@next/third-parties/google";
@@ -36,6 +37,7 @@ export default function DashboardLayout({
   const [sheetHeight, setSheetHeight] = useState(400);
   const { toggleSidebar } = useSidebarStore();
   const { layers, handleLayerAction } = useLegendHook();
+  const isMobile = useBreakpointValue({ base: true, md: false });
 
   useEffect(() => {
     // As we can't read localStorage outside the useEffect, we update the
@@ -71,79 +73,79 @@ export default function DashboardLayout({
       <Box hideBelow="md">
         <PageHeader />
       </Box>
-      {/* Desktop view */}
-      <Grid
-        templateColumns="auto min-content 1fr"
-        templateAreas="'sidebar chat map'"
-        templateRows="1fr"
-        maxH="calc(100vh - 3rem)"
-        hideBelow="md"
-      >
-        <Sidebar />
-        <ChatPanel />
-        <Grid templateRows="1fr" gridArea="map">
-          <Box overflow="hidden">
-            <Legend layers={layers} onLayerAction={handleLayerAction} />
+      {isMobile ? (
+        <Box
+          position="relative"
+          w="100vw"
+          h="min(100dvh, 100vh)"
+          overflow="hidden"
+          gridRow={1}
+          hideFrom="md"
+        >
+          <Box
+            w="100%"
+            h={`calc(100% - ${sheetHeight}px + 12px)`}
+            transition="height 0.05s linear"
+          >
+            <Drawer.Root placement="start">
+              <Drawer.Trigger asChild>
+                <IconButton
+                  variant="plain"
+                  bg="bg"
+                  position="absolute"
+                  top={3}
+                  left={3}
+                  rounded="sm"
+                  overflow="hidden"
+                  zIndex={100}
+                  onClick={toggleSidebar}
+                >
+                  <ListIcon />
+                </IconButton>
+              </Drawer.Trigger>
+              <Portal>
+                <Drawer.Backdrop backdropFilter="blur(2px)" />
+                <Drawer.Positioner>
+                  <Drawer.Content>
+                    <Sidebar />
+                  </Drawer.Content>
+                </Drawer.Positioner>
+              </Portal>
+            </Drawer.Root>
+            <Box
+              position="absolute"
+              top={3}
+              left={"3.75rem"}
+              rounded="sm"
+              overflow="hidden"
+              zIndex={100}
+            >
+              <PageHeader />
+            </Box>
             <Map />
           </Box>
-        </Grid>
-      </Grid>
-
-      {/* Mobile View */}
-      <Box
-        position="relative"
-        w="100vw"
-        h="min(100dvh, 100vh)"
-        overflow="hidden"
-        gridRow={1}
-        hideFrom="md"
-      >
-        <Box
-          w="100%"
-          h={`calc(100% - ${sheetHeight}px + 12px)`}
-          transition="height 0.05s linear"
-        >
-          <Drawer.Root placement="start">
-            <Drawer.Trigger asChild>
-              <IconButton
-                variant="plain"
-                bg="bg"
-                position="absolute"
-                top={3}
-                left={3}
-                rounded="sm"
-                overflow="hidden"
-                zIndex={100}
-                onClick={toggleSidebar}
-              >
-                <ListIcon />
-              </IconButton>
-            </Drawer.Trigger>
-            <Portal>
-              <Drawer.Backdrop backdropFilter="blur(2px)" />
-              <Drawer.Positioner>
-                <Drawer.Content>
-                  <Sidebar />
-                </Drawer.Content>
-              </Drawer.Positioner>
-            </Portal>
-          </Drawer.Root>
-          <Box
-            position="absolute"
-            top={3}
-            left={"3.75rem"}
-            rounded="sm"
-            overflow="hidden"
-            zIndex={100}
-          >
-            <PageHeader />
-          </Box>
-          <Map />
+          <DraggableBottomSheet onHeightChange={setSheetHeight}>
+            <ChatPanel />
+          </DraggableBottomSheet>
         </Box>
-        <DraggableBottomSheet onHeightChange={setSheetHeight}>
+      ) : (
+        <Grid
+          templateColumns="auto min-content 1fr"
+          templateAreas="'sidebar chat map'"
+          templateRows="1fr"
+          maxH="calc(100vh - 3rem)"
+          hideBelow="md"
+        >
+          <Sidebar />
           <ChatPanel />
-        </DraggableBottomSheet>
-      </Box>
+          <Grid templateRows="1fr" gridArea="map">
+            <Box overflow="hidden">
+              <Legend layers={layers} onLayerAction={handleLayerAction} />
+              <Map />
+            </Box>
+          </Grid>
+        </Grid>
+      )}
 
       <Suspense fallback={null}>
         <DebugToastsMount />


### PR DESCRIPTION
Fixes the issue with the map where it wasn't zooming to the boundaries of geometries.

This as happening because 2 maps were being rendered (one for mobile and one for desktop) and the actions were being fired on the hidden map. The `hideFrom` prop doesn't prevent the code from being rendered but hides it instead with `display: none`. The result is that there are 2 maps rendered albeit only one being visible.
In general it's not idea to have 2 different structures for mobile and desktop. It should be the same and be responsive. If not possible at all, it is better to render conditionally instead of visually (when complex interactive components are at play)