### PR TITLE
Fix bad setstate, update welcome prompts

### DIFF
--- a/app/(home)/page.tsx
+++ b/app/(home)/page.tsx
@@ -13,16 +13,6 @@ import TeamSection from "./sections/9_TeamSection";
 import CTASection from "./sections/11_CTA";
 import FooterSection from "./sections/12_Footer";
 
-const SAMPLE_PROMPTS = [
-  "Tell me about wild fires in the Brazilian Amazon Rainforest",
-  "What are the latest deforestation trends in Indonesia?",
-  "How is climate change affecting biodiversity in the Amazon?",
-  "Show me recent land use changes in the Congo Basin",
-  "What country's forests sequester the most carbon?",
-  "Where are the most disturbances to nature happening now?",
-  "Show me high priority areas in my monitoring portfolio",
-];
-
 export default function LandingPage() {
   const [promptIndex, setPromptIndex] = useState(0);
   const { prompts, fetchPrompts } = usePromptStore(); // TODO - determine if landing page should use sample prompts above, or the prompst from the welcome modal
@@ -32,14 +22,12 @@ export default function LandingPage() {
   return (
     <>
       <LandingHero
-        prompts={SAMPLE_PROMPTS}
+        prompts={prompts}
         promptIndex={promptIndex}
         setPromptIndex={setPromptIndex}
       />
       <PromptMarquee
         prompts={prompts}
-        promptIndex={promptIndex}
-        setPromptIndex={setPromptIndex}
       />
       <FeaturesTabsSection />
       <SupportWorkTabsSection />

--- a/app/(home)/sections/2_PromptMarquee.tsx
+++ b/app/(home)/sections/2_PromptMarquee.tsx
@@ -5,16 +5,9 @@ const MARQUEE_SPEED = 40;
 
 type PromptMarqueeProps = {
   prompts: string[];
-  promptIndex: number;
-  setPromptIndex: React.Dispatch<React.SetStateAction<number>>;
 };
 
-function renderPromptBoxes(
-  prompts: string[],
-  setPromptIndex: React.Dispatch<React.SetStateAction<number>>
-) {
-  const LANDING_PAGE_VERSION = process.env.NEXT_PUBLIC_LANDING_PAGE_VERSION;
-  
+function renderPromptBoxes(prompts: string[]) {
   return Array(2)
     .fill(prompts)
     .flat()
@@ -33,10 +26,6 @@ function renderPromptBoxes(
         _hover={{
           "&&": { opacity: 1 },
         }}
-        onClick={() => {
-          if (LANDING_PAGE_VERSION !== "public") return;
-          setPromptIndex(() => i);
-        }}
       >
         {prompt}
       </Box>
@@ -50,7 +39,6 @@ function renderMarqueeRow({
   sliderWidth,
   direction,
   sliderRef,
-  setPromptIndex,
 }: {
   prompts: string[];
   animationName: string;
@@ -58,7 +46,6 @@ function renderMarqueeRow({
   sliderWidth: number;
   direction: "left" | "right";
   sliderRef?: React.Ref<HTMLDivElement>;
-  setPromptIndex: React.Dispatch<React.SetStateAction<number>>;
 }) {
   const style =
     direction === "left"
@@ -87,12 +74,12 @@ function renderMarqueeRow({
       }}
       ref={sliderRef}
     >
-      {renderPromptBoxes(prompts, setPromptIndex)}
+      {renderPromptBoxes(prompts)}
     </Flex>
   );
 }
 
-function PromptMarquee({ prompts, setPromptIndex }: PromptMarqueeProps) {
+function PromptMarquee({ prompts }: PromptMarqueeProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const sliderRef = useRef<HTMLDivElement>(null);
   const [sliderWidth, setSliderWidth] = useState(0);
@@ -127,7 +114,6 @@ function PromptMarquee({ prompts, setPromptIndex }: PromptMarqueeProps) {
         animationName: "dynamicSlideLeft",
         animationDuration,
         sliderWidth,
-        setPromptIndex,
         direction: "left",
         sliderRef,
       })}
@@ -135,7 +121,6 @@ function PromptMarquee({ prompts, setPromptIndex }: PromptMarqueeProps) {
         prompts,
         animationName: "dynamicSlideRight",
         animationDuration,
-        setPromptIndex,
         sliderWidth,
         direction: "right",
       })}


### PR DESCRIPTION
This PR:
- Removes the functionality of clicking a scrolling prompt to set that prompt in the input box (fixes bad setstate)
- Removes the hardcoded "sample prompts" from the homepage, in favor of the prompts from the fetchPrompts() function