### PR TITLE
Render dataset info above context menu

### DIFF
--- a/app/components/DatasetInfoModal.tsx
+++ b/app/components/DatasetInfoModal.tsx
@@ -27,7 +27,7 @@ export function DatasetInfoModal({
     <Dialog.Root open={isOpen} onOpenChange={(e) => !e.open && onClose()}>
       <Portal>
         <Dialog.Backdrop backdropFilter="blur(8px)" />
-        <Dialog.Positioner>
+        <Dialog.Positioner zIndex={1600}>
           <Dialog.Content maxW="3xl" p="10" borderRadius="8px">
             <Dialog.Title mb="4" fontSize="xl" fontWeight="bold" pr="6">{dataset.dataset_name}</Dialog.Title>
             <Dialog.Description asChild css={{ "& p": { whiteSpace: "pre-wrap" } }}>


### PR DESCRIPTION
Ensure info modal renders above the context menu (previously this was obscured behind)

<img width="947" height="763" alt="Screenshot 2025-09-16 at 9 32 53 PM" src="https://github.com/user-attachments/assets/f48166e1-9902-4f58-87cd-0a19dd372971" />
