### PR TITLE
Close sidebar on thread click on mobile

### DIFF
--- a/app/app/(chat)/layout.tsx
+++ b/app/app/(chat)/layout.tsx
@@ -34,7 +34,7 @@ export default function DashboardLayout({
 }) {
   const { cookieConsent, setConsentStatus } = useCookieConsentStore();
   const [sheetHeight, setSheetHeight] = useState(400);
-  const { toggleSidebar } = useSidebarStore();
+  const { toggleSidebar, isDrawerOpen, openDrawer, closeDrawer } = useSidebarStore();
   const isMobile = useBreakpointValue({ base: true, md: false });
 
   useEffect(() => {
@@ -83,7 +83,7 @@ export default function DashboardLayout({
         h={`calc(100% - ${sheetHeight}px + 12px)`}
         transition="height 0.05s linear"
       >
-        <Drawer.Root placement="start">
+        <Drawer.Root placement="start" open={isDrawerOpen} onOpenChange={(details) => !details.open && closeDrawer()}>
           <Drawer.Trigger asChild>
             <IconButton
               variant="plain"
@@ -94,7 +94,7 @@ export default function DashboardLayout({
               rounded="sm"
               overflow="hidden"
               zIndex={100}
-              onClick={toggleSidebar}
+              onClick={openDrawer}
             >
               <ListIcon />
             </IconButton>
@@ -103,7 +103,7 @@ export default function DashboardLayout({
             <Drawer.Backdrop backdropFilter="blur(2px)" />
             <Drawer.Positioner>
               <Drawer.Content>
-                <Sidebar />
+                <Sidebar isMobile={isMobile} />
               </Drawer.Content>
             </Drawer.Positioner>
           </Portal>

--- a/app/store/sidebarStore.ts
+++ b/app/store/sidebarStore.ts
@@ -20,6 +20,7 @@ interface ThreadGroups {
 
 interface SidebarState {
   sideBarVisible: boolean;
+  isDrawerOpen: boolean;
   threads: ThreadEntry[];
   threadGroups: ThreadGroups;
   fetchThreads: () => Promise<void>;
@@ -32,6 +33,8 @@ interface SidebarState {
   toggleSidebar: () => void;
   fetchApiStatus: () => Promise<void>;
   apiStatus: "Idle" | "OK" | "Error";
+  openDrawer: () => void;
+  closeDrawer: () => void;
 }
 
 const computeThreadGroups = (data: ThreadEntry[]): ThreadGroups => {
@@ -66,9 +69,11 @@ const useSidebarStore = create<SidebarState>((set, get) => ({
     older: [],
   },
   apiStatus: "Idle",
+  isDrawerOpen: false,
   toggleSidebar: () =>
     set((state) => ({ sideBarVisible: !state.sideBarVisible })),
-
+  openDrawer: () => set({ isDrawerOpen: true }),
+  closeDrawer: () => set({ isDrawerOpen: false }),
   getThreadById: (threadId: string | null | undefined) => {
     const { threads } = get();
     return threads.find((thread) => thread.id === threadId);


### PR DESCRIPTION
Updates Sidebar to:
- [X] Close sidebar drawer on mobile when thread is clicked
- [X] Make whole thread item clickable (not just link)
- [ ] Add loading state for threads