### PR TITLE
Remove incorrect map tile size

### DIFF
--- a/app/components/Map.tsx
+++ b/app/components/Map.tsx
@@ -119,7 +119,6 @@ function Map({ disableMapAreaControls }: { disableMapAreaControls?: boolean }) {
           tiles={[
             `https://api.mapbox.com/styles/v1/devseed/cmazl5ws500bz01scaa27dqi4/tiles/{z}/{x}/{y}?access_token=${MAPBOX_ACCESS_TOKEN}`,
           ]}
-          tileSize={256}
         >
           <Layer id="background-tiles" type="raster" />
         </Source>


### PR DESCRIPTION
This PR Fixes the issue with small map labels by removing the incorrect declaration of `tileSize={256}` on the `<Source>` of the background tiles.

Mapbox styles should be tile size 512 by default: https://docs.mapbox.com/help/glossary/zoom-level/#tile-size
Maplibre defaults to a tile size of 512: https://maplibre.org/maplibre-style-spec/sources/#tilesize

| Before | After |
| -- | -- |
| <img width="890" alt="Screenshot 2025-09-17 at 10 38 40 AM" src="https://github.com/user-attachments/assets/6cc464a4-803a-4d0a-b0e3-348a46c167fe" /> | <img width="890" alt="Screenshot 2025-09-17 at 10 37 38 AM" src="https://github.com/user-attachments/assets/403bcb93-9a1f-4645-bb74-e56a9d06fceb" /> |

Contributes to #205 