### PR TITLE
Fix mobile layout flash

### DIFF
--- a/app/app/(chat)/layout.tsx
+++ b/app/app/(chat)/layout.tsx
@@ -6,6 +6,7 @@ import {
   Drawer,
   Portal,
   IconButton,
+  useBreakpoint,
   useBreakpointValue,
 } from "@chakra-ui/react";
 import { Suspense, useEffect, useState } from "react";
@@ -34,7 +35,9 @@ export default function DashboardLayout({
   const { cookieConsent, setConsentStatus } = useCookieConsentStore();
   const [sheetHeight, setSheetHeight] = useState(400);
   const { toggleSidebar } = useSidebarStore();
-  const isMobile = useBreakpointValue({ base: true, md: false },{ fallback: "md" });
+  const isMobile = useBreakpointValue({ base: true, md: false }, {ssr: false});
+  const breakpoint = useBreakpoint({ ssr: typeof window !== "undefined" ? false : undefined, })
+
 
   useEffect(() => {
     // As we can't read localStorage outside the useEffect, we update the

--- a/app/app/(chat)/layout.tsx
+++ b/app/app/(chat)/layout.tsx
@@ -6,7 +6,6 @@ import {
   Drawer,
   Portal,
   IconButton,
-  useBreakpoint,
   useBreakpointValue,
 } from "@chakra-ui/react";
 import { Suspense, useEffect, useState } from "react";
@@ -35,8 +34,9 @@ export default function DashboardLayout({
   const { cookieConsent, setConsentStatus } = useCookieConsentStore();
   const [sheetHeight, setSheetHeight] = useState(400);
   const { toggleSidebar } = useSidebarStore();
-  const isMobile = useBreakpointValue({ base: true, md: false }, {ssr: false});
-  const breakpoint = useBreakpoint({ ssr: typeof window !== "undefined" ? false : undefined, })
+  const isMobile = useBreakpointValue({ base: true, md: false });
+  const [mobileHeight, setMobileHeight] = useState("0")
+  const [desktopHeight, setDesktopHeight] = useState("0")
 
 
   useEffect(() => {
@@ -51,6 +51,12 @@ export default function DashboardLayout({
     }
   }, [cookieConsent, setConsentStatus]);
 
+  useEffect(() => {
+    // Set layout heights after mount to avoid flash of both layouts at once
+    setMobileHeight("min(100dvh, 100vh)")
+    setDesktopHeight("auto")
+  }, [])
+
   function DebugToastsMount() {
     const params = useSearchParams();
     const debugEnabled =
@@ -64,6 +70,7 @@ export default function DashboardLayout({
       templateColumns="auto min-content 1fr"
       templateAreas="'sidebar chat map'"
       templateRows="1fr"
+      h={{ base: 0, md: desktopHeight }}
       maxH="calc(100vh - 3rem)"
       display={{ base: "none", md: "grid" }}
     >
@@ -77,7 +84,7 @@ export default function DashboardLayout({
     <Box
       position="relative"
       w="100vw"
-      h={{ base: "min(100dvh, 100vh)", md: 0 }}
+      h={{ base: mobileHeight, md: 0 }}
       overflow="hidden"
       gridRow={{ base: 1, md: "none" }}
       display={{ base: "block", md: "none" }}

--- a/app/app/(chat)/layout.tsx
+++ b/app/app/(chat)/layout.tsx
@@ -34,7 +34,10 @@ export default function DashboardLayout({
   const { cookieConsent, setConsentStatus } = useCookieConsentStore();
   const [sheetHeight, setSheetHeight] = useState(400);
   const { toggleSidebar } = useSidebarStore();
-  const isMobile = useBreakpointValue({ base: true, md: false },{ ssr: typeof window !== "undefined" ? false : undefined, });
+  const isMobile = useBreakpointValue({ base: true, md: false });
+  const [mobileHeight, setMobileHeight] = useState("0")
+  const [desktopHeight, setDesktopHeight] = useState("0")
+
 
   useEffect(() => {
     // As we can't read localStorage outside the useEffect, we update the
@@ -47,6 +50,12 @@ export default function DashboardLayout({
       setConsentStatus(true);
     }
   }, [cookieConsent, setConsentStatus]);
+
+  useEffect(() => {
+    // Set layout heights after mount to avoid flash of both layouts at once
+    setMobileHeight("min(100dvh, 100vh)")
+    setDesktopHeight("auto")
+  }, [])
 
   function DebugToastsMount() {
     const params = useSearchParams();
@@ -61,7 +70,7 @@ export default function DashboardLayout({
       templateColumns="auto min-content 1fr"
       templateAreas="'sidebar chat map'"
       templateRows="1fr"
-      h={{ base: 0, md: "auto" }}
+      h={{ base: 0, md: desktopHeight }}
       maxH="calc(100vh - 3rem)"
       display={{ base: "none", md: "grid" }}
     >
@@ -75,7 +84,7 @@ export default function DashboardLayout({
     <Box
       position="relative"
       w="100vw"
-      h={{ base: "min(100dvh, 100vh)", md: 0 }}
+      h={{ base: mobileHeight, md: 0 }}
       overflow="hidden"
       gridRow={{ base: 1, md: "none" }}
       display={{ base: "block", md: "none" }}

--- a/app/app/(chat)/layout.tsx
+++ b/app/app/(chat)/layout.tsx
@@ -34,10 +34,7 @@ export default function DashboardLayout({
   const { cookieConsent, setConsentStatus } = useCookieConsentStore();
   const [sheetHeight, setSheetHeight] = useState(400);
   const { toggleSidebar } = useSidebarStore();
-  const isMobile = useBreakpointValue({ base: true, md: false });
-  const [mobileHeight, setMobileHeight] = useState("0")
-  const [desktopHeight, setDesktopHeight] = useState("0")
-
+  const isMobile = useBreakpointValue({ base: true, md: false },{ ssr: typeof window !== "undefined" ? false : undefined, });
 
   useEffect(() => {
     // As we can't read localStorage outside the useEffect, we update the
@@ -50,12 +47,6 @@ export default function DashboardLayout({
       setConsentStatus(true);
     }
   }, [cookieConsent, setConsentStatus]);
-
-  useEffect(() => {
-    // Set layout heights after mount to avoid flash of both layouts at once
-    setMobileHeight("min(100dvh, 100vh)")
-    setDesktopHeight("auto")
-  }, [])
 
   function DebugToastsMount() {
     const params = useSearchParams();
@@ -70,7 +61,7 @@ export default function DashboardLayout({
       templateColumns="auto min-content 1fr"
       templateAreas="'sidebar chat map'"
       templateRows="1fr"
-      h={{ base: 0, md: desktopHeight }}
+      h={{ base: 0, md: "auto" }}
       maxH="calc(100vh - 3rem)"
       display={{ base: "none", md: "grid" }}
     >
@@ -84,7 +75,7 @@ export default function DashboardLayout({
     <Box
       position="relative"
       w="100vw"
-      h={{ base: mobileHeight, md: 0 }}
+      h={{ base: "min(100dvh, 100vh)", md: 0 }}
       overflow="hidden"
       gridRow={{ base: 1, md: "none" }}
       display={{ base: "block", md: "none" }}

--- a/app/app/(chat)/layout.tsx
+++ b/app/app/(chat)/layout.tsx
@@ -74,9 +74,9 @@ export default function DashboardLayout({
     <Box
       position="relative"
       w="100vw"
-      h="min(100dvh, 100vh)"
+      h={{ base: "min(100dvh, 100vh)", md: 0 }}
       overflow="hidden"
-      gridRow={1}
+      gridRow={{ base: 1, md: "none" }}
       display={{ base: "block", md: "none" }}
     >
       <Box

--- a/app/app/(chat)/layout.tsx
+++ b/app/app/(chat)/layout.tsx
@@ -34,7 +34,7 @@ export default function DashboardLayout({
   const { cookieConsent, setConsentStatus } = useCookieConsentStore();
   const [sheetHeight, setSheetHeight] = useState(400);
   const { toggleSidebar } = useSidebarStore();
-  const isMobile = useBreakpointValue({ base: true, md: false });
+  const isMobile = useBreakpointValue({ base: true, md: false },{ fallback: "md" });
 
   useEffect(() => {
     // As we can't read localStorage outside the useEffect, we update the


### PR DESCRIPTION
CSS Hotfix for flash of extra space in layout coming from mobile layout render.

### Current challenge:

https://github.com/user-attachments/assets/cbe0dae5-b393-4315-a951-3009947c5e04

### Why this is happening:
Both the mobile and desktop layouts are rendered by default on the server with SSR. The Chakra `useBreakpointValue` hook can't fire until the page is initially rendered on the client, and so both components are loading and taking up space. This PR attempts to set a 0 height on both the layout wrappers, and then set the correct heights on load.