### PR TITLE
Add link back to app from dashboard settings page

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -24,6 +24,7 @@ import {
   FloppyDiskIcon,
   GearIcon,
   LifebuoyIcon,
+  MapTrifoldIcon,
   SignOutIcon,
   UserIcon,
 } from "@phosphor-icons/react";
@@ -303,6 +304,12 @@ export default function UserSettingsPage() {
             <Link href="https://help.globalnaturewatch.org/" target="_blank">
               <LifebuoyIcon />
               Help
+            </Link>
+          </Button>
+          <Button asChild>
+            <Link href="/app">
+              <MapTrifoldIcon />
+              Back to Application
             </Link>
           </Button>
         </ButtonGroup>


### PR DESCRIPTION
To review: button text and link placement

<img width="1558" height="1035" alt="image" src="https://github.com/user-attachments/assets/83a6dd96-b056-4d05-8267-5f98a94b9f16" />
