### PR TITLE
Share Threads

### DIFF
--- a/app/ChatPanelHeader.tsx
+++ b/app/ChatPanelHeader.tsx
@@ -115,9 +115,9 @@ function ChatPanelHeader() {
           </IconButton>
         </Tooltip>
       )}
-      {currentThreadId ? (
+      {currentThreadId && currentThread ? (
         <ThreadActionsMenu
-          thread={{ id: currentThreadId, name: currentThreadName }}
+          thread={currentThread}
         >
           <Button
             variant="ghost"

--- a/app/components/ChatDisclaimer.tsx
+++ b/app/components/ChatDisclaimer.tsx
@@ -1,4 +1,4 @@
-import { Box, CloseButton } from "@chakra-ui/react";
+import { Box, CloseButton, type BoxProps } from "@chakra-ui/react";
 import {
   CheckCircleIcon,
   InfoIcon,
@@ -6,8 +6,8 @@ import {
   WarningIcon,
 } from "@phosphor-icons/react";
 
-interface ChatDisclaimerProps {
-  setDisplayDisclaimer: React.Dispatch<React.SetStateAction<boolean>>;
+interface ChatDisclaimerProps extends BoxProps {
+  setDisplayDisclaimer?: React.Dispatch<React.SetStateAction<boolean>>;
   type?: "info" | "error" | "warning" | "success";
   children: React.ReactNode;
 }
@@ -29,7 +29,8 @@ const TypeIcon = {
 export default function ChatDisclaimer({
   setDisplayDisclaimer,
   type = "info",
-  children
+  children,
+  ...boxProps
 }: ChatDisclaimerProps) {
   const IconComponent = TypeIcon[type];
 
@@ -45,6 +46,7 @@ export default function ChatDisclaimer({
       gap={2}
       my={4}
       mb={6}
+      {...boxProps}
     >
       <IconComponent
         weight="fill"
@@ -53,13 +55,15 @@ export default function ChatDisclaimer({
         fill={`var(--chakra-colors-${typeColorMap[type]}-600)`}
       />
       {children}
-      <CloseButton
-        size="2xs"
-        variant="ghost"
-        colorPalette={typeColorMap[type]}
-        title="Hide disclaimer"
-        onClick={() => setDisplayDisclaimer((prev) => !prev)}
-      />
+      {setDisplayDisclaimer && (
+        <CloseButton
+          size="2xs"
+          variant="ghost"
+          colorPalette={typeColorMap[type]}
+          title="Hide disclaimer"
+          onClick={() => setDisplayDisclaimer((prev) => !prev)}
+        />
+      )}
     </Box>
   );
 }

--- a/app/components/ChatDisclaimer.tsx
+++ b/app/components/ChatDisclaimer.tsx
@@ -54,7 +54,7 @@ export default function ChatDisclaimer({
         size="16"
         fill={`var(--chakra-colors-${typeColorMap[type]}-600)`}
       />
-      {children}
+      <Box>{children}</Box>
       {setDisplayDisclaimer && (
         <CloseButton
           size="2xs"

--- a/app/components/ThreadActionsMenu.tsx
+++ b/app/components/ThreadActionsMenu.tsx
@@ -7,23 +7,26 @@ import {
   DotsThreeIcon,
   PencilSimpleIcon,
   TrashIcon,
+  ShareIcon,
 } from "@phosphor-icons/react";
 import ThreadDeleteDialog from "./ThreadDeleteDialog";
 import ThreadRenameDialog from "./ThreadRenameDialog";
+import ThreadShareDialog from "./ThreadShareDialog";
 import { sendGAEvent } from "@next/third-parties/google";
 
 function ThreadActionsMenu({
   thread,
   children,
 }: {
-  thread: { id: string; name: string };
+  thread: { id: string; name: string, is_public?: boolean };
   children?: React.ReactNode;
 }) {
   const router = useRouter();
-  const { renameThread, deleteThread } = useSidebarStore();
+  const { renameThread, shareThread, deleteThread } = useSidebarStore();
   const { currentThreadId } = useChatStore();
 
   const [renameOpen, setRenameOpen] = useState(false);
+  const [shareOpen, setShareOpen] = useState(false);
   const [deleteOpen, setDeleteOpen] = useState(false);
 
   const onRename = useCallback(
@@ -38,6 +41,12 @@ function ThreadActionsMenu({
     },
     [thread.id, thread.name, renameThread]
   );
+
+  const onShare = useCallback(
+    async (is_public: boolean) => {
+      await shareThread(thread.id, is_public);
+    }, [thread.id, shareThread]
+  )
 
   const onDelete = useCallback(async () => {
     sendGAEvent("event", "thread_deleted", { 
@@ -87,6 +96,14 @@ function ThreadActionsMenu({
                 Rename
               </Menu.Item>
               <Menu.Item
+                value="share conversation"
+                color="fg.muted"
+                onSelect={() => setShareOpen(true)}
+              >
+                <ShareIcon />
+                Share
+              </Menu.Item>
+              <Menu.Item
                 value="delete"
                 color="fg.error"
                 _hover={{ bg: "bg.error", color: "fg.error" }}
@@ -104,6 +121,13 @@ function ThreadActionsMenu({
         isOpen={renameOpen}
         onOpenChange={setRenameOpen}
         onRename={onRename}
+      />
+      <ThreadShareDialog
+        isPublic={thread.is_public}
+        isOpen={shareOpen}
+        onOpenChange={setShareOpen}
+        onShare={onShare}
+        threadId={thread.id}
       />
       <ThreadDeleteDialog
         threadName={thread.name}

--- a/app/components/ThreadActionsMenu.tsx
+++ b/app/components/ThreadActionsMenu.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback } from "react";
-import { Menu, Portal, IconButton } from "@chakra-ui/react";
+import { Menu, IconButton } from "@chakra-ui/react";
 import { useRouter } from "next/navigation";
 import useSidebarStore from "../store/sidebarStore";
 import useChatStore from "../store/chatStore";
@@ -65,7 +65,7 @@ function ThreadActionsMenu({
 
   return (
     <>
-      <Menu.Root>
+      <Menu.Root positioning={{ strategy: "fixed", hideWhenDetached: true }}>
         <Menu.Trigger asChild>
           {children || (
             <IconButton
@@ -84,7 +84,6 @@ function ThreadActionsMenu({
             </IconButton>
           )}
         </Menu.Trigger>
-        <Portal>
           <Menu.Positioner>
             <Menu.Content>
               <Menu.Item
@@ -114,7 +113,6 @@ function ThreadActionsMenu({
               </Menu.Item>
             </Menu.Content>
           </Menu.Positioner>
-        </Portal>
       </Menu.Root>
       <ThreadRenameDialog
         name={thread.name}

--- a/app/components/ThreadShareDialog.tsx
+++ b/app/components/ThreadShareDialog.tsx
@@ -115,8 +115,7 @@ function ThreadShareDialog(props: ThreadShareDialogProps) {
                 Sharing creates a public, view-only link to this conversation.
                 Make sure it contains no personal or sensitive information.
                 You can switch Visibility back to private later.
-                <br />
-                Learn more in our{' '}
+                For more information, read our{' '}
                 <Link
                   textDecoration="underline"
                   textDecorationStyle="dotted"

--- a/app/components/ThreadShareDialog.tsx
+++ b/app/components/ThreadShareDialog.tsx
@@ -20,6 +20,7 @@ import {
   CopyIcon,
   CheckIcon,
 } from "@phosphor-icons/react";
+import { sendGAEvent } from "@next/third-parties/google";
 import ChatDisclaimer from "./ChatDisclaimer";
 
 interface ThreadShareDialogProps {
@@ -184,6 +185,9 @@ function ThreadShareDialog(props: ThreadShareDialogProps) {
                   colorPalette="primary"
                   onClick={() => {
                     clipboard.copy();
+                    sendGAEvent("event", "share_link_copied", {
+                      share_url: shareUrl,
+                    });
                   }}
                 >
                   {clipboard.copied ? <CheckIcon /> : <CopyIcon />}

--- a/app/components/ThreadShareDialog.tsx
+++ b/app/components/ThreadShareDialog.tsx
@@ -112,7 +112,11 @@ function ThreadShareDialog(props: ThreadShareDialogProps) {
             </Dialog.Header>
             <Dialog.Body pb="4" display="flex" flexDir="column" gap="4">
               <ChatDisclaimer m={0}>
-                Lorem ipsum dolor this is legal copy. Read our
+                Sharing creates a public, view-only link to this conversation.
+                Make sure it contains no personal or sensitive information.
+                You can switch Visibility back to private later.
+                <br />
+                Learn more in our{' '}
                 <Link
                   textDecoration="underline"
                   textDecorationStyle="dotted"
@@ -122,7 +126,7 @@ function ThreadShareDialog(props: ThreadShareDialogProps) {
                   href="https://www.wri.org/about/legal/general-terms-use"
                 >
                   Terms of use
-                </Link>
+                </Link>.
               </ChatDisclaimer>
               <Field.Root id="visibility" w="full">
                 <Select.Root

--- a/app/components/ThreadShareDialog.tsx
+++ b/app/components/ThreadShareDialog.tsx
@@ -1,0 +1,205 @@
+import { useRef, useCallback, useState, useEffect } from "react";
+import {
+  Dialog,
+  useClipboard,
+  Portal,
+  Button,
+  CloseButton,
+  Input,
+  HStack,
+  Select,
+  createListCollection,
+  Field,
+  Link,
+} from "@chakra-ui/react";
+import { toaster } from "@/app/components/ui/toaster";
+import {
+  GlobeIcon,
+  LinkIcon,
+  LockIcon,
+  CopyIcon,
+  CheckIcon,
+} from "@phosphor-icons/react";
+import ChatDisclaimer from "./ChatDisclaimer";
+
+interface ThreadShareDialogProps {
+  threadId: string;
+  isPublic?: boolean;
+  onShare: (isPublic: boolean) => void;
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+type ValueChangeDetails = { value: string[] };
+
+function ThreadShareDialog(props: ThreadShareDialogProps) {
+  const { threadId, isPublic, onShare, isOpen, onOpenChange } = props;
+  const shareUrl =
+    typeof window !== "undefined"
+      ? `${window.location.origin}/app/threads/${threadId}`
+      : threadId;
+  const clipboard = useClipboard({ value: shareUrl });
+  const ref = useRef<HTMLInputElement>(null);
+  const [threadIsPublic, setThreadIsPublic] = useState<boolean>(false);
+
+  useEffect(() => {
+    if (isOpen && isPublic !== undefined) {
+      setThreadIsPublic(isPublic);
+    }
+  }, [isPublic, isOpen]);
+
+  const updateVisibility = useCallback(
+    async (newIsPublic: boolean) => {
+      try {
+        setThreadIsPublic(newIsPublic);
+        await onShare(newIsPublic);
+        toaster.create({
+          title: "Visibility updated",
+          description: `Thread ${threadId} is now ${
+            newIsPublic ? "public" : "private"
+          }`,
+          type: "success",
+          duration: 3000,
+        });
+      } catch (error) {
+        // Revert the local state on error
+        setThreadIsPublic(!newIsPublic);
+        toaster.create({
+          title: "Visibility update failed",
+          description: `Failed to make thread ${threadId} ${
+            newIsPublic ? "public" : "private"
+          }. Please try again.`,
+          type: "error",
+          duration: 4000,
+        });
+        console.error("Failed to update thread visibility:", error);
+      }
+    },
+    [onShare, threadId]
+  );
+
+  const shareOptions = createListCollection({
+    items: [
+      {
+        label: "Private (only you can access)",
+        icon: <LockIcon />,
+        value: "false",
+      },
+      {
+        label: "Public (anyone can access)",
+        icon: <GlobeIcon />,
+        value: "true",
+      },
+    ],
+  });
+
+  return (
+    <Dialog.Root
+      initialFocusEl={() => ref.current}
+      placement="center"
+      open={isOpen}
+      onOpenChange={({ open }) => onOpenChange(open)}
+    >
+      <Portal>
+        <Dialog.Backdrop />
+        <Dialog.Positioner>
+          <Dialog.Content>
+            <Dialog.CloseTrigger asChild>
+              <CloseButton size="sm" />
+            </Dialog.CloseTrigger>
+            <Dialog.Header>
+              <Dialog.Title>Share Conversation</Dialog.Title>
+            </Dialog.Header>
+            <Dialog.Body pb="4" display="flex" flexDir="column" gap="4">
+              <ChatDisclaimer m={0}>
+                Lorem ipsum dolor this is legal copy. Read our
+                <Link
+                  textDecoration="underline"
+                  textDecorationStyle="dotted"
+                  rel="noreferrer"
+                  color="primary.solid"
+                  target="_blank"
+                  href="https://www.wri.org/about/legal/general-terms-use"
+                >
+                  Terms of use
+                </Link>
+              </ChatDisclaimer>
+              <Field.Root id="visibility" w="full">
+                <Select.Root
+                  collection={shareOptions}
+                  ref={ref}
+                  size="sm"
+                  width="full"
+                  value={[threadIsPublic.toString()]}
+                  positioning={{ strategy: "fixed", hideWhenDetached: true }}
+                  onValueChange={(details: ValueChangeDetails) => {
+                    if (details.value.length > 0) {
+                      const newValue = details.value[0] === "true";
+                      updateVisibility(newValue);
+                    }
+                  }}
+                >
+                  <Select.HiddenSelect />
+                  <Select.Label>Visibility</Select.Label>
+                  <Select.Control>
+                    <Select.Trigger>
+                      <HStack>
+                        {threadIsPublic ? <GlobeIcon /> : <LockIcon />}
+                        {threadIsPublic
+                          ? "Public (anyone can access)"
+                          : "Private (only you can access)"}
+                      </HStack>
+                    </Select.Trigger>
+                    <Select.IndicatorGroup>
+                      <Select.Indicator />
+                    </Select.IndicatorGroup>
+                  </Select.Control>
+
+                  <Select.Positioner w="var(--reference-width)">
+                    <Select.Content>
+                      {shareOptions.items.map((option) => (
+                        <Select.Item item={option} key={option.label}>
+                          <HStack>
+                            {option.icon}
+                            {option.label}
+                          </HStack>
+                          <Select.ItemIndicator />
+                        </Select.Item>
+                      ))}
+                    </Select.Content>
+                  </Select.Positioner>
+                </Select.Root>
+              </Field.Root>
+              {threadIsPublic && <Input value={shareUrl} w="full" readOnly />}
+            </Dialog.Body>
+            <Dialog.Footer>
+              <Dialog.ActionTrigger asChild>
+                <Button variant="outline">Cancel</Button>
+              </Dialog.ActionTrigger>
+              {threadIsPublic ? (
+                <Button
+                  colorPalette="primary"
+                  onClick={() => {
+                    clipboard.copy();
+                  }}
+                >
+                  {clipboard.copied ? <CheckIcon /> : <CopyIcon />}
+                  {clipboard.copied ? "Link Copied" : "Copy share link"}
+                </Button>
+              ) : (
+                <Button
+                  colorPalette="primary"
+                  onClick={() => updateVisibility(true)}
+                >
+                  <LinkIcon />
+                  Create share link
+                </Button>
+              )}
+            </Dialog.Footer>
+          </Dialog.Content>
+        </Dialog.Positioner>
+      </Portal>
+    </Dialog.Root>
+  );
+}
+export default ThreadShareDialog;

--- a/app/components/ThreadShareDialog.tsx
+++ b/app/components/ThreadShareDialog.tsx
@@ -34,10 +34,10 @@ type ValueChangeDetails = { value: string[] };
 
 function ThreadShareDialog(props: ThreadShareDialogProps) {
   const { threadId, isPublic, onShare, isOpen, onOpenChange } = props;
-  const shareUrl =
-    typeof window !== "undefined"
-      ? `${window.location.origin}/app/threads/${threadId}`
-      : threadId;
+  const baseUrl =
+    process.env.NEXT_PUBLIC_SITE_URL ||
+    (typeof window !== "undefined" ? window.location.origin : "");
+  const shareUrl = `${baseUrl}/app/threads/${threadId}`;
   const clipboard = useClipboard({ value: shareUrl });
   const ref = useRef<HTMLInputElement>(null);
   const [threadIsPublic, setThreadIsPublic] = useState<boolean>(false);

--- a/app/store/sidebarStore.ts
+++ b/app/store/sidebarStore.ts
@@ -24,6 +24,7 @@ interface SidebarState {
   threadGroups: ThreadGroups;
   fetchThreads: () => Promise<void>;
   renameThread: (threadId: string, newName: string) => Promise<void>;
+  shareThread: (threadId: string, isPublic: boolean) => Promise<void>;
   deleteThread: (threadId: string) => Promise<void>;
   getThreadById: (
     threadId: string | null | undefined
@@ -114,6 +115,28 @@ const useSidebarStore = create<SidebarState>((set, get) => ({
       });
     } else {
       throw new Error("Failed to rename thread");
+    }
+  },
+
+   shareThread: async (threadId: string, isPublic: boolean) => {
+    const response = await fetch(`/api/threads/${threadId}`, {
+      method: "PATCH",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ is_public: isPublic }),
+    });
+
+    if (response.ok) {
+      // Update the thread in the store
+      set((state) => {
+        const threads = state.threads.map((thread) =>
+          thread.id === threadId ? { ...thread, is_public: isPublic } : thread
+        );
+        return { threads, threadGroups: computeThreadGroups(threads) };
+      });
+    } else {
+      throw new Error("Failed to share thread");
     }
   },
 


### PR DESCRIPTION
Allow users to share threads.

Creates a "Share Thread" dialog accessible from the thread actions menu found in both the sidebar thread options and the Chat Panel Header.

https://github.com/user-attachments/assets/353da5e6-a610-4488-b270-23407667f280

@01painadam the "This is legal copy" text in the dialog needs a review. We may also want to add text noting that users do need to be registered and signed in to see threads, at least for the closed/limited beta.

Closes #78 