### PR TITLE
Initial prompt disclaimer box

### DIFF
--- a/app/components/ChatMessages.tsx
+++ b/app/components/ChatMessages.tsx
@@ -1,16 +1,18 @@
 "use client";
-import { Fragment, useEffect, useRef } from "react";
-import { Box } from "@chakra-ui/react";
+import { Fragment, useState, useEffect, useRef } from "react";
+import { Box, Text, Link } from "@chakra-ui/react";
 import useChatStore from "@/app/store/chatStore";
 import MessageBubble from "./MessageBubble";
 import Reasoning from "./Reasoning";
 import SamplePrompts from "./SamplePrompts";
+import ChatDisclaimer from "./ChatDisclaimer";
 
 const LANDING_PAGE_VERSION = process.env.NEXT_PUBLIC_LANDING_PAGE_VERSION;
 
 function ChatMessages() {
   const containerRef = useRef<HTMLDivElement>(null);
   const { messages, isLoading } = useChatStore();
+  const [displayDisclaimer, setDisplayDisclaimer] = useState(true);
 
   // Auto-scroll to bottom when new messages are added or loading state changes
   useEffect(() => {
@@ -53,6 +55,40 @@ function ChatMessages() {
         const isFirst = index === 0;
         return (
           <Fragment key={message.id}>
+                        {displayDisclaimer && (
+              <ChatDisclaimer
+                type="info"
+                setDisplayDisclaimer={setDisplayDisclaimer}
+              >
+                <Text>
+                This is an <strong>experimental beta</strong> of Global Nature Watch.
+                <br />
+                AI makes mistakes. Verify outputs with primary sources.
+                While in beta, assistant behavior, application features and available datasets may change or be removed.
+                <br />
+                To learn more about how to use the app, check out the{" "}
+                <Link
+                    color="primary.solid"
+                    textDecor="underline"
+                    href="https://help.globalnaturewatch.org/get-started"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    Help Center
+                  </Link>{"."}
+                <br />
+                Your input helps shape the future of Global Nature Watch.
+                Please send your feedback to{" "}
+                  <Link
+                    color="primary.solid"
+                    textDecor="underline"
+                    href="mailto:landcarbonlab@wri.org"
+                  >
+                    landcarbonlab@wri.org
+                  </Link>{"."}
+                </Text>
+              </ChatDisclaimer>
+            )}
             <MessageBubble
               message={message}
               isConsecutive={isConsecutive}

--- a/app/components/ChatMessages.tsx
+++ b/app/components/ChatMessages.tsx
@@ -55,7 +55,7 @@ function ChatMessages() {
         const isFirst = index === 0;
         return (
           <Fragment key={message.id}>
-                        {displayDisclaimer && (
+                        {isFirst && displayDisclaimer && (
               <ChatDisclaimer
                 type="info"
                 setDisplayDisclaimer={setDisplayDisclaimer}

--- a/app/components/ChatMessages.tsx
+++ b/app/components/ChatMessages.tsx
@@ -61,25 +61,32 @@ function ChatMessages() {
                 setDisplayDisclaimer={setDisplayDisclaimer}
               >
                 <Text>
-                This is an <strong>experimental beta</strong> of Global Nature Watch.
+                <strong>Beta notice</strong>
                 <br />
-                AI makes mistakes. Verify outputs with primary sources.
-                While in beta, assistant behavior, application features and available datasets may change or be removed.
-                <br />
-                To learn more about how to use the app, check out the{" "}
+                This version of Global Nature Watch is still being tested. Expect mistakes and verify results with primary sources.
+                Assistant behavior, features and datasets may change or be removed while in beta.
+                Visit the{" "}
                 <Link
                     color="primary.solid"
                     textDecor="underline"
-                    href="https://help.globalnaturewatch.org/get-started"
+                    href="https://help.globalnaturewatch.org/"
                     target="_blank"
                     rel="noopener noreferrer"
                   >
                     Help Center
-                  </Link>{"."}
+                  </Link>{" "}
+                  to learn more.
                 <br />
-                Your input helps shape the future of Global Nature Watch.
-                Please send your feedback to{" "}
+                  Your feedback is critical to improving Global Nature Watch. Complete{" "}
                   <Link
+                    color="primary.solid"
+                    textDecor="underline"
+                    href="https://surveys.hotjar.com/860def81-d4f2-4f8c-abee-339ebc3129f3"
+                  >
+                    this survey
+                  </Link>{" "}
+                   or us at{" "} 
+                   <Link
                     color="primary.solid"
                     textDecor="underline"
                     href="mailto:landcarbonlab@wri.org"

--- a/app/components/ChatMessages.tsx
+++ b/app/components/ChatMessages.tsx
@@ -85,7 +85,7 @@ function ChatMessages() {
                   >
                     this survey
                   </Link>{" "}
-                   or us at{" "} 
+                   or email us at{" "} 
                    <Link
                     color="primary.solid"
                     textDecor="underline"

--- a/app/store/chatStore.ts
+++ b/app/store/chatStore.ts
@@ -61,7 +61,7 @@ const initialState: ChatState = {
       &nbsp;
       Hi, I'm your nature monitoring assistant, powered by AI and open data from [Global Forest Watch](https://globalforestwatch.org) and [Land and Carbon Lab](https://landcarbonlab.org).
       &nbsp;
-      You can ask me about land cover change, forest loss, or biodiversity risks in places you care about. For more details on how to get started, check out the [Help Centre](https://help.globalnaturewatch.org/get-started).`,
+      You can ask me about land cover change, forest loss, or biodiversity risks in places you care about. For more details on how to get started, check out the [Help Center](https://help.globalnaturewatch.org/get-started).`,
       timestamp: new Date().toISOString(),
     },
   ],

--- a/app/store/chatStore.ts
+++ b/app/store/chatStore.ts
@@ -59,7 +59,7 @@ const initialState: ChatState = {
       message:
       `**Welcome to Global Nature Watch!**
       &nbsp;
-      Hi, I'm your nature monitoring assistant, powered by AI and open data from [Global Forest Watch](https://globalforestwatch.org) and [Land and Carbon Lab](https://landcarbonlab.org).
+      Hi, I'm your nature monitoring assistant, powered by AI and open data from [Global Forest Watch](https://globalforestwatch.org) and [Land & Carbon Lab](https://landcarbonlab.org).
       &nbsp;
       You can ask me about land cover change, forest loss, or biodiversity risks in places you care about. For more details on how to get started, check out the [Help Center](https://help.globalnaturewatch.org/get-started).`,
       timestamp: new Date().toISOString(),


### PR DESCRIPTION
Now we have more certainty over the rollout, re-implementing @LanesGood's disclaimer box on the initial message. 

<img width="611" height="245" alt="Screenshot 2025-10-29 at 5 38 23 PM" src="https://github.com/user-attachments/assets/198561f9-4ed5-465b-9eb2-1580a3dda259" />