### PR TITLE
Add basemap tile url switchers

### DIFF
--- a/app/components/Map.tsx
+++ b/app/components/Map.tsx
@@ -17,7 +17,7 @@ import {
   useBreakpointValue,
   Flex,
   Link as ChLink,
-  Spinner
+  Spinner,
 } from "@chakra-ui/react";
 import { ListDashesIcon, PlusIcon, XIcon } from "@phosphor-icons/react";
 import useMapStore from "@/app/store/mapStore";
@@ -36,6 +36,9 @@ function Map({ disableMapAreaControls }: { disableMapAreaControls?: boolean }) {
   const [mapCenter, setMapCenter] = useState([0, 0]);
   const [showLegend, setShowLegend] = useState(false);
   const isMobile = useBreakpointValue({ base: true, md: false });
+  const [basemapTiles, setBasemapTiles] = useState(
+    "devseed/cmazl5ws500bz01scaa27dqi4"
+  );
   const { geoJsonFeatures, setMapRef, initializeTerraDraw } = useMapStore();
   const { layers, handleLayerAction } = useLegendHook();
   const { context } = useContextStore();
@@ -123,7 +126,7 @@ function Map({ disableMapAreaControls }: { disableMapAreaControls?: boolean }) {
           id="background"
           type="raster"
           tiles={[
-            `https://api.mapbox.com/styles/v1/devseed/cmazl5ws500bz01scaa27dqi4/tiles/{z}/{x}/{y}?access_token=${MAPBOX_ACCESS_TOKEN}`,
+            `https://api.mapbox.com/styles/v1/${basemapTiles}/tiles/{z}/{x}/{y}?access_token=${MAPBOX_ACCESS_TOKEN}`,
           ]}
         >
           <Layer id="background-tiles" type="raster" />
@@ -166,7 +169,12 @@ function Map({ disableMapAreaControls }: { disableMapAreaControls?: boolean }) {
         />
         <SelectAreaLayer />
 
-        {!disableMapAreaControls && <MapAreaControls />}
+        {!disableMapAreaControls && (
+          <MapAreaControls
+            basemapTiles={basemapTiles}
+            setBasemapTiles={setBasemapTiles}
+          />
+        )}
 
         <AbsoluteCenter fontSize="sm" opacity={0.375} hideBelow="md">
           <PlusIcon />

--- a/app/components/MapAreaControls.tsx
+++ b/app/components/MapAreaControls.tsx
@@ -27,6 +27,7 @@ import { MAX_AREA_KM2, MIN_AREA_KM2 } from "../constants/custom-areas";
 import { formatAreaWithUnits } from "../utils/formatArea";
 import { useCustomAreasCreate } from "../hooks/useCustomAreasCreate";
 import useContextStore from "../store/contextStore";
+import { BasemapSelector } from "./map/BasemapSelector";
 
 function Wrapper({
   children,
@@ -55,7 +56,14 @@ function Wrapper({
   );
 }
 
-function MapAreaControls() {
+interface MapAreaControlsProps {
+  basemapTiles: string;
+  setBasemapTiles: (tileUrl: string) => void;
+}
+function MapAreaControls({
+  basemapTiles,
+  setBasemapTiles,
+}: MapAreaControlsProps) {
   const {
     setSelectAreaLayer,
     isDrawingMode,
@@ -158,6 +166,11 @@ function MapAreaControls() {
           {!showTools ? <MapTrifoldIcon /> : <XIcon />}
           Tools
         </Button>
+        <BasemapSelector
+          currentBasemap={basemapTiles}
+          onBasemapChange={setBasemapTiles}
+          display={{ base: showTools ? "inherit" : "none", md: "inherit" }}
+        />
         <ButtonGroup
           size="sm"
           variant="subtle"

--- a/app/components/map/BasemapSelector.tsx
+++ b/app/components/map/BasemapSelector.tsx
@@ -1,0 +1,159 @@
+"use client";
+import {
+  Popover,
+  Image,
+  VStack,
+  IconButton,
+  Flex,
+  Heading,
+} from "@chakra-ui/react";
+import { CheckIcon, MapTrifoldIcon } from "@phosphor-icons/react";
+
+export interface BasemapOption {
+  id: string;
+  name: string;
+  tileUrl: string;
+  thumbnailUrl: string;
+}
+
+const basemapOptions: BasemapOption[] = [
+  {
+    id: "light",
+    name: "Light",
+    tileUrl: "devseed/cmazl5ws500bz01scaa27dqi4",
+    thumbnailUrl:
+      "https://api.mapbox.com/styles/v1/devseed/cmazl5ws500bz01scaa27dqi4/static/0,0,0,0,0/200x200@2x?access_token=" +
+      process.env.NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN,
+  },
+  {
+    id: "satellite",
+    name: "Satellite",
+    tileUrl: "mapbox/satellite-v9",
+    thumbnailUrl:
+      "https://api.mapbox.com/styles/v1/mapbox/satellite-v9/static/0,0,0,0,0/200x200@2x?access_token=" +
+      process.env.NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN,
+  },
+  {
+    id: "dark",
+    name: "Dark",
+    tileUrl: "devseed/cm7nk8rlu01bm01qvb6pues5y",
+    thumbnailUrl:
+      "https://api.mapbox.com/styles/v1/devseed/cm7nk8rlu01bm01qvb6pues5y/static/0,0,0,0,0/200x200@2x?access_token=" +
+      process.env.NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN,
+  },
+];
+
+interface BasemapSelectorProps {
+  display: Record<string, string> | string;
+  currentBasemap: string;
+  onBasemapChange: (tileUrl: string) => void;
+}
+
+export function BasemapSelector({
+  display,
+  currentBasemap,
+  onBasemapChange,
+}: BasemapSelectorProps) {
+  const currentOption =
+    basemapOptions.find((option) => option.tileUrl === currentBasemap) ||
+    basemapOptions[0];
+
+  return (
+    <Popover.Root positioning={{ placement: "top-start", strategy: "fixed" }}>
+      <Popover.Trigger asChild>
+        <IconButton
+          display={display}
+          variant="subtle"
+          size="lg"
+          bg={currentOption ? `url(${currentOption.thumbnailUrl})` : "bg"}
+          bgSize="cover"
+          position="absolute"
+          pointerEvents="all"
+          bottom={{ base: "4.25rem", md: "calc(7rem - 2px)" }}
+          left={{ base: 3.5, md: "calc(0.5rem - 2px)" }}
+          zIndex={510}
+          boxShadow="md"
+          border="1px solid"
+          borderColor={
+            currentOption.id === "light" ? "border" : "border.inverted"
+          }
+          animation={{
+            base: "0.16s ease-out 1 forwards slide-from-bottom-full, 0.24s ease-out 1 forwards fade-in",
+            md: "none",
+          }}
+        >
+          <MapTrifoldIcon
+            fill={
+              currentOption.id === "light"
+                ? "var(--chakra-colors-fg-muted)"
+                : "var(--chakra-colors-fg-inverted)"
+            }
+          />
+        </IconButton>
+      </Popover.Trigger>
+      <Popover.Positioner>
+        <Popover.Content maxW="12rem">
+          <Popover.Body p={3}>
+            <VStack gap={2} align="stretch">
+              <Heading
+                size="xs"
+                fontWeight="medium"
+                textTransform="uppercase"
+                letterSpacing="wide"
+                as="p"
+                color="fg.muted"
+              >
+                Basemap Style
+              </Heading>
+              {basemapOptions.map((option) => (
+                <Flex
+                  key={option.id}
+                  gap={2}
+                  cursor="pointer"
+                  alignItems="center"
+                  onClick={() => onBasemapChange(option.tileUrl)}
+                  overflow="hidden"
+                  _hover={{ color: "primary.solid" }}
+                  transition="border-color 0.2s"
+                >
+                  <Image
+                    src={option.thumbnailUrl}
+                    alt={option.name}
+                    width="40px"
+                    height="40px"
+                    objectFit="cover"
+                    overflow="hidden"
+                    borderRadius="md"
+                    border="2px solid"
+                    borderColor={
+                      option.tileUrl === currentBasemap
+                        ? "primary.solid"
+                        : "border"
+                    }
+                  />
+                  <Heading
+                    size="sm"
+                    mr="auto"
+                    as="p"
+                    my={0}
+                    color={
+                      option.tileUrl === currentBasemap ? "primary.solid" : "fg"
+                    }
+                  >
+                    {option.name}
+                  </Heading>
+                  {option.tileUrl === currentBasemap && (
+                    <CheckIcon
+                      fill="var(--chakra-colors-primary-solid)"
+                      weight="bold"
+                    />
+                  )}
+                </Flex>
+              ))}
+            </VStack>
+          </Popover.Body>
+        </Popover.Content>
+      </Popover.Positioner>
+    </Popover.Root>
+  );
+}


### PR DESCRIPTION
Adds basemap switcher. This was part of the original designs and I've prototyped here as a test. The "Satellite" basemap layer is Mapbox's standard satellite layer without labels, [mapbox-satellite-v9](https://api.mapbox.com/styles/v1/mapbox/satellite-v9.html?title=true&access_token=pk.eyJ1IjoiZXhhbXBsZXMiLCJhIjoiY2xxeTBib3pyMGsxcTJpbXQ3bmo4YXU0ZiJ9.wvqlBMQSxTHgvAh6l9OXXw#8.19/40.573/-74.274). The "Dark" basemap is the one we created for phase 1 of the project.

https://github.com/user-attachments/assets/22d12493-2aba-4f19-a891-a1a88d130811


