### PR TITLE
use osano for cookie consent

### DIFF
--- a/app/app/(chat)/layout.tsx
+++ b/app/app/(chat)/layout.tsx
@@ -20,29 +20,17 @@ import { useSearchParams } from "next/navigation";
 import DraggableBottomSheet from "@/app/components/BottomSheet";
 import { ListIcon } from "@phosphor-icons/react";
 import useSidebarStore from "@/app/store/sidebarStore";
-import useCookieConsentStore from "@/app/store/cookieConsentStore";
-
-const GA_ID = process.env.NEXT_PUBLIC_GOOGLE_ANALYTICS_ID;
 
 export default function DashboardLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
-  const { setConsentStatus } = useCookieConsentStore();
   const [sheetHeight, setSheetHeight] = useState(400);
   const { toggleSidebar } = useSidebarStore();
   const isMobile = useBreakpointValue({ base: true, md: false });
   const [mobileHeight, setMobileHeight] = useState("0");
   const [desktopHeight, setDesktopHeight] = useState("0");
-
-  useEffect(() => {
-    // As we can't read localStorage outside the useEffect, we update the
-    // cookieConsent state value if the consent was given previously.
-    if (GA_ID && localStorage.getItem("analyticsConsent") === "true") {
-      setConsentStatus(true);
-    }
-  }, [setConsentStatus]);
 
   useEffect(() => {
     // Set layout heights after mount to avoid flash of both layouts at once

--- a/app/components/Analytics.tsx
+++ b/app/components/Analytics.tsx
@@ -1,27 +1,9 @@
 "use client";
 
-import { useEffect } from "react";
 import { GoogleAnalytics } from "@next/third-parties/google";
-import useCookieConsentStore from "@/app/store/cookieConsentStore";
 
 export default function Analytics() {
-  const { cookieConsent, setConsentStatus } = useCookieConsentStore();
   const gaId = process.env.NEXT_PUBLIC_GOOGLE_ANALYTICS_ID;
-
-  useEffect(() => {
-    if (!gaId) return;
-    try {
-      const asked = localStorage.getItem("analyticsConsentAsked");
-      const consent = localStorage.getItem("analyticsConsent");
-      if (asked && consent === "true" && !cookieConsent) {
-        setConsentStatus(true);
-      }
-    } catch {
-      // ignore
-    }
-  }, [cookieConsent, gaId, setConsentStatus]);
-
   if (!gaId) return null;
-  if (!cookieConsent) return null;
   return <GoogleAnalytics gaId={gaId} />;
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from "next";
 import Providers from "@/app/components/providers";
 import { IBM_Plex_Sans, IBM_Plex_Mono } from "next/font/google";
-import CookieConsent from "@/app/components/CookieConsent";
+import Script from "next/script";
 import Analytics from "@/app/components/Analytics";
 import HotjarTrigger from "@/app/components/HotjarTrigger";
 
@@ -33,6 +33,7 @@ export default function RootLayout({
       className={`${ibmPlexSans.variable} ${ibmPlexMono.variable}`}
     >
       <head>
+        <Script src="https://cmp.osano.com/AzyfddTRtqi1560Dk/1543dfc1-f73d-43a2-8296-3849161e9ff5/osano.js" />
         <script
           dangerouslySetInnerHTML={{
             __html: `
@@ -52,7 +53,6 @@ export default function RootLayout({
         <Providers>
           <Analytics />
           {children}
-          <CookieConsent />
           <HotjarTrigger />
         </Providers>
       </body>


### PR DESCRIPTION
This changes the consent for GA4 to use Osano. Since the script is in [discovery mode](https://docs.osano.com/hc/en-us/articles/22472145619988-Compliance-Modes-Listener-Permissive-Strict) it doesn't trigger a consent banner. Is this something we can try to change in the dashboard @01painadam to see how the banner behaves? 