### PR TITLE
Add text-select copy disclaimer

### DIFF
--- a/app/components/ChatMessages.tsx
+++ b/app/components/ChatMessages.tsx
@@ -59,7 +59,6 @@ function ChatMessages() {
         onClose={onClose}
         target={tooltipTarget}
         onCopy={handleCopy}
-        containerRef={containerRef}
       />
       {messages.map((message, index) => {
         // Check if this message is consecutive to the previous one of the same type

--- a/app/components/ChatMessages.tsx
+++ b/app/components/ChatMessages.tsx
@@ -3,6 +3,8 @@ import { Fragment, useState, useEffect, useRef } from "react";
 import { Box, Text, Link } from "@chakra-ui/react";
 import useChatStore from "@/app/store/chatStore";
 import MessageBubble from "./MessageBubble";
+import { SelectionTooltip } from "./SelectionTooltip";
+import { useSelectionTooltip } from "../hooks/useSelectionTooltip";
 import Reasoning from "./Reasoning";
 import SamplePrompts from "./SamplePrompts";
 import ChatDisclaimer from "./ChatDisclaimer";
@@ -13,7 +15,9 @@ function ChatMessages() {
   const containerRef = useRef<HTMLDivElement>(null);
   const { messages, isLoading } = useChatStore();
   const [displayDisclaimer, setDisplayDisclaimer] = useState(true);
+  const { isTooltipOpen, tooltipTarget, handleMouseUp, handleCopy, onClose } = useSelectionTooltip(containerRef);
 
+    
   // Auto-scroll to bottom when new messages are added or loading state changes
   useEffect(() => {
     if (containerRef.current) {
@@ -42,12 +46,21 @@ function ChatMessages() {
   }, []);
 
   // Show reasoning after the last user message when loading
+    
+  
   const lastUserMessageIndex = messages.findLastIndex(
     (msg) => msg.type === "user"
   );
 
   return (
-    <Box ref={containerRef} fontSize="sm">
+    <Box ref={containerRef} fontSize="sm" position="relative">
+      <SelectionTooltip
+        isOpen={isTooltipOpen}
+        onClose={onClose}
+        target={tooltipTarget}
+        onCopy={handleCopy}
+        containerRef={containerRef}
+      />
       {messages.map((message, index) => {
         // Check if this message is consecutive to the previous one of the same type
         const previousMessage = index > 0 ? messages[index - 1] : null;
@@ -100,6 +113,7 @@ function ChatMessages() {
               message={message}
               isConsecutive={isConsecutive}
               isFirst={isFirst}
+              onSelectText={handleMouseUp}
             />
             {isLoading && index === lastUserMessageIndex && <Reasoning />}
 

--- a/app/components/MessageBubble.tsx
+++ b/app/components/MessageBubble.tsx
@@ -36,14 +36,15 @@ interface MessageBubbleProps {
   message: ChatMessage;
   isConsecutive?: boolean; // Whether this message is consecutive to the previous one of the same type
   isFirst?: boolean;
+  onSelectText: () => void;
 }
 
-function MessageBubble({ message, isConsecutive = false, isFirst = false }: MessageBubbleProps) {
+function MessageBubble({ message, isConsecutive = false, isFirst = false, onSelectText }: MessageBubbleProps) {
   const [formattedTimestamp, setFormattedTimestamp] = useState("");
-  const clipboard = useClipboard({ value: message.message });
   const [isRating, setIsRating] = useState(false);
   const [feedbackOpen, setFeedbackOpen] = useState(false);
   const [feedbackText, setFeedbackText] = useState("");
+  const clipboard = useClipboard({ value: message.message });
   const { currentThreadId } = useChatStore();
 
   useEffect(() => {
@@ -158,7 +159,7 @@ function MessageBubble({ message, isConsecutive = false, isFirst = false }: Mess
       mb={isConsecutive ? 1 : 4} // Reduced margin for consecutive messages
       _first={{ base: { mt: 3 }, md: { mt: 6 } }}
     >
-      <Box
+            <Box
         display="flex"
         flexDir="column"
         alignItems={isUser ? "flex-end" : "flex-start"}
@@ -229,9 +230,11 @@ function MessageBubble({ message, isConsecutive = false, isFirst = false }: Mess
               },
             }}
           >
-            <Markdown remarkPlugins={[remarkBreaks]}>
-              {message.message}
-            </Markdown>
+                        <Box onMouseUp={onSelectText}>
+              <Markdown remarkPlugins={[remarkBreaks]}>
+                {message.message}
+              </Markdown>
+            </Box>
           </Box>
         )}
         {!isUser && !isConsecutive && !isError && !isFirst && (

--- a/app/components/SelectionTooltip.tsx
+++ b/app/components/SelectionTooltip.tsx
@@ -1,0 +1,74 @@
+"use client";
+import { Box, Button, HStack, Text } from "@chakra-ui/react";
+import { SparkleIcon } from "@phosphor-icons/react";
+import { useState, useEffect } from "react";
+
+interface SelectionTooltipProps {
+  isOpen: boolean;
+  onClose: () => void;
+  target: DOMRect | null;
+  onCopy: () => void;
+  containerRef: React.RefObject<HTMLDivElement | null>;
+}
+
+export function SelectionTooltip({ isOpen, onClose, target, onCopy, containerRef }: SelectionTooltipProps) {
+  const [copied, setCopied] = useState(false);
+
+  useEffect(() => {
+    if (isOpen) {
+      setCopied(false);
+    }
+  }, [isOpen]);
+
+    useEffect(() => {
+    if (isOpen) {
+      window.addEventListener("resize", onClose);
+      return () => {
+        window.removeEventListener("resize", onClose);
+      };
+    }
+  }, [isOpen, onClose]);
+
+  const handleCopy = () => {
+    onCopy();
+    setCopied(true);
+  };
+
+  if (!isOpen || !target) return null;
+
+  return (
+    <Box
+      position="absolute"
+      top={`${target.bottom + 8}px`}
+      left="5%"
+      zIndex={1000}
+      bg="white"
+      border="1px solid"
+      borderColor="gray.200"
+      borderRadius="md"
+      boxShadow="sm"
+      py={1}
+      px={2}
+      w="fit-content"
+      maxW="90%"
+    >
+      <HStack gap={3} alignItems="center">
+        <SparkleIcon color="var(--chakra-colors-lime-500)" size={18} weight="fill" style={{ flexShrink: 0 }} />
+        <Text fontSize="sm" color="gray.600" flex={1}>
+          This is AI-generated text. Verify before using in your work.
+        </Text>
+        <Button
+          size={{ base: "xs", md: "sm" }}
+          onClick={handleCopy}
+          variant="outline"
+          colorScheme="gray"
+          bg="white"
+          color="blue.500"
+          flexShrink={0}
+        >
+          {copied ? "Copied" : "Copy"}
+        </Button>
+      </HStack>
+    </Box>
+  );
+}

--- a/app/components/SelectionTooltip.tsx
+++ b/app/components/SelectionTooltip.tsx
@@ -8,10 +8,9 @@ interface SelectionTooltipProps {
   onClose: () => void;
   target: DOMRect | null;
   onCopy: () => void;
-  containerRef: React.RefObject<HTMLDivElement | null>;
 }
 
-export function SelectionTooltip({ isOpen, onClose, target, onCopy, containerRef }: SelectionTooltipProps) {
+export function SelectionTooltip({ isOpen, onClose, target, onCopy }: SelectionTooltipProps) {
   const [copied, setCopied] = useState(false);
 
   useEffect(() => {
@@ -40,7 +39,7 @@ export function SelectionTooltip({ isOpen, onClose, target, onCopy, containerRef
     <Box
       position="absolute"
       top={`${target.bottom + 8}px`}
-      left="5%"
+      left="5%" // TODO: not sure this is the best solution, but it passes the eye-test for now
       zIndex={1000}
       bg="white"
       border="1px solid"

--- a/app/hooks/useSelectionTooltip.ts
+++ b/app/hooks/useSelectionTooltip.ts
@@ -1,0 +1,78 @@
+"use client";
+import { useState, useEffect, RefObject } from "react";
+import { useClipboard } from "@chakra-ui/react";
+import { sendGAEvent } from "@next/third-parties/google";
+
+export function useSelectionTooltip(containerRef: RefObject<HTMLDivElement | null>) {
+  const [selection, setSelection] = useState("");
+  const [isTooltipOpen, setTooltipOpen] = useState(false);
+  const [tooltipTarget, setTooltipTarget] = useState<DOMRect | null>(null);
+  const clipboard = useClipboard({ value: selection });
+
+  const handleMouseUp = () => {
+    const selectedText = window.getSelection()?.toString() || "";
+    if (selectedText && containerRef.current) {
+      setSelection(selectedText);
+      setTooltipOpen(true);
+      const selection = window.getSelection();
+      if (selection && selection.rangeCount > 0) {
+        const range = selection.getRangeAt(0);
+        const rect = range.getBoundingClientRect();
+        const containerRect = containerRef.current.getBoundingClientRect();
+
+        // Calculate position relative to the container
+        const relativeTop = rect.top - containerRect.top + containerRef.current.scrollTop;
+        const relativeLeft = rect.left - containerRect.left;
+
+        // Create a DOMRect-like object with container-relative coordinates
+        const adjustedRect = {
+          top: relativeTop,
+          left: relativeLeft,
+          width: rect.width,
+          height: rect.height,
+          bottom: relativeTop + rect.height,
+          right: relativeLeft + rect.width,
+          x: relativeLeft,
+          y: relativeTop,
+        } as DOMRect;
+
+        setTooltipTarget(adjustedRect);
+      }
+    } else {
+      setTooltipOpen(false);
+    }
+  };
+
+  const handleCopy = () => {
+    clipboard.copy();
+    sendGAEvent("event", "response_text_copied", {
+      copied_text: selection,
+    });
+  };
+
+  const onClose = () => {
+    setTooltipOpen(false);
+  };
+
+  useEffect(() => {
+    const handleDocumentCopy = () => {
+      if (isTooltipOpen) {
+        setTooltipOpen(false);
+      }
+    };
+
+    document.addEventListener("copy", handleDocumentCopy);
+
+    return () => {
+      document.removeEventListener("copy", handleDocumentCopy);
+    };
+  }, [isTooltipOpen]);
+
+  return {
+    isTooltipOpen,
+    tooltipTarget,
+    handleMouseUp,
+    handleCopy,
+    onClose,
+  };
+}

--- a/app/theme/index.tsx
+++ b/app/theme/index.tsx
@@ -95,6 +95,7 @@ export const config = defineConfig({
         lime: {
           100: { value: "#F7FBD9" },
           400: { value: "#E3F37F" },
+          500: { value: "#C3D16F" },
         },
         mint: {
           50: { value: "#e2fff8" },


### PR DESCRIPTION
### Summary
This PR adds a tooltip that appears when users highlight text in assistant responses. The tooltip displays a disclaimer reminding users to verify AI-generated content before using it in their work, along with a convenient copy button.

![chrome-capture-2025-11-4](https://github.com/user-attachments/assets/17a551f0-25a9-47ee-a891-598665c1d5ba)

Behaviour:
- When you select/highlight text in an assistant's message, a tooltip appears below the selection
- The tooltip is centered below on the selected text and stays within the chat pane boundaries
- Only one tooltip appears at a time (selecting text in a different message closes any existing tooltip)
- The tooltip closes when users copy the text with ctrl/cmd+c, click away, or select different text

Adds:
 - Custom hook `useSelectionTooltip.ts` that manages tooltip state and positioning logic
 - Tooltip component `SelectionTooltip.tsx`

Updates:
 - `ChatMessages.tsx` uses the custom hook and renders a single tooltip instance
 - `MessageBubble.tsx` sends `onMouseUp` events to parent for tooltip triggering

### Open questions
- Is there a better way to position the tooltip in the pane?
- is its prominent enough? I feel like it blends in with the chat pane
- should ctrl+c dismiss or set button text to `Copied`? (and could clicking `Copy` dismiss?)
- should there be a button to dismiss the component?