### PR TITLE
Hotfix - prompts used

### DIFF
--- a/app/components/PageHeader.tsx
+++ b/app/components/PageHeader.tsx
@@ -120,7 +120,7 @@ function PageHeader() {
               content={
                 totalPrompts > 5000 
                   ? "You have unlimited prompts!" 
-                  : `${usedPrompts} of ${totalPrompts} prompts used. These refresh every 24 hours.`
+                  : `${usedPrompts} of ${totalPrompts} prompts used. Prompts refresh every 24 hours.`
               }
               showArrow
             >

--- a/app/components/PageHeader.tsx
+++ b/app/components/PageHeader.tsx
@@ -17,7 +17,9 @@ import {
   LifebuoyIcon,
   SignOutIcon,
   UserIcon,
+  InfoIcon,
 } from "@phosphor-icons/react";
+import { Tooltip } from "./ui/tooltip";
 
 import useAuthStore from "../store/authStore";
 import Link from "next/link";
@@ -113,7 +115,25 @@ function PageHeader() {
             ) : (
               totalPrompts
             )}{" "}
-            Prompts used
+            daily prompts
+            <Tooltip
+              content={
+                totalPrompts > 5000 
+                  ? "You have unlimited prompts!" 
+                  : `${usedPrompts} of ${totalPrompts} prompts used. These refresh every 24 hours.`
+              }
+              showArrow
+            >
+              <Text
+                as="span"
+                display="inline-block"
+                ml="1"
+                verticalAlign="text-bottom"
+                cursor="help"
+              >
+                <InfoIcon />
+              </Text>
+            </Tooltip>
           </Progress.Label>
           <Progress.Track bg="primary.950" maxH="4px">
             <Progress.Range bg="white" />

--- a/app/components/PageHeader.tsx
+++ b/app/components/PageHeader.tsx
@@ -113,7 +113,7 @@ function PageHeader() {
             ) : (
               totalPrompts
             )}{" "}
-            Prompts
+            Prompts used
           </Progress.Label>
           <Progress.Track bg="primary.950" maxH="4px">
             <Progress.Range bg="white" />


### PR DESCRIPTION
### Summary

Makes the prompt quota more clear, stating: `Prompts used`.

<img width="1120" height="745" alt="image" src="https://github.com/user-attachments/assets/c2dd1fee-fbb0-49ce-8fa1-26f069ac13a3" />

This comes after user interviews where the interviewees thought that they had 0 _prompts left_ 

### Notes
@faustoperez maybe there is a longer term solution where we can add a info button+tooltip explaining what the bar means (i.e. a daily quota)
