### PR TITLE
Async GA utility

### DIFF
--- a/app/api/auth/me/route.ts
+++ b/app/api/auth/me/route.ts
@@ -4,6 +4,9 @@ import { cookies } from "next/headers";
 import { API_CONFIG } from "@/app/config/api";
 import { getAPIRequestHeaders } from "../../shared/utils";
 
+// Force dynamic rendering - this route should never be cached
+export const dynamic = "force-dynamic";
+
 const TOKEN_NAME = "auth_token";
 
 export async function GET() {
@@ -96,13 +99,22 @@ export async function GET() {
       userObj && typeof userObj.id === "string" ? (userObj.id as string) : null;
     const userId = idSub ?? idRoot ?? idUserId ?? idFromUser ?? email;
 
-    return NextResponse.json({
-      isAuthenticated: true,
-      user: { email, id: userId },
-      promptsUsed,
-      promptQuota,
-      hasProfile,
-    });
+    return NextResponse.json(
+      {
+        isAuthenticated: true,
+        user: { email, id: userId },
+        promptsUsed,
+        promptQuota,
+        hasProfile,
+      },
+      {
+        headers: {
+          "Cache-Control": "no-store, no-cache, must-revalidate",
+          Pragma: "no-cache",
+          Expires: "0",
+        },
+      }
+    );
   } catch {
     return NextResponse.json({ isAuthenticated: false }, { status: 401 });
   }

--- a/app/components/ThreadActionsMenu.tsx
+++ b/app/components/ThreadActionsMenu.tsx
@@ -13,6 +13,7 @@ import ThreadDeleteDialog from "./ThreadDeleteDialog";
 import ThreadRenameDialog from "./ThreadRenameDialog";
 import ThreadShareDialog from "./ThreadShareDialog";
 import { sendGAEvent } from "@next/third-parties/google";
+import { sendGAEventAsync } from "@/app/utils/analytics";
 
 function ThreadActionsMenu({
   thread,
@@ -49,7 +50,7 @@ function ThreadActionsMenu({
   )
 
   const onDelete = useCallback(async () => {
-    sendGAEvent("event", "thread_deleted", { 
+    await sendGAEventAsync("thread_deleted", { 
       thread_name: thread.name,
       thread_id: thread.id,
      });

--- a/app/components/providers/index.tsx
+++ b/app/components/providers/index.tsx
@@ -18,7 +18,13 @@ function AuthBootstrapper() {
     let cancelled = false;
     async function loadAuth() {
       try {
-        const res = await fetch("/api/auth/me", { cache: "no-store" });
+        const res = await fetch(`/api/auth/me?_t=${Date.now()}`, {
+          cache: "no-store",
+          headers: {
+            "Cache-Control": "no-cache, no-store, must-revalidate",
+            Pragma: "no-cache",
+          },
+        });
         if (!res.ok) {
           throw new Error("unauthorized");
         }

--- a/app/onboarding/form.tsx
+++ b/app/onboarding/form.tsx
@@ -241,7 +241,14 @@ export default function OnboardingForm() {
       ) => {
         for (let attempt = 0; attempt < maxAttempts; attempt++) {
           try {
-            const check = await fetch("/api/auth/me", { cache: "no-store" });
+            // Cache-busting timestamp prevents stale responses
+            const check = await fetch(`/api/auth/me?_t=${Date.now()}`, {
+              cache: "no-store",
+              headers: {
+                "Cache-Control": "no-cache, no-store, must-revalidate",
+                Pragma: "no-cache",
+              },
+            });
             if (check.ok) {
               const data = await check.json();
               if (data?.hasProfile) return true;

--- a/app/onboarding/form.tsx
+++ b/app/onboarding/form.tsx
@@ -28,7 +28,7 @@ import { showApiError } from "@/app/hooks/useErrorHandler";
 import { submitToOrtto } from "@/app/actions/ortto";
 import LclLogo from "../components/LclLogo";
 import { ArrowLeftIcon } from "@phosphor-icons/react";
-import { sendGAEvent } from "@next/third-parties/google";
+import { sendGAEventAsync } from "@/app/utils/analytics";
 
 type ProfileConfig = {
   sectors: Record<string, string>;
@@ -256,7 +256,7 @@ export default function OnboardingForm() {
 
       const verified = await waitForProfileCompletion();
       if (verified) {
-        sendGAEvent("event", "sign_up", {
+        await sendGAEventAsync("sign_up", {
           sector: payload.sector_code,
           role: payload.role_code,
           country: payload.country_code,

--- a/app/utils/analytics.ts
+++ b/app/utils/analytics.ts
@@ -1,0 +1,36 @@
+import { sendGAEvent } from "@next/third-parties/google";
+
+declare global {
+  interface Window {
+    gtag?: (...args: unknown[]) => void;
+  }
+}
+
+/**
+ * Sends a GA4 event and waits for confirmation before resolving.
+ * Uses event_callback for reliable delivery, especially before navigation.
+ * Falls back to sendGAEvent with a small delay if gtag is unavailable.
+ *
+ * @param eventName - The name of the GA4 event
+ * @param params - Event parameters to send
+ * @param timeoutMs - Maximum time to wait for callback (default 2000ms)
+ */
+export async function sendGAEventAsync(
+  eventName: string,
+  params: Record<string, unknown>,
+  timeoutMs = 2000
+): Promise<void> {
+  return new Promise((resolve) => {
+    if (typeof window !== "undefined" && window.gtag) {
+      window.gtag("event", eventName, {
+        ...params,
+        event_callback: () => resolve(),
+        event_timeout: timeoutMs,
+      });
+    } else {
+      // Fallback: use standard sendGAEvent with small delay
+      sendGAEvent("event", eventName, params);
+      setTimeout(resolve, 150);
+    }
+  });
+}


### PR DESCRIPTION
Attempt to fix #395 

- Adds an asynchronous utility to block the GA event until the onboarding form finishes processing, I used it as well in delete thread because deleting causes a reroute
- Fix some caching issues that could have stale API data in local development