### PR TITLE
GNW beta --> GNW preview

### DIFF
--- a/app/(home)/sections/11_CTA.tsx
+++ b/app/(home)/sections/11_CTA.tsx
@@ -37,7 +37,7 @@ export default function CTASection() {
             </Box>
             <Button asChild variant="solid" colorPalette="primary" rounded="lg">
               <Link href="/app">
-                {LANDING_PAGE_VERSION === "public" ? "Explore the beta" : "Try the preview"}
+                {LANDING_PAGE_VERSION === "public" ? "Explore the preview" : "Try the preview"}
                 <CaretRightIcon weight="bold" />
               </Link>
             </Button>

--- a/app/(home)/sections/1_Hero.tsx
+++ b/app/(home)/sections/1_Hero.tsx
@@ -166,7 +166,7 @@ export default function LandingHero({
             >
               Global Nature Watch is an open, AI-powered system that transforms groundbreaking
               land monitoring data into intelligence to understand Earth&rsquo;s landscapes.
-              Test the beta and help shape the future of land monitoring.
+              Test the preview and help shape the future of land monitoring.
             </Text>
           </Container>
           <Container
@@ -282,14 +282,14 @@ export default function LandingHero({
             >
               <Text>
                 <Badge size="xs" fontSize="8px" rounded="4px" mr="1">
-                  BETA
+                  PREVIEW
                 </Badge>
                 Global Nature Watch is
                 {LANDING_PAGE_VERSION === "closed"
-                  ? " in closed beta."
+                  ? " in closed preview."
                   : LANDING_PAGE_VERSION === "limited"
-                  ? " in limited beta."
-                  : " in beta."}
+                  ? " in limited preview."
+                  : " in preview."}
               </Text>
               <Tooltip
                 openDelay={100}
@@ -306,7 +306,7 @@ export default function LandingHero({
                   alignItems="center"
                 >
                   <QuestionIcon />
-                  What does beta mean?
+                  What does preview mean?
                 </Box>
               </Tooltip>
             </Box>

--- a/app/(home)/sections/4_FeaturesTabs.tsx
+++ b/app/(home)/sections/4_FeaturesTabs.tsx
@@ -68,7 +68,7 @@ export default function FeaturesTabsSection() {
               rounded="lg"
             >
               <Link href="/app">
-                Explore the beta
+                Explore the preview
                 <CaretRightIcon weight="bold" />
               </Link>
             </Button>

--- a/app/(home)/sections/5_SupportWorkTabs.tsx
+++ b/app/(home)/sections/5_SupportWorkTabs.tsx
@@ -153,7 +153,7 @@ export default function SupportWorkTabsSection() {
                 rounded="lg"
               >
                 <Link href="/app">
-                  Explore the beta
+                  Explore the preview
                   <CaretRightIcon weight="bold" />
                 </Link>
               </Button>

--- a/app/components/ChatMessages.tsx
+++ b/app/components/ChatMessages.tsx
@@ -55,49 +55,50 @@ function ChatMessages() {
         const isFirst = index === 0;
         return (
           <Fragment key={message.id}>
-                        {isFirst && displayDisclaimer && (
+            {isFirst && displayDisclaimer && (
               <ChatDisclaimer
                 type="info"
                 setDisplayDisclaimer={setDisplayDisclaimer}
               >
                 <Box>
                   <Text mb={{ base: 1, md: 2 }}>
-                    <strong>Global Nature Watch beta</strong>
+                    <strong>Global Nature Watch preview</strong>
                   </Text>
                   <Text mb={{ base: 1, md: 2 }}>
-                    You&apos;re using a beta version that&apos;s still under active development.
+                    You&apos;re using a preview version that&apos;s still under active development.
                     You may encounter errors or incomplete results, so verify results with primary sources.
                     Features, datasets, and assistant behavior may change or be removed as we iterate.
                   </Text>
                   <Text>
-                    By using this beta, you&apos;re helping shape the future of Global Nature Watch.
-                  Share feedback via{" "}
-                  <Link
-                    color="primary.solid"
-                    textDecor="underline"
-                    href="https://surveys.hotjar.com/860def81-d4f2-4f8c-abee-339ebc3129f3"
-                  >
-                    this survey
-                  </Link>{" "}
-                  or by emailing{" "}
-                  <Link
-                    color="primary.solid"
-                    textDecor="underline"
-                    href="mailto:landcarbonlab@wri.org"
-                  >
-                    landcarbonlab@wri.org
-                  </Link>{". "}
-                  Visit the{" "}
-                  <Link
-                    color="primary.solid"
-                    textDecor="underline"
-                    href="https://help.globalnaturewatch.org/"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                  >
-                    Help Center
-                  </Link>{" "}
-                  to learn more about the beta.
+                    By using this preview, you&apos;re helping shape the future of Global Nature Watch.
+                    Share feedback via{" "}
+                    <Link
+                      color="primary.solid"
+                      textDecor="underline"
+                      href="https://surveys.hotjar.com/860def81-d4f2-4f8c-abee-339ebc3129f3"
+                    >
+                      this survey
+                    </Link>{" "}
+                    or by emailing{" "}
+                    <Link
+                      color="primary.solid"
+                      textDecor="underline"
+                      href="mailto:landcarbonlab@wri.org"
+                    >
+                      landcarbonlab@wri.org
+                    </Link>
+                    {" "}
+                    Visit the{" "}
+                    <Link
+                      color="primary.solid"
+                      textDecor="underline"
+                      href="https://help.globalnaturewatch.org/"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      Help Center
+                    </Link>{" "}
+                    to learn more about the preview.
                   </Text>
                 </Box>
               </ChatDisclaimer>

--- a/app/components/GlobalHeader.tsx
+++ b/app/components/GlobalHeader.tsx
@@ -85,7 +85,7 @@ const renderNavItems = (
           </Link>
         ) : (
           <Link href="/app" onClick={() => setNavOpen && setNavOpen(false)}>
-            Explore the beta
+            Explore the preview
           </Link>
         )}
       </Button>

--- a/app/components/PageHeader.tsx
+++ b/app/components/PageHeader.tsx
@@ -77,7 +77,7 @@ function PageHeader() {
           variant="solid"
           size="xs"
         >
-          BETA
+          PREVIEW
         </Badge>
       </Flex>
       <Flex gap="6" alignItems="center" hideBelow="md">

--- a/app/onboarding/form.tsx
+++ b/app/onboarding/form.tsx
@@ -311,7 +311,7 @@ export default function OnboardingForm() {
               variant="solid"
               size="xs"
             >
-              BETA
+              PREVIEW
             </Badge>
           </Flex>
           <Button

--- a/app/sidebar.tsx
+++ b/app/sidebar.tsx
@@ -231,7 +231,7 @@ export function Sidebar() {
             variant="solid"
             size="xs"
           >
-            BETA
+            PREVIEW
           </Badge>
         </Flex>
       </Flex>

--- a/app/unauthorized/page.tsx
+++ b/app/unauthorized/page.tsx
@@ -110,7 +110,7 @@ export default function UnauthorizedPage() {
               Thank you for your interest in Global Nature Watch!
             </Text>
             <Text fontSize={{ base: "xl", md: "2xl"}} {...commonStyles}>
-              Right now access is limited while we are in closed beta. We&apos;d
+              Right now access is limited while we are in closed preview. We&apos;d
               love for you to be part of what&apos;s next, so join the waitlist
               to be among the first to know when the tool becomes available.
             </Text>


### PR DESCRIPTION
Changes instances of `GNW Beta` to `Preview` across the app.

<img width="231" height="38" alt="Screenshot 2026-01-28 at 10 43 15 AM" src="https://github.com/user-attachments/assets/030473d7-1288-48ee-bbe3-4f5d7b50aa51" />

Changes applied:
-  Badge: BETA -> PREVIEW
- Global Header:  Explore the beta -> Explore the preview
- Landing page (several)
- Chat pane: disclaimer text
- Unauthorised page: closed beta -> closed preview