### PR TITLE
Add starter prompts back for new convos

### DIFF
--- a/app/components/ChatMessages.tsx
+++ b/app/components/ChatMessages.tsx
@@ -110,7 +110,7 @@ function ChatMessages() {
             {isLoading && index === lastUserMessageIndex && <Reasoning />}
 
             {/* Prompt options for first message, removed when sent */}
-            {messages.length < 2 && LANDING_PAGE_VERSION !== "public" && (
+            {messages.length < 2 && (
               <SamplePrompts />
             )}
           </Fragment>

--- a/app/components/ChatMessages.tsx
+++ b/app/components/ChatMessages.tsx
@@ -7,8 +7,6 @@ import Reasoning from "./Reasoning";
 import SamplePrompts from "./SamplePrompts";
 import ChatDisclaimer from "./ChatDisclaimer";
 
-const LANDING_PAGE_VERSION = process.env.NEXT_PUBLIC_LANDING_PAGE_VERSION;
-
 function ChatMessages() {
   const containerRef = useRef<HTMLDivElement>(null);
   const { messages, isLoading } = useChatStore();


### PR DESCRIPTION
Add starter prompts to new conversations:

<img width="578" height="266" alt="Screenshot 2026-01-28 at 10 52 47 AM" src="https://github.com/user-attachments/assets/5e1888b3-53fa-4d71-9da7-566b426df547" />

Possible flows to test:
- User selects prompt on homepage --> starts new conversation in `/app`. **No starter prompts visible** ❌  
- User selects `Explore the beta` --> starts new conversation in `/app`. **Starter prompts are visible** ✅ 
- User selects "new conversation" while in `/app` **Starter prompts are visible** ✅ 

