### PR TITLE
Update prompts based on usage stats

### DIFF
--- a/public/welcome-prompts.json
+++ b/public/welcome-prompts.json
@@ -24,7 +24,7 @@
     "What are the net carbon emissions from deforestation in the Congo Basin?",
     "Show recent forest disturbance alerts in Borneo.",
     "How much deforestation is linked to cocoa production in Côte d'Ivoire?",
-    "What percantage of the Phillippines was forest in 2000?",
+    "What percentage of the Phillippines was forest in 2000?",
     "What does the land cover look like across Colombia's Pacific coast?"
   ]
 }

--- a/public/welcome-prompts.json
+++ b/public/welcome-prompts.json
@@ -1,5 +1,5 @@
 {
-  "prompts": [
+  "prompts_v1": [
     "Show changes in grassland extent in Montana.",
     "Analyse forest loss trends in the Rusizi Basin, Rwanda, over the last 10 years.",
     "How much of the Democratic Republic of Congo is natural land?",
@@ -11,5 +11,20 @@
     "Compare disturbances in France last month: natural events vs human activity.",
     "What were the top three causes of tree loss in Brazil last year?",
     "Show the biggest changes in land cover in Kenya between 2015 and 2024."
+  ],
+  "prompts": [
+    "What are the trends in natural grassland area in Bolivia since 2015?",
+    "What were the top three causes of tree loss in Brazil last year?",
+    "Show the biggest changes in land cover in Kenya between 2015 and 2024.",
+    "How much of the Democratic Republic of Congo is natural land?",
+    "Where in Indonesia have restoration efforts occurred over the past decade?",
+    "Show changes in grassland extent in Mongolia.",
+    "Show forest loss from wildfires in the Mediterranean over the last five years.",
+    "How much natural land was converted to cropland in Spain between 2015 and 2024?",
+    "What are the net carbon emissions from deforestation in the Congo Basin?",
+    "Show recent forest disturbance alerts in Borneo.",
+    "How much deforestation is linked to cocoa production in Côte d'Ivoire?",
+    "What percantage of the Phillippines was forest in 2000?",
+    "What does the land cover look like across Colombia's Pacific coast?"
   ]
 }


### PR DESCRIPTION
We analysed all 428 welcome-prompt sessions since Zeno went open days. Three prompts are actively hurting first impressions:

- Spain "last summer" - 48% soft error rate since the data doesn't have seasonal granularity.
- Rusizi Basin, Rwanda - 67% success, 115s latency... so users wait 2 min for a coin flip.
- France "last month" - 83% bounce (worst of all 11), 25% soft error. Again vague time frame makes it fragile.

Also, carbon/emissions (4.5% of organic demand), DIST-ALERT near-real-time monitoring (3rd organic dataset), and supply-chain/EUDR queries have zero welcome-prompt representation.

### Changes
- Keep 5 that already work well (Bolivia, Brazil, Kenya, DRC, Indonesia)
- Fix:
  - Montana → Mongolia (fixes 59% of clicks)
  - California → Mediterranean (faster, maps to Spanish cohort)
  - Spain "last summer" → Spain "2015-2024" (fixes the 48% error rate)
- Replace 3 broken prompts with carbon (Congo Basin), alerts (Borneo), and supply chain (Côte d'Ivoire cocoa)
- Add 2 for dataset coverage: Philippines forest cover and Colombia Pacific coast land cover, which gets us from 6/10 to 10/10 datasets demoed.