### PR TITLE
2. Chart accessibility

### DIFF
--- a/app/components/WidgetMessage.tsx
+++ b/app/components/WidgetMessage.tsx
@@ -85,6 +85,7 @@ export default function WidgetMessage({ widget }: WidgetMessageProps) {
             <Box overflowX="auto" maxW="100%">
               <TableWidget
                 data={widget.data as Record<string, string | number | boolean>[]}
+                caption={widget.title}
               />
             </Box>
           </WidgetErrorBoundary>

--- a/app/components/widgets/ChartWidget.tsx
+++ b/app/components/widgets/ChartWidget.tsx
@@ -26,6 +26,7 @@ import formatChartData, {
   toAxisLabel,
 } from "@/app/utils/formatCharts";
 import { InsightWidget } from "@/app/types/chat";
+import { STROKE_DASH_PATTERNS } from "@/app/utils/ChartColors";
 
 type ChartType =
   | "bar"
@@ -283,7 +284,7 @@ export default function ChartWidget({ widget }: ChartWidgetProps) {
         ));
       }
       case "line": {
-        return chart.series.map((item) => (
+        return chart.series.map((item, idx) => (
           <Line
             key={item.name}
             type="monotone"
@@ -291,12 +292,13 @@ export default function ChartWidget({ widget }: ChartWidgetProps) {
             dataKey={chart.key(item.name)}
             stroke={chart.color(item.color)}
             strokeWidth={2}
+            strokeDasharray={STROKE_DASH_PATTERNS[idx % STROKE_DASH_PATTERNS.length]}
             isAnimationActive={false}
           />
         ));
       }
       case "area": {
-        return chart.series.map((item) => (
+        return chart.series.map((item, idx) => (
           <Area
             key={item.name}
             type="monotone"
@@ -307,6 +309,7 @@ export default function ChartWidget({ widget }: ChartWidgetProps) {
             fillOpacity={0.2}
             stroke={chart.color(item.color)}
             strokeWidth={2}
+            strokeDasharray={STROKE_DASH_PATTERNS[idx % STROKE_DASH_PATTERNS.length]}
             isAnimationActive={false}
           />
         ));

--- a/app/components/widgets/ChartWidget.tsx
+++ b/app/components/widgets/ChartWidget.tsx
@@ -330,7 +330,10 @@ export default function ChartWidget({ widget }: ChartWidgetProps) {
     }
   };
 
+  const chartLabel = `${type} chart: ${widget.title || ""}. ${widget.description || ""}`.trim();
+
   return (
+    <Box role="img" aria-label={chartLabel} tabIndex={0}>
     <Chart.Root maxH="280px" chart={chart} overflow="hidden">
       <ChartTypeWrapper data={chart.data}>
         {type !== "pie" && (
@@ -423,5 +426,6 @@ export default function ChartWidget({ widget }: ChartWidgetProps) {
         {renderChartItems()}
       </ChartTypeWrapper>
     </Chart.Root>
+    </Box>
   );
 }

--- a/app/components/widgets/TableWidget.tsx
+++ b/app/components/widgets/TableWidget.tsx
@@ -3,9 +3,10 @@ import { Badge, Box, Table } from "@chakra-ui/react";
 
 interface TableWidgetProps {
   data: Record<string, string | number | boolean>[];
+  caption?: string;
 }
 
-export default function TableWidget({ data }: TableWidgetProps) {
+export default function TableWidget({ data, caption }: TableWidgetProps) {
   // Helper function to format numeric values
   const formatValue = (
     value: string | number | boolean
@@ -17,7 +18,12 @@ export default function TableWidget({ data }: TableWidgetProps) {
   const headers = Object.keys(data[0]);
   return (
     <Box>
-      <Table.Root variant="line" striped bg="transparent" size="sm">
+      <Table.Root variant="line" striped bg="transparent" size="sm" aria-label={caption || "Data table"}>
+        {caption && (
+          <Table.Caption placement="top" textAlign="left" mt={0} mb={2} fontSize="xs" color="fg.muted">
+            {caption}
+          </Table.Caption>
+        )}
         <Table.Header>
           <Table.Row>
             {data &&
@@ -28,6 +34,7 @@ export default function TableWidget({ data }: TableWidgetProps) {
                   color="neutral.500"
                   fontWeight="normal"
                   whiteSpace="pre"
+                  scope="col"
                 >
                   {toSentenceCase(key)}
                 </Table.ColumnHeader>

--- a/app/components/widgets/TableWidget.tsx
+++ b/app/components/widgets/TableWidget.tsx
@@ -9,7 +9,7 @@ interface TableWidgetProps {
 export default function TableWidget({ data, caption }: TableWidgetProps) {
   // Helper function to format numeric values
   const formatValue = (
-    value: string | number | boolean
+    value: string | number | boolean,
   ): string | number | boolean => {
     return typeof value === "number"
       ? new Intl.NumberFormat("en-US").format(value)
@@ -18,9 +18,22 @@ export default function TableWidget({ data, caption }: TableWidgetProps) {
   const headers = Object.keys(data[0]);
   return (
     <Box>
-      <Table.Root variant="line" striped bg="transparent" size="sm" aria-label={caption || "Data table"}>
+      <Table.Root
+        variant="line"
+        striped
+        bg="transparent"
+        size="sm"
+        aria-label={caption || "Data table"}
+      >
         {caption && (
-          <Table.Caption placement="top" textAlign="left" mt={0} mb={2} fontSize="xs" color="fg.muted">
+          <Table.Caption
+            captionSide="top"
+            textAlign="left"
+            mt={0}
+            mb={2}
+            fontSize="xs"
+            color="fg.muted"
+          >
             {caption}
           </Table.Caption>
         )}
@@ -45,7 +58,7 @@ export default function TableWidget({ data, caption }: TableWidgetProps) {
           {data.map(
             (
               row: Record<string, string | number | boolean>,
-              rowIndex: number
+              rowIndex: number,
             ) => (
               <Table.Row key={rowIndex} bg="transparent">
                 {headers.map((key: string, cellIndex: number) => {
@@ -80,7 +93,7 @@ export default function TableWidget({ data, caption }: TableWidgetProps) {
                   );
                 })}
               </Table.Row>
-            )
+            ),
           )}
         </Table.Body>
       </Table.Root>

--- a/app/utils/ChartColors.tsx
+++ b/app/utils/ChartColors.tsx
@@ -1,40 +1,59 @@
 import theme from "@/app/theme";
+
 /**
- * A utility function to retrieve a specific, ordered array of chart colors
- * from the Chakra UI theme.
- * @returns {string[]} An array of hex color strings.
+ * Retrieves an ordered array of chart colors from the Chakra UI theme.
+ *
+ * The order is chosen to maximise perceptual distance for common forms
+ * of color-vision deficiency (deuteranopia, protanopia, tritanopia).
+ * Adjacent colors in the sequence should remain distinguishable even
+ * when reds/greens or blues/yellows are confused.
+ *
+ * @returns An array of hex color strings.
  */
-export default function getChartColors() {
+export default function getChartColors(): string[] {
   const { tokens } = theme;
   const colors = tokens.categoryMap.get("colors")!;
   const allColors = Array.from(colors.values());
 
-  // The desired order of colors for the chart
+  // Ordered for maximum colorblind-safe contrast between neighbours:
+  //   blue → orange → green → pink → cyan → red → purple → yellow → mint → berenjena
   const chartColorNames = [
     "blue",
-    "cyan",
-    "mint",
-    "green",
-    "yellow",
     "orange",
-    "red",
+    "green",
     "pink",
+    "cyan",
+    "red",
     "purple",
+    "yellow",
+    "mint",
     "berenjena",
   ];
 
-  // Create a lookup map for fast access using the color's unique name
-  // (e.g., "colors.cyan.500") as the key.
-  const colorMap = new Map(allColors.map((color) => [color.name, color.value]));
+  const colorMap = new Map(allColors.map((c) => [c.name, c.value]));
 
-  // Map over the ordered array and pull values directly from the map
-  const chartColors = chartColorNames
-    .map((name) => {
-      const key = `colors.${name}.500`;
-      return colorMap.get(key) || null; // Get the value by its key
-    })
-    .filter(Boolean); // This removes any nulls if a color wasn't found
-
-  // Return the final, ordered array of colors
-  return chartColors;
+  return chartColorNames
+    .map((name) => colorMap.get(`colors.${name}.500`) || null)
+    .filter((v): v is string => v !== null);
 }
+
+/**
+ * Stroke dash patterns for multi-series line / area charts.
+ * Using distinct dash arrays provides a secondary (non-color) encoding
+ * so that series remain distinguishable for colorblind users or in
+ * greyscale print.
+ *
+ * Index 0 = solid (primary series), then increasingly distinctive dashes.
+ */
+export const STROKE_DASH_PATTERNS: string[] = [
+  "0",         // solid
+  "6 3",       // short dash
+  "2 2",       // dotted
+  "10 4",      // long dash
+  "10 4 2 4",  // dash-dot
+  "6 3 2 3 2 3", // dash-dot-dot
+  "14 4",      // extra-long dash
+  "4 4",       // medium dash
+  "8 3 2 3",   // long-dash-dot
+  "2 6",       // sparse dot
+];


### PR DESCRIPTION
  ## Accessibility: screen reader support and colourblind-safe palette

  Broken out from #415 (2/6). Depends on [PR 1](https://github.com/wri/project-zeno-next/pull/421).

  Makes charts and tables usable for screen reader and colourblind users. Charts get `role="img"` with descriptive
   aria-labels and keyboard focus. Tables get captions and scoped column headers. The colour palette is reordered
  to maximise perceptual distance for deuteranopia/protanopia, and stroke dash patterns are added as a secondary
  non-colour encoding for line and area series.

  ### Commits
  - 810ffee — Add screen reader support to charts and tables
  - 0cb1f04 — Colorblind-safe palette and stroke dash patterns