### PR TITLE
Env-based prototype mode

### DIFF
--- a/app/components/PageHeader.tsx
+++ b/app/components/PageHeader.tsx
@@ -54,8 +54,8 @@ function PageHeader() {
       px={{ base: 3, md: 5 }}
       py="2"
       h={{ base: 10, md: 12 }}
-      bg={isPrototype ? "#f59e0b" : "primary.solid"}
-      color={isPrototype ? "#451a03" : "fg.inverted"}
+      bg={isPrototype ? "#d1d5db" : "primary.solid"}
+      color={isPrototype ? "#1f2937" : "fg.inverted"}
       zIndex={1300}
       position="relative"
     >
@@ -67,22 +67,29 @@ function PageHeader() {
           transition="opacity 0.24s ease"
           _hover={{ opacity: 0.8 }}
         >
-          <LclLogo width={16} avatarOnly fill={isPrototype ? "#451a03" : "white"} />
-          <Heading as="h1" size="sm" color={isPrototype ? "#451a03" : "fg.inverted"}>
+          <LclLogo
+            width={16}
+            avatarOnly
+            fill={isPrototype ? "#1f2937" : "white"}
+          />
+          <Heading
+            as="h1"
+            size="sm"
+            color={isPrototype ? "#1f2937" : "fg.inverted"}
+          >
             Global Nature Watch
           </Heading>
         </ChakraLink>
         <Badge
-          colorPalette={isPrototype ? "orange" : "primary"}
-          bg={isPrototype ? "#451a03" : "primary.800"}
-          color={isPrototype ? "#fef3c7" : undefined}
+          colorPalette={isPrototype ? "gray" : "primary"}
+          bg={isPrototype ? "#1f2937" : "primary.800"}
+          color={isPrototype ? "#f3f4f6" : undefined}
           letterSpacing="wider"
           variant="solid"
           size="xs"
         >
           {isPrototype ? "PROTOTYPE" : "PREVIEW"}
         </Badge>
-
       </Flex>
       {isPrototype && (
         <Text
@@ -90,7 +97,7 @@ function PageHeader() {
           fontWeight="bold"
           letterSpacing="wider"
           textTransform="uppercase"
-          color="#451a03"
+          color="#1f2937"
           position="absolute"
           left="50%"
           transform="translateX(-50%)"
@@ -103,10 +110,10 @@ function PageHeader() {
         <Link href="https://help.globalnaturewatch.org/" target="_blank">
           <Button
             variant="solid"
-            colorPalette={isPrototype ? "orange" : "primary"}
-            bg={isPrototype ? "#d97706" : undefined}
-            color={isPrototype ? "#451a03" : undefined}
-            _hover={{ bg: isPrototype ? "#b45309" : "primary.fg" }}
+            colorPalette={isPrototype ? "gray" : "primary"}
+            bg={isPrototype ? "#9ca3af" : undefined}
+            color={isPrototype ? "#1f2937" : undefined}
+            _hover={{ bg: isPrototype ? "#6b7280" : "primary.fg" }}
             size="sm"
           >
             <LifebuoyIcon />
@@ -128,7 +135,7 @@ function PageHeader() {
             mb="0.5"
             fontSize="xs"
             fontWeight="normal"
-            color={isPrototype ? "#78350f" : "primary.100"}
+            color={isPrototype ? "#6b7280" : "primary.100"}
           >
             {usedPrompts}/
             {totalPrompts > 5000 ? (
@@ -141,8 +148,8 @@ function PageHeader() {
             daily prompts
             <Tooltip
               content={
-                totalPrompts > 5000 
-                  ? "You have unlimited prompts!" 
+                totalPrompts > 5000
+                  ? "You have unlimited prompts!"
                   : `${usedPrompts} of ${totalPrompts} prompts used. Prompts refresh every 24 hours.`
               }
               showArrow
@@ -158,8 +165,11 @@ function PageHeader() {
               </Text>
             </Tooltip>
           </Progress.Label>
-          <Progress.Track bg={isPrototype ? "#78350f" : "primary.950"} maxH="4px">
-            <Progress.Range bg={isPrototype ? "#451a03" : "white"} />
+          <Progress.Track
+            bg={isPrototype ? "#6b7280" : "primary.950"}
+            maxH="4px"
+          >
+            <Progress.Range bg={isPrototype ? "#1f2937" : "white"} />
           </Progress.Track>
         </Progress.Root>
         {isAuthenticated ? (
@@ -167,10 +177,10 @@ function PageHeader() {
             <Menu.Trigger asChild>
               <Button
                 variant="solid"
-                colorPalette={isPrototype ? "orange" : "primary"}
-                bg={isPrototype ? "#d97706" : undefined}
-                color={isPrototype ? "#451a03" : undefined}
-                _hover={{ bg: isPrototype ? "#b45309" : "primary.fg" }}
+                colorPalette={isPrototype ? "gray" : "primary"}
+                bg={isPrototype ? "#9ca3af" : undefined}
+                color={isPrototype ? "#1f2937" : undefined}
+                _hover={{ bg: isPrototype ? "#6b7280" : "primary.fg" }}
                 size="sm"
               >
                 <UserIcon />
@@ -206,10 +216,10 @@ function PageHeader() {
           <Button
             asChild
             variant="solid"
-            colorPalette={isPrototype ? "orange" : "primary"}
-            bg={isPrototype ? "#d97706" : undefined}
-            color={isPrototype ? "#451a03" : undefined}
-            _hover={{ bg: isPrototype ? "#b45309" : "primary.fg" }}
+            colorPalette={isPrototype ? "gray" : "primary"}
+            bg={isPrototype ? "#9ca3af" : undefined}
+            color={isPrototype ? "#1f2937" : undefined}
+            _hover={{ bg: isPrototype ? "#6b7280" : "primary.fg" }}
             size="sm"
           >
             <Link href="/app">

--- a/app/components/PageHeader.tsx
+++ b/app/components/PageHeader.tsx
@@ -25,6 +25,8 @@ import useAuthStore from "../store/authStore";
 import Link from "next/link";
 import { toaster } from "@/app/components/ui/toaster";
 
+const isPrototype = process.env.NEXT_PUBLIC_PROTOTYPE_MODE === "true";
+
 function PageHeader() {
   const { userEmail, usedPrompts, totalPrompts, isAuthenticated } =
     useAuthStore();
@@ -52,8 +54,8 @@ function PageHeader() {
       px={{ base: 3, md: 5 }}
       py="2"
       h={{ base: 10, md: 12 }}
-      bg="primary.solid"
-      color="fg.inverted"
+      bg={isPrototype ? "#f59e0b" : "primary.solid"}
+      color={isPrototype ? "#451a03" : "fg.inverted"}
       zIndex={1300}
       position="relative"
     >
@@ -65,27 +67,46 @@ function PageHeader() {
           transition="opacity 0.24s ease"
           _hover={{ opacity: 0.8 }}
         >
-          <LclLogo width={16} avatarOnly fill="white" />
-          <Heading as="h1" size="sm" color="fg.inverted">
+          <LclLogo width={16} avatarOnly fill={isPrototype ? "#451a03" : "white"} />
+          <Heading as="h1" size="sm" color={isPrototype ? "#451a03" : "fg.inverted"}>
             Global Nature Watch
           </Heading>
         </ChakraLink>
         <Badge
-          colorPalette="primary"
-          bg="primary.800"
+          colorPalette={isPrototype ? "orange" : "primary"}
+          bg={isPrototype ? "#451a03" : "primary.800"}
+          color={isPrototype ? "#fef3c7" : undefined}
           letterSpacing="wider"
           variant="solid"
           size="xs"
         >
-          PREVIEW
+          {isPrototype ? "PROTOTYPE" : "PREVIEW"}
         </Badge>
+
       </Flex>
+      {isPrototype && (
+        <Text
+          fontSize="xs"
+          fontWeight="bold"
+          letterSpacing="wider"
+          textTransform="uppercase"
+          color="#451a03"
+          position="absolute"
+          left="50%"
+          transform="translateX(-50%)"
+          pointerEvents="none"
+        >
+          NOT FOR PRODUCTION USE
+        </Text>
+      )}
       <Flex gap="6" alignItems="center" hideBelow="md">
         <Link href="https://help.globalnaturewatch.org/" target="_blank">
           <Button
             variant="solid"
-            colorPalette="primary"
-            _hover={{ bg: "primary.fg" }}
+            colorPalette={isPrototype ? "orange" : "primary"}
+            bg={isPrototype ? "#d97706" : undefined}
+            color={isPrototype ? "#451a03" : undefined}
+            _hover={{ bg: isPrototype ? "#b45309" : "primary.fg" }}
             size="sm"
           >
             <LifebuoyIcon />
@@ -107,7 +128,7 @@ function PageHeader() {
             mb="0.5"
             fontSize="xs"
             fontWeight="normal"
-            color="primary.100"
+            color={isPrototype ? "#78350f" : "primary.100"}
           >
             {usedPrompts}/
             {totalPrompts > 5000 ? (
@@ -137,8 +158,8 @@ function PageHeader() {
               </Text>
             </Tooltip>
           </Progress.Label>
-          <Progress.Track bg="primary.950" maxH="4px">
-            <Progress.Range bg="white" />
+          <Progress.Track bg={isPrototype ? "#78350f" : "primary.950"} maxH="4px">
+            <Progress.Range bg={isPrototype ? "#451a03" : "white"} />
           </Progress.Track>
         </Progress.Root>
         {isAuthenticated ? (
@@ -146,8 +167,10 @@ function PageHeader() {
             <Menu.Trigger asChild>
               <Button
                 variant="solid"
-                colorPalette="primary"
-                _hover={{ bg: "primary.fg" }}
+                colorPalette={isPrototype ? "orange" : "primary"}
+                bg={isPrototype ? "#d97706" : undefined}
+                color={isPrototype ? "#451a03" : undefined}
+                _hover={{ bg: isPrototype ? "#b45309" : "primary.fg" }}
                 size="sm"
               >
                 <UserIcon />
@@ -183,8 +206,10 @@ function PageHeader() {
           <Button
             asChild
             variant="solid"
-            colorPalette="primary"
-            _hover={{ bg: "primary.fg" }}
+            colorPalette={isPrototype ? "orange" : "primary"}
+            bg={isPrototype ? "#d97706" : undefined}
+            color={isPrototype ? "#451a03" : undefined}
+            _hover={{ bg: isPrototype ? "#b45309" : "primary.fg" }}
             size="sm"
           >
             <Link href="/app">


### PR DESCRIPTION
Adds a visual indicator for prototype deployments so testers and stakeholders can immediately distinguish them from production and avoid unrealistic assumptions about the level of quality / production-readiness

 ### What it does

 - Reads `NEXT_PUBLIC_PROTOTYPE_MODE` env var
 - When true: header turns amber, PREVIEW --> PROTOTYPE, and a centred "NOT FOR PRODUCTION USE" label appears
 - When unset: zero changes. All values fall through to defaults

![gnw-proto](https://github.com/user-attachments/assets/8a0e3e9f-9c27-4447-bcb1-d3e8431ea1f8)

 ### Changes

 - app/components/PageHeader.tsx — conditional color swap + badge text + centered label via ternaries on a
 module-level isPrototype const

 ### Notes

 - No new components or layout changes
 - Only colour/text ternaries in the existing header
 - In future, prototypes and proof of concept branches will have PRs tagged as `DO NOT DEPLOY`