### PR TITLE
Chat UX: human msg scroll-to-top

### DIFF
--- a/app/components/ChatMessages.tsx
+++ b/app/components/ChatMessages.tsx
@@ -9,13 +9,19 @@ import ChatDisclaimer from "./ChatDisclaimer";
 
 function ChatMessages() {
   const containerRef = useRef<HTMLDivElement>(null);
+  const lastUserMessageRef = useRef<HTMLDivElement>(null);
+  const spacerRef = useRef<HTMLDivElement>(null);
   const { messages, isLoading, toolSteps: currentToolSteps } = useChatStore();
   const [displayDisclaimer, setDisplayDisclaimer] = useState(true);
   const shouldAutoScroll = useRef(true);
 
   const scrollToBottom = () => {
     const parent = containerRef.current?.parentElement;
-    if (parent) parent.scrollTop = parent.scrollHeight;
+    if (!parent) return;
+    // Exclude the spacer from the scroll target so auto-scroll lands at the
+    // bottom of real content, not the bottom of blank space.
+    const spacerHeight = spacerRef.current?.offsetHeight ?? 0;
+    parent.scrollTop = parent.scrollHeight - spacerHeight;
   };
 
   // Track whether the user has manually scrolled away from the bottom
@@ -32,10 +38,26 @@ function ChatMessages() {
     return () => parent.removeEventListener("scroll", handleScroll);
   }, []);
 
-  // Always scroll to bottom on new messages or loading state changes
+  // Scroll user message to top on send; scroll to bottom for AI streaming
   useEffect(() => {
-    shouldAutoScroll.current = true;
-    scrollToBottom();
+    const lastMessage = messages[messages.length - 1];
+    if (lastMessage?.type === "user" && lastUserMessageRef.current) {
+      // Pin user message to top. Do NOT re-enable shouldAutoScroll here — the
+      // ResizeObserver would otherwise immediately fire scrollToBottom() when
+      // the 60vh spacer is added, overriding this scroll.
+      shouldAutoScroll.current = false;
+      const parent = containerRef.current?.parentElement;
+      if (parent) {
+        const parentRect = parent.getBoundingClientRect();
+        const msgRect = lastUserMessageRef.current.getBoundingClientRect();
+        parent.scrollTop += msgRect.top - parentRect.top - 16;
+      }
+    } else {
+      // AI streaming or loading state change — re-enable auto-scroll and chase
+      // the bottom as new content streams in.
+      shouldAutoScroll.current = true;
+      scrollToBottom();
+    }
   }, [messages, isLoading]);
 
   // Scroll on content resize only if the user hasn't scrolled away
@@ -52,7 +74,7 @@ function ChatMessages() {
 
   // Show reasoning after the last user message when loading
   const lastUserMessageIndex = messages.findLastIndex(
-    (msg) => msg.type === "user"
+    (msg) => msg.type === "user",
   );
 
   return (
@@ -62,8 +84,11 @@ function ChatMessages() {
         const previousMessage = index > 0 ? messages[index - 1] : null;
         const isConsecutive = previousMessage?.type === message.type;
         const isFirst = index === 0;
+        const isLastUserMessage =
+          index === lastUserMessageIndex && message.type === "user";
         return (
           <Fragment key={message.id}>
+            {isLastUserMessage && <Box ref={lastUserMessageRef} />}
             {isFirst && displayDisclaimer && (
               <ChatDisclaimer
                 type="info"
@@ -74,13 +99,15 @@ function ChatMessages() {
                     <strong>Global Nature Watch preview</strong>
                   </Text>
                   <Text mb={{ base: 1, md: 2 }}>
-                    You&apos;re using a preview version that&apos;s still under active development.
-                    You may encounter errors or incomplete results, so verify results with primary sources.
-                    Features, datasets, and assistant behavior may change or be removed as we iterate.
+                    You&apos;re using a preview version that&apos;s still under
+                    active development. You may encounter errors or incomplete
+                    results, so verify results with primary sources. Features,
+                    datasets, and assistant behavior may change or be removed as
+                    we iterate.
                   </Text>
                   <Text>
-                    By using this preview, you&apos;re helping shape the future of Global Nature Watch.
-                    Share feedback via{" "}
+                    By using this preview, you&apos;re helping shape the future
+                    of Global Nature Watch. Share feedback via{" "}
                     <Link
                       color="primary.solid"
                       textDecor="underline"
@@ -95,8 +122,7 @@ function ChatMessages() {
                       href="mailto:landcarbonlab@wri.org"
                     >
                       landcarbonlab@wri.org
-                    </Link>
-                    {" "}
+                    </Link>{" "}
                     Visit the{" "}
                     <Link
                       color="primary.solid"
@@ -125,8 +151,8 @@ function ChatMessages() {
                 )}
                 {/* Show reasoning for completed queries (user messages with toolSteps) */}
                 {message.toolSteps && message.toolSteps.length > 0 && (
-                  <Reasoning 
-                    toolSteps={message.toolSteps} 
+                  <Reasoning
+                    toolSteps={message.toolSteps}
                     isLoading={false}
                     reasoningDuration={message.reasoningDuration}
                   />
@@ -135,12 +161,11 @@ function ChatMessages() {
             )}
 
             {/* Prompt options for first message, removed when sent */}
-            {messages.length < 2 && (
-              <SamplePrompts />
-            )}
+            {messages.length < 2 && <SamplePrompts />}
           </Fragment>
         );
       })}
+      {isLoading && <Box ref={spacerRef} height="100vh" />}
     </Box>
   );
 }

--- a/app/components/ChatMessages.tsx
+++ b/app/components/ChatMessages.tsx
@@ -15,36 +15,41 @@ function ChatMessages() {
   const [displayDisclaimer, setDisplayDisclaimer] = useState(true);
   const shouldAutoScroll = useRef(true);
 
+  // Scroll to the bottom of real content, ignoring the blank spacer.
   const scrollToBottom = () => {
     const parent = containerRef.current?.parentElement;
     if (!parent) return;
-    // Exclude the spacer from the scroll target so auto-scroll lands at the
-    // bottom of real content, not the bottom of blank space.
     const spacerHeight = spacerRef.current?.offsetHeight ?? 0;
-    parent.scrollTop = parent.scrollHeight - spacerHeight;
+    parent.scrollTop = Math.max(
+      0,
+      parent.scrollHeight - spacerHeight - parent.clientHeight,
+    );
   };
 
-  // Track whether the user has manually scrolled away from the bottom
+  // Track whether the user has manually scrolled away from the bottom.
+  // Subtract spacer height so the spacer doesn't inflate the distance-to-bottom
+  // and falsely mark the user as having scrolled away.
   useEffect(() => {
     const parent = containerRef.current?.parentElement;
     if (!parent) return;
 
     const handleScroll = () => {
+      const spacerHeight = spacerRef.current?.offsetHeight ?? 0;
       const { scrollTop, scrollHeight, clientHeight } = parent;
-      shouldAutoScroll.current = scrollHeight - scrollTop - clientHeight < 100;
+      shouldAutoScroll.current =
+        scrollHeight - spacerHeight - scrollTop - clientHeight < 100;
     };
 
     parent.addEventListener("scroll", handleScroll);
     return () => parent.removeEventListener("scroll", handleScroll);
   }, []);
 
-  // Scroll user message to top on send; scroll to bottom for AI streaming
+  // Pin user message to top on send; re-enable auto-scroll when AI arrives.
   useEffect(() => {
     const lastMessage = messages[messages.length - 1];
     if (lastMessage?.type === "user" && lastUserMessageRef.current) {
-      // Pin user message to top. Do NOT re-enable shouldAutoScroll here — the
-      // ResizeObserver would otherwise immediately fire scrollToBottom() when
-      // the 60vh spacer is added, overriding this scroll.
+      // Lock the viewport at the user message. ResizeObserver is suppressed
+      // (shouldAutoScroll=false) so the spacer addition doesn't scroll us away.
       shouldAutoScroll.current = false;
       const parent = containerRef.current?.parentElement;
       if (parent) {
@@ -53,19 +58,27 @@ function ChatMessages() {
         parent.scrollTop += msgRect.top - parentRect.top - 16;
       }
     } else {
-      // AI streaming or loading state change — re-enable auto-scroll and chase
-      // the bottom as new content streams in.
+      // AI has started or loading ended — re-enable auto-scroll.
+      // Don't call scrollToBottom here; the ResizeObserver will trigger it
+      // once AI content actually overflows the viewport.
       shouldAutoScroll.current = true;
-      scrollToBottom();
     }
   }, [messages, isLoading]);
 
-  // Scroll on content resize only if the user hasn't scrolled away
+  // Scroll on content resize — but only once AI content has grown past the
+  // visible fold. This lets messages fill the blank space before scrolling.
   useEffect(() => {
     if (!containerRef.current) return;
 
     const observer = new ResizeObserver(() => {
-      if (shouldAutoScroll.current) scrollToBottom();
+      const parent = containerRef.current?.parentElement;
+      if (!parent || !shouldAutoScroll.current) return;
+      const spacerHeight = spacerRef.current?.offsetHeight ?? 0;
+      const contentBottom = parent.scrollHeight - spacerHeight;
+      const viewportBottom = parent.scrollTop + parent.clientHeight;
+      if (contentBottom > viewportBottom) {
+        scrollToBottom();
+      }
     });
     observer.observe(containerRef.current);
 


### PR DESCRIPTION
 Improves the chat experience when sending messages and receiving AI responses.  

![backfill-ezgif com-crop](https://github.com/user-attachments/assets/564f1246-f88d-410f-9f29-4bf32856184c)

  - When a user sends a message, the pane scrolls to pin that message at the top,
  leaving blank space below for incoming AI content
  - AI messages stream into that blank space without moving the viewport — the
  view only begins scrolling down once the AI content fills the pane and overflows
  - Fixed scrollToBottom formula to target the bottom of real content, ignoring
  the scroll spacer
  - Fixed manual-scroll detection (shouldAutoScroll) to account for the spacer
  height, preventing it from falsely disabling auto-scroll
  - ResizeObserver now only fires scrollToBottom when content has actually grown
  past the visible fold

This one's for you @faustoperez