### PR TITLE
Hotfix - Remove border on reasoning component

### DIFF
--- a/app/components/Reasoning.tsx
+++ b/app/components/Reasoning.tsx
@@ -65,10 +65,7 @@ function Reasoning({
         justifyContent="flex-start"
         alignItems="center"
         gap="2"
-        border="1px solid"
-        borderColor="border"
         mb={4}
-        rounded="md"
         p={2}
         px={3}
       >
@@ -107,10 +104,7 @@ function Reasoning({
       <Collapsible.Root
         open={isOpen}
         onOpenChange={(e) => setIsOpen(e.open)}
-        border="1px solid"
-        borderColor="border.emphasized"
         mb={4}
-        rounded="md"
         p={2}
         px={3}
       >
@@ -169,9 +163,7 @@ function Reasoning({
                               <Heading as="h3" size="xs" mb={2} {...props} />
                             </>
                           ),
-                          p: ({ ...props }) => (
-                            <Text mb={2} {...props} />
-                          ),
+                          p: ({ ...props }) => <Text mb={2} {...props} />,
                           br: () => <Box h={2} />, // Add spacing for line breaks
                         }}
                       >


### PR DESCRIPTION
Small change to remove the border while keeping the dropdown claret icon (once populated with data)

It feels out of place in the chat pane to see a big reasoning box, so trying to follow Claude-esque patterns.

New:
<img width="560" height="196" alt="Screenshot 2026-03-17 at 6 03 03 PM" src="https://github.com/user-attachments/assets/d0e2682e-2256-49fe-8436-08b46eedb838" />

Any opinions @LanesGood ?