### PR TITLE
Orient and declutter years

### DIFF
--- a/app/components/widgets/ChartWidget.tsx
+++ b/app/components/widgets/ChartWidget.tsx
@@ -269,7 +269,11 @@ export default function ChartWidget({
     type === "scatter" ||
     xAxis?.toLowerCase() === "year" ||
     (formattedData.length > 0 && typeof formattedData[0][xAxis] === "number");
-  const needsAngledTicks = !isNumericXAxis && formattedData.length > 4;
+  const needsAngledTicks =
+    (!isNumericXAxis && formattedData.length > 4) ||
+    (isNumericXAxis && formattedData.length > 10);
+  const xAxisInterval: number | "preserveStartEnd" =
+    isNumericXAxis && formattedData.length > 10 ? "preserveStartEnd" : 0;
 
   const renderChartItems = () => {
     switch (type) {
@@ -415,7 +419,7 @@ export default function ChartWidget({
                 angle={needsAngledTicks ? -35 : 0}
                 textAnchor={needsAngledTicks ? "end" : "middle"}
                 height={needsAngledTicks ? 90 : 40}
-                interval={0}
+                interval={xAxisInterval}
                 fontSize={11}
               >
                 {xAxis && (


### PR DESCRIPTION
Year-based charts with many data points (e.g. 2000–2023) were showing all tick labels at interval={0}, causing them to overlap. Fixed by:                                                                                             
- Using "preserveStartEnd" interval for numeric/year axes with >10 data points
- Extending needsAngledTicks to also apply to dense numeric axes, so year labels render at -35° like categorical   
ones already did      

### Before
<img width="1020" height="560" alt="image" src="https://github.com/user-attachments/assets/00c4a3f2-2795-4132-a622-fc6e6ed2483b" />

### After
<img width="514" height="235" alt="Screenshot 2026-03-20 at 5 55 28 PM" src="https://github.com/user-attachments/assets/6dd6368c-0f69-45dc-ac4f-a4b6b632b64e" />
