### PR TITLE
Add agent sandbox for local API testing       

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,20 @@ pnpm dev
 
 ✨ You can now access the app at [http://localhost:3000](http://localhost:3000)
 
+## Agent Sandbox
+
+A page at `/app/agent-sandbox` that renders the full GNW chat + map UI without authentication. It's intended for backend/agent developers working on [project-zeno](https://github.com/wri/project-zeno) who need to test local API changes against the real frontend.
+
+Point `NEXT_PUBLIC_API_HOST` in your `.env.local` at your local agent, start the dev server, and visit:
+
+```
+http://localhost:3000/app/agent-sandbox
+```
+
+No login required. The page is not available in production.
+
+See [`app/app/agent-sandbox/README.md`](app/app/agent-sandbox/README.md) for full usage details.
+
 ## Chart Debug Page
 
 A hidden page at `/chart-debug` renders every chart and table widget type with representative dummy data. Use it to visually QA chart rendering, test new features, and catch regressions.

--- a/app/ChatPanelHeader.tsx
+++ b/app/ChatPanelHeader.tsx
@@ -25,6 +25,7 @@ import Link from "next/link";
 import { Tooltip } from "./components/ui/tooltip";
 import useSidebarStore from "./store/sidebarStore";
 import useChatStore from "./store/chatStore";
+import { EraserIcon } from "@phosphor-icons/react";
 import ThreadActionsMenu from "./components/ThreadActionsMenu";
 import { sendGAEvent } from "@next/third-parties/google";
 
@@ -47,7 +48,7 @@ function ChatPanelHeader() {
     toggleSidebar,
     getThreadById,
   } = useSidebarStore();
-  const { currentThreadId, messages } = useChatStore();
+  const { currentThreadId, messages, isDevPrototype } = useChatStore();
 
   const currentThread = getThreadById(currentThreadId);
   const currentThreadName = currentThread
@@ -99,7 +100,7 @@ function ChatPanelHeader() {
       hideBelow="md"
       zIndex={100}
     >
-      {!sideBarVisible && (
+      {!isDevPrototype && !sideBarVisible && (
         <Tooltip
           content="Open sidebar"
           positioning={{ placement: "right" }}
@@ -273,7 +274,19 @@ function ChatPanelHeader() {
           </Portal>
         </Menu.Root>
       )}
-      {!sideBarVisible && (
+      {isDevPrototype && (
+        <Tooltip content="Clear conversation" showArrow>
+          <IconButton
+            variant="ghost"
+            size="sm"
+            aria-label="Clear conversation"
+            onClick={() => useChatStore.getState().devProtoClear?.()}
+          >
+            <EraserIcon />
+          </IconButton>
+        </Tooltip>
+      )}
+      {!isDevPrototype && !sideBarVisible && (
         <Tooltip content="New conversation" showArrow>
           <IconButton asChild variant="ghost" size="sm">
             <Link href="/app" aria-label="New conversation">

--- a/app/app/agent-sandbox/README.md
+++ b/app/app/agent-sandbox/README.md
@@ -1,0 +1,38 @@
+# Agent Sandbox
+
+A stripped-down, auth-free version of the main GNW app UI, intended for backend/agent developers working on [project-zeno](https://github.com/wri/project-zeno) who need to test local API changes against the real frontend without setting up auth.
+
+## What it does
+
+- Renders the full chat + map UI (same `ChatPanel` and `Map` components as the main app)
+- Routes all API requests to `NEXT_PUBLIC_API_HOST` in your `.env.local`
+- Bypasses authentication — no login required, no session, no prompt limits
+- Resets all stores on mount so you always start from a clean state
+
+## What it doesn't do
+
+- It is **not** a testing harness for frontend code — use the main app or `chart-debug` for that
+- It does **not** mock the API — it talks to a real backend, just whichever one you point it at
+- It is **not** available in production (tree-shaken at build time via `NODE_ENV` guard + middleware exemption)
+
+## How to use
+
+1. Point `NEXT_PUBLIC_API_HOST` at your local agent in `.env.local`:
+
+   ```
+   NEXT_PUBLIC_API_HOST=http://localhost:8000
+   ```
+
+2. Start the dev server:
+
+   ```sh
+   pnpm dev
+   ```
+
+3. Visit [http://localhost:3000/app/agent-sandbox](http://localhost:3000/app/agent-sandbox)
+
+The header shows an **AGENT SANDBOX** badge so it's clear you're not in the main app. The system message in the chat confirms which API host is being used.
+
+## How auth is bypassed
+
+The middleware exempts `/app/agent-sandbox` from the normal auth check — no env var toggle needed. The production guard (`NODE_ENV === "production"`) ensures the page renders nothing if it somehow reaches a production build.

--- a/app/app/agent-sandbox/page.tsx
+++ b/app/app/agent-sandbox/page.tsx
@@ -14,7 +14,7 @@ import { usePromptStore } from "@/app/store/promptStore";
 import { API_CONFIG } from "@/app/config/api";
 
 const PROTO_MESSAGE = [
-  "**API Dev prototype** — no auth required.",
+  "**Agent sandbox** — no auth required.",
   "",
   `Requests go to \`${API_CONFIG.API_HOST}\` via \`NEXT_PUBLIC_API_HOST\` in \`.env.local\`.`,
   "",
@@ -22,6 +22,11 @@ const PROTO_MESSAGE = [
 ].join("\n");
 
 export default function ApiDevPrototype() {
+  // Guard: only available in development.
+  // Auth is bypassed via the middleware exemption for /app/agent-sandbox (not via an env var).
+  // process.env.NODE_ENV is inlined at build time by Next.js, so this tree-shakes in production.
+  if (process.env.NODE_ENV === "production") return null;
+
   useEffect(() => {
     const savedPrompts = usePromptStore.getState().prompts;
 
@@ -29,8 +34,8 @@ export default function ApiDevPrototype() {
       useChatStore.setState({
         messages: [{ id: "proto-init", type: "system", message: PROTO_MESSAGE, timestamp: new Date().toISOString() }],
         isDevPrototype: true,
-        devProtoClear: applyProtoState,
       });
+      useChatStore.getState().setDevProtoClear(applyProtoState);
       usePromptStore.setState({ prompts: [] });
     };
 
@@ -41,7 +46,8 @@ export default function ApiDevPrototype() {
     applyProtoState();
 
     return () => {
-      useChatStore.setState({ isDevPrototype: false, devProtoClear: null });
+      useChatStore.setState({ isDevPrototype: false });
+      useChatStore.getState().setDevProtoClear(null);
       usePromptStore.setState({ prompts: savedPrompts });
     };
   }, []);
@@ -77,7 +83,7 @@ export default function ApiDevPrototype() {
             variant="solid"
             size="xs"
           >
-            API DEV
+            AGENT SANDBOX
           </Badge>
         </Flex>
       </Flex>

--- a/app/app/api-dev/page.tsx
+++ b/app/app/api-dev/page.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import "maplibre-gl/dist/maplibre-gl.css";
+import { useEffect } from "react";
+import { Flex, Grid, Heading, Badge } from "@chakra-ui/react";
+import ChatPanel from "@/app/ChatPanel";
+import Map from "@/app/components/Map";
+import LclLogo from "@/app/components/LclLogo";
+import useAuthStore from "@/app/store/authStore";
+import useChatStore from "@/app/store/chatStore";
+import useMapStore from "@/app/store/mapStore";
+import useContextStore from "@/app/store/contextStore";
+import { usePromptStore } from "@/app/store/promptStore";
+import { API_CONFIG } from "@/app/config/api";
+
+const PROTO_MESSAGE = [
+  "**API Dev prototype** — no auth required.",
+  "",
+  `Requests go to \`${API_CONFIG.API_HOST}\` via \`NEXT_PUBLIC_API_HOST\` in \`.env.local\`.`,
+  "",
+  "All map tools work normally: AOIs render on the map, datasets load as tile layers, and chart insights appear inline.",
+].join("\n");
+
+export default function ApiDevPrototype() {
+  useEffect(() => {
+    const savedPrompts = usePromptStore.getState().prompts;
+
+    const applyProtoState = () => {
+      useChatStore.setState({
+        messages: [{ id: "proto-init", type: "system", message: PROTO_MESSAGE, timestamp: new Date().toISOString() }],
+        isDevPrototype: true,
+        devProtoClear: applyProtoState,
+      });
+      usePromptStore.setState({ prompts: [] });
+    };
+
+    useChatStore.getState().reset();
+    useMapStore.getState().reset();
+    useContextStore.getState().reset();
+    useAuthStore.getState().setPromptUsage(0, 999999);
+    applyProtoState();
+
+    return () => {
+      useChatStore.setState({ isDevPrototype: false, devProtoClear: null });
+      usePromptStore.setState({ prompts: savedPrompts });
+    };
+  }, []);
+
+  return (
+    <Grid
+      maxH="min(100dvh, 100vh)"
+      h="min(100dvh, 100vh)"
+      templateRows="min-content minmax(0px, 1fr)"
+      bg="bg"
+    >
+      {/* Header */}
+      <Flex
+        alignItems="center"
+        justifyContent="space-between"
+        px={5}
+        py="2"
+        h={12}
+        bg="primary.solid"
+        color="fg.inverted"
+        zIndex={1300}
+        position="relative"
+      >
+        <Flex gap="2" alignItems="center">
+          <LclLogo width={16} avatarOnly fill="white" />
+          <Heading as="h1" size="sm" color="fg.inverted">
+            Global Nature Watch
+          </Heading>
+          <Badge
+            colorPalette="primary"
+            bg="primary.800"
+            letterSpacing="wider"
+            variant="solid"
+            size="xs"
+          >
+            API DEV
+          </Badge>
+        </Flex>
+      </Flex>
+
+      {/* Chat + Map — same grid pattern as the main app */}
+      <Grid
+        templateColumns="min-content 1fr"
+        templateAreas="'chat map'"
+        templateRows="1fr"
+        maxH="calc(100vh - 3rem)"
+      >
+        <ChatPanel />
+        <Map disableMapAreaControls />
+      </Grid>
+    </Grid>
+  );
+}

--- a/app/components/ChatInput.tsx
+++ b/app/components/ChatInput.tsx
@@ -40,7 +40,7 @@ export default function ChatInput({
 
   const [focusEl, setFocusEl] = useState<HTMLTextAreaElement | null>(null);
 
-  const { sendMessage, isLoading } = useChatStore();
+  const { sendMessage, isLoading, isDevPrototype } = useChatStore();
   const { context, removeContext } = useContextStore();
 
   const openContextMenu = (type: ChatContextType) => {
@@ -65,7 +65,7 @@ export default function ChatInput({
     }
 
     const result = await sendMessage(message);
-    if (result.isNew) {
+    if (result.isNew && !isDevPrototype) {
       router.replace(`/app/threads/${result.id}`);
     }
   };

--- a/app/components/ChatMessages.tsx
+++ b/app/components/ChatMessages.tsx
@@ -1,6 +1,8 @@
 "use client";
 import { Fragment, useState, useEffect, useRef } from "react";
 import { Box, Text, Link } from "@chakra-ui/react";
+import Markdown from "react-markdown";
+import remarkBreaks from "remark-breaks";
 import useChatStore from "@/app/store/chatStore";
 import MessageBubble from "./MessageBubble";
 import Reasoning from "./Reasoning";
@@ -11,7 +13,7 @@ function ChatMessages() {
   const containerRef = useRef<HTMLDivElement>(null);
   const lastUserMessageRef = useRef<HTMLDivElement>(null);
   const spacerRef = useRef<HTMLDivElement>(null);
-  const { messages, isLoading, toolSteps: currentToolSteps } = useChatStore();
+  const { messages, isLoading, toolSteps: currentToolSteps, isDevPrototype } = useChatStore();
   const [displayDisclaimer, setDisplayDisclaimer] = useState(true);
   const shouldAutoScroll = useRef(true);
 
@@ -102,7 +104,7 @@ function ChatMessages() {
         return (
           <Fragment key={message.id}>
             {isLastUserMessage && <Box ref={lastUserMessageRef} />}
-            {isFirst && displayDisclaimer && (
+            {isFirst && displayDisclaimer && !isDevPrototype && (
               <ChatDisclaimer
                 type="info"
                 setDisplayDisclaimer={setDisplayDisclaimer}
@@ -151,11 +153,17 @@ function ChatMessages() {
                 </Box>
               </ChatDisclaimer>
             )}
-            <MessageBubble
-              message={message}
-              isConsecutive={isConsecutive}
-              isFirst={isFirst}
-            />
+            {isFirst && isDevPrototype ? (
+              <ChatDisclaimer type="warning" my={4} mb={6}>
+                <Markdown remarkPlugins={[remarkBreaks]}>{message.message}</Markdown>
+              </ChatDisclaimer>
+            ) : (
+              <MessageBubble
+                message={message}
+                isConsecutive={isConsecutive}
+                isFirst={isFirst}
+              />
+            )}
             {message.type === "user" && (
               <>
                 {/* Show reasoning for current loading query (last user message) */}

--- a/app/components/WidgetMessage.tsx
+++ b/app/components/WidgetMessage.tsx
@@ -107,9 +107,11 @@ export default function WidgetMessage({ widget }: WidgetMessageProps) {
       <Flex gap={3} px={4} py={3} flexDir="column">
         {hasData && (
           <>
-            <Text fontSize="xs" color="fg.muted">
-              {widget.description}
-            </Text>
+            {widget.description && (
+              <Text fontSize="xs" color="fg.muted">
+                {widget.description}
+              </Text>
+            )}
             <Separator />
           </>
         )}

--- a/app/components/widgets/ChartWidget.tsx
+++ b/app/components/widgets/ChartWidget.tsx
@@ -440,21 +440,8 @@ export default function ChartWidget({
                 axisLine={false}
                 tickLine={false}
                 domain={["auto", "auto"]}
-              >
-                {yAxis && (
-                  <Label
-                    value={toAxisLabel(yAxis)}
-                    angle={-90}
-                    position="insideLeft"
-                    offset={10}
-                    style={{
-                      fontSize: 11,
-                      fill: "var(--chakra-colors-fg-muted)",
-                      textAnchor: "middle",
-                    }}
-                  />
-                )}
-              </YAxis>
+                width={65}
+              />
             </>
           )}
           <Tooltip

--- a/app/store/chat-tools/generateInsights.ts
+++ b/app/store/chat-tools/generateInsights.ts
@@ -4,7 +4,6 @@ interface ChartData {
   id: string;
   title: string;
   type: "line" | "bar" | "table";
-  insight: string;
   data: unknown;
   xAxis: string;
   yAxis: string;
@@ -24,7 +23,7 @@ export function generateInsightsTool(
       ).map((chart: ChartData) => ({
         type: chart.type,
         title: chart.title,
-        description: chart.insight,
+        description: "",
         data: chart.data,
         xAxis: chart.xAxis,
         yAxis: chart.yAxis,

--- a/app/store/chatStore.ts
+++ b/app/store/chatStore.ts
@@ -32,6 +32,8 @@ interface ChatState {
   toolSteps: ToolStepData[];
   pendingTraceId: string | null;
   reasoningStartTime: number | null; // Timestamp when reasoning started
+  isDevPrototype: boolean;
+  devProtoClear: (() => void) | null;
 }
 
 interface ChatActions {
@@ -73,6 +75,8 @@ const initialState: ChatState = {
   toolSteps: [],
   pendingTraceId: null,
   reasoningStartTime: null,
+  isDevPrototype: false,
+  devProtoClear: null,
 };
 
 // Helper function to process stream messages and add them to chat
@@ -145,7 +149,7 @@ async function processStreamMessage(
     }
 
     // Special handling for generate_insights tool
-    if (streamMessage.name === "generate_insights" && streamMessage.insights) {
+    if (streamMessage.name === "generate_insights" && streamMessage.charts_data) {
       // Non-blocking: do not await tool side-effects
       void Promise.resolve().then(() =>
         generateInsightsTool(streamMessage, addMessage)

--- a/app/store/chatStore.ts
+++ b/app/store/chatStore.ts
@@ -54,6 +54,7 @@ interface ChatActions {
   addToolStep: (toolData: StreamMessage) => void;
   clearToolSteps: () => void;
   attachToolStepsToLastUserMessage: (durationOverride?: number) => void;
+  setDevProtoClear: (fn: (() => void) | null) => void;
 }
 
 const initialState: ChatState = {
@@ -472,6 +473,8 @@ const useChatStore = create<ChatState & ChatActions>((set, get) => ({
   },
 
   clearToolSteps: () => set({ toolSteps: [] }),
+
+  setDevProtoClear: (fn) => set({ devProtoClear: fn }),
 
   attachToolStepsToLastUserMessage: (durationOverride?: number) => {
     set((state) => {

--- a/middleware.ts
+++ b/middleware.ts
@@ -38,7 +38,8 @@ export async function middleware(request: NextRequest) {
 
   // General guard for /app, /onboarding, and /dashboard
   const isOnboarding = pathname.startsWith("/onboarding");
-  const isApp = pathname.startsWith("/app");
+  const isApp =
+    pathname.startsWith("/app") && !pathname.startsWith("/app/api-dev");
   const isDashboard = pathname.startsWith("/dashboard");
 
   if (isOnboarding || isApp || isDashboard) {

--- a/middleware.ts
+++ b/middleware.ts
@@ -39,7 +39,7 @@ export async function middleware(request: NextRequest) {
   // General guard for /app, /onboarding, and /dashboard
   const isOnboarding = pathname.startsWith("/onboarding");
   const isApp =
-    pathname.startsWith("/app") && !pathname.startsWith("/app/api-dev");
+    pathname.startsWith("/app") && !pathname.startsWith("/app/agent-sandbox");
   const isDashboard = pathname.startsWith("/dashboard");
 
   if (isOnboarding || isApp || isDashboard) {


### PR DESCRIPTION
## Summary
                                                                                                 
Adds an auth-free route at `/app/agent-sandbox` that renders the full GNW chat + map UI against a  
configurable API host. Intended for project-zeno backend developers who need to test local agent 
changes against the real frontend without setting up auth or a user account.

<img width="1465" height="854" alt="Screenshot 2026-03-31 at 09 43 08" src="https://github.com/user-attachments/assets/deeedd2d-b4ba-47f0-8df6-89d0ef4c66ee" />

As such this remove all user-based features for this page: conversation threads, prompt quotas, login etc are all gone.
                                                                                 
## What's in this PR                                                                                

- New route at /app/agent-sandbox — full ChatPanel + Map, no auth, stores reset on mount         
- Middleware exempts /app/agent-sandbox from the auth guard
- Production guard (NODE_ENV === "production") tree-shakes the page from prod builds             
- README.md updated with usage instructions; inline app/app/agent-sandbox/README.md for deeper   
docs                                                                                             
                                                          
## How to use                                                                                       
Add `.env.local` with `NEXT_PUBLIC_API_HOST=http://localhost:8000` (or whatever port your local API runs on)
                                                                                                 
Then go to `http://localhost:3000/app/agent-sandbox`. No login needed!                            