### PR TITLE
Remove generative description text from insight chart widgets               

### DIFF
--- a/app/components/WidgetMessage.tsx
+++ b/app/components/WidgetMessage.tsx
@@ -2,7 +2,6 @@
 import { useState } from "react";
 import {
   Box,
-  Text,
   Heading,
   Flex,
   Separator,
@@ -105,14 +104,7 @@ export default function WidgetMessage({ widget }: WidgetMessageProps) {
         </Heading>
       </Flex>
       <Flex gap={3} px={4} py={3} flexDir="column">
-        {hasData && (
-          <>
-            <Text fontSize="xs" color="fg.muted">
-              {widget.description}
-            </Text>
-            <Separator />
-          </>
-        )}
+        {hasData && <Separator />}
         {/* Toolbar row — segmented toggle + full-screen */}
         <Flex justify="flex-start" gap={2} flexWrap="wrap" align="center">
           {/* Segmented Chart / Table toggle */}
@@ -262,11 +254,6 @@ export default function WidgetMessage({ widget }: WidgetMessageProps) {
                   </Dialog.CloseTrigger>
                 </Dialog.Header>
                 <Dialog.Body px={0} pb={0}>
-                  {widget.description && (
-                    <Text fontSize="xs" color="fg.muted" mb={3}>
-                      {widget.description}
-                    </Text>
-                  )}
                   <WidgetErrorBoundary fallbackTitle="Unable to render chart">
                     <ChartWidget widget={widget} expanded />
                   </WidgetErrorBoundary>


### PR DESCRIPTION
Insight text and Chat text currently diverge (resulting in a few bug reports). Easy fix is to remove the former.

<img width="509" height="671" alt="Screenshot 2026-04-08 at 13 48 31" src="https://github.com/user-attachments/assets/fc632ad9-7e31-49b7-9d4e-2b42c101a4ec" />

Removes the AI-generated description text that appeared above charts in the Insight component so that the separator and chart toolbar now render directly without the interpretive text block.
                                                                                                   
Applies to both the inline view and the expanded full-screen dialog.  