### PR TITLE
Enable Global Queries

### DIFF
--- a/app/components/DebugToastsPanel.tsx
+++ b/app/components/DebugToastsPanel.tsx
@@ -8,11 +8,38 @@ import {
   showServiceUnavailableError,
 } from "@/app/hooks/useErrorHandler";
 import { toaster } from "@/app/components/ui/toaster";
+import { pickAoiTool } from "@/app/store/chat-tools/pickAoi";
+import useMapStore from "@/app/store/mapStore";
+
+const GLOBAL_LAYER_ID = "global-layer";
 
 function DebugToastsPanel({ enabled }: { enabled?: boolean }) {
   const envEnabled = process.env.NEXT_PUBLIC_ENABLE_DEBUG_TOOLS === "true";
   const active = enabled ?? envEnabled;
   const [dismissed, setDismissed] = useState(false);
+  const layers = useMapStore((s) => s.layers);
+  const removeLayer = useMapStore((s) => s.removeLayer);
+
+  const globalLayerActive = layers.some((l) => l.id === GLOBAL_LAYER_ID);
+
+  const handleToggleGlobalLayer = () => {
+    if (globalLayerActive) {
+      removeLayer(GLOBAL_LAYER_ID);
+    } else {
+      pickAoiTool(
+        {
+          type: "tool",
+          name: "pick_aoi",
+          timestamp: new Date().toISOString(),
+          aoi_selection: {
+            name: "All countries in the world",
+            aois: [],
+          },
+        },
+        () => {},
+      );
+    }
+  };
 
   if (!active || dismissed) return null;
 
@@ -36,6 +63,14 @@ function DebugToastsPanel({ enabled }: { enabled?: boolean }) {
         <CloseButton size="2xs" onClick={() => setDismissed(true)} />
       </Box>
       <Stack direction="row" gap="2" wrap="wrap">
+        <Button
+          size="xs"
+          colorPalette={globalLayerActive ? "red" : "blue"}
+          variant="subtle"
+          onClick={handleToggleGlobalLayer}
+        >
+          {globalLayerActive ? "Remove Global Layer" : "Toggle Global Layer"}
+        </Button>
         <Button
           size="xs"
           onClick={() => showServiceUnavailableError("Demo Service")}

--- a/app/components/Map.tsx
+++ b/app/components/Map.tsx
@@ -24,6 +24,7 @@ import useMapStore from "@/app/store/mapStore";
 import MapAreaControls from "./MapAreaControls";
 import useContextStore from "@/app/store/contextStore";
 import DynamicTileLayers from "./map/layers/DynamicTileLayers";
+import VectorTileLayers from "./map/layers/VectorTileLayers";
 import SelectAreaLayer from "./map/layers/select-area-layer";
 import { useLegendHook } from "@/app/components/legend/useLegendHook";
 import GeoJsonLayers from "./map/layers/GeoJsonLayers";
@@ -163,6 +164,7 @@ function Map({ disableMapAreaControls }: { disableMapAreaControls?: boolean }) {
         </Box>
 
         <DynamicTileLayers />
+        <VectorTileLayers areas={areas} />
         <GeoJsonLayers areas={areas} />
         <SelectAreaLayer />
 

--- a/app/components/legend/useLegendHook.tsx
+++ b/app/components/legend/useLegendHook.tsx
@@ -19,7 +19,7 @@ export function useLegendHook() {
 
   useEffect(() => {
     const legendLayers: LegendLayer[] = managedLayers.flatMap(layer => {
-      if (layer.type === "geojson") {
+      if (layer.type === "geojson" || layer.type === "vector") {
         return {
           id: layer.id,
           title: layer.selectionName ?? layer.name,

--- a/app/components/map/layers/VectorTileLayers.tsx
+++ b/app/components/map/layers/VectorTileLayers.tsx
@@ -1,0 +1,87 @@
+import { useMemo } from "react";
+import { Layer, Source } from "react-map-gl/maplibre";
+import useMapStore from "@/app/store/mapStore";
+import type { Layer as ManagedLayer } from "@/app/store/layerManagerSlice";
+import type { ContextItem } from "@/app/store/contextStore";
+
+interface VectorTileLayersProps {
+  areas: ContextItem[];
+}
+
+/**
+ * Renders managed vector tile (MVT/PBF) layers from the layer store.
+ * Applies context-aware styling: blue when the layer is the active area
+ * context, gray otherwise — consistent with GeoJsonLayers.
+ */
+function VectorTileLayers({ areas }: VectorTileLayersProps) {
+  const allLayers = useMapStore((s) => s.layers);
+  const vectorLayers = useMemo(
+    () =>
+      allLayers.filter(
+        (l): l is ManagedLayer & { tileUrl: string; sourceLayer: string } =>
+          l.type === "vector" && !!l.tileUrl && !!l.sourceLayer,
+      ),
+    [allLayers],
+  );
+
+  return (
+    <>
+      {vectorLayers.map((layer) => {
+        const sourceId = `vector-tile-source-${layer.id}`;
+        const fillLayerId = `vector-tile-fill-${layer.id}`;
+        const lineLayerId = `vector-tile-line-${layer.id}`;
+
+        const isInContext = areas.some(
+          (a) =>
+            a.aoiSelection?.name === layer.name || a.content === layer.name,
+        );
+
+        const lineColor = isInContext ? "#8EA4E8" : "#666E7B";
+        const lineOpacity = !layer.visible ? 0 : isInContext ? 1 : 0.5;
+        const opacity = layer.opacity ?? 1;
+
+        return (
+          <Source
+            key={layer.id}
+            id={sourceId}
+            type="vector"
+            tiles={[layer.tileUrl]}
+          >
+            {/* Subtle fill to make features selectable visually */}
+            <Layer
+              id={fillLayerId}
+              type="fill"
+              source-layer={layer.sourceLayer}
+              paint={{
+                "fill-color": lineColor,
+                "fill-opacity": isInContext ? 0.06 * opacity : 0,
+              }}
+            />
+            <Layer
+              id={lineLayerId}
+              type="line"
+              source-layer={layer.sourceLayer}
+              paint={{
+                "line-color": lineColor,
+                "line-width": [
+                  "interpolate",
+                  ["linear"],
+                  ["zoom"],
+                  2,
+                  0.4,
+                  6,
+                  0.8,
+                  10,
+                  1.5,
+                ],
+                "line-opacity": lineOpacity * opacity,
+              }}
+            />
+          </Source>
+        );
+      })}
+    </>
+  );
+}
+
+export default VectorTileLayers;

--- a/app/store/chat-tools/pickAoi.ts
+++ b/app/store/chat-tools/pickAoi.ts
@@ -59,10 +59,6 @@ export async function pickAoiTool(
     const aois: AOI[] = aoiSelection?.aois ?? (streamMessage.aoi ? [streamMessage.aoi as AOI] : []);
     const selectionName: string = aoiSelection?.name ?? (aois[0]?.name || "Unknown");
 
-    if (aois.length === 0) {
-      throw new Error("No AOI data found in stream message");
-    }
-
     // Global query: render a vector tile layer instead of fetching per-country GeoJSON
     if (isGlobalQuery(selectionName)) {
       const gadm = selectLayerOptions.find((o) => o.id === "GADM")!;
@@ -96,6 +92,10 @@ export async function pickAoiTool(
       });
 
       return;
+    }
+
+    if (aois.length === 0) {
+      throw new Error("No AOI data found in stream message");
     }
 
     // Build an AOISelection to store on the context (even for single-AOI fallback)

--- a/app/store/chat-tools/pickAoi.ts
+++ b/app/store/chat-tools/pickAoi.ts
@@ -5,6 +5,14 @@ import useContextStore from "../contextStore";
 import { fetchGeometry } from "@/app/utils/geometryClient";
 import bbox from "@turf/bbox";
 import { GeoJsonEntry } from "../layerManagerSlice";
+import { selectLayerOptions } from "@/app/types/map";
+
+const GLOBAL_LAYER_ID = "global-layer";
+const GLOBAL_LAYER_NAME = "Global Layer";
+
+function isGlobalQuery(name: string): boolean {
+  return name.toLowerCase() === "all countries in the world";
+}
 
 /**
  * Fetch geometry for a single AOI and add it to the layer manager
@@ -53,6 +61,41 @@ export async function pickAoiTool(
 
     if (aois.length === 0) {
       throw new Error("No AOI data found in stream message");
+    }
+
+    // Global query: render a vector tile layer instead of fetching per-country GeoJSON
+    if (isGlobalQuery(selectionName)) {
+      const gadm = selectLayerOptions.find((o) => o.id === "GADM")!;
+      const worldBbox: Feature = {
+        type: "Feature",
+        properties: {},
+        geometry: {
+          type: "Polygon",
+          coordinates: [[
+            [-180, -85], [180, -85], [180, 85], [-180, 85], [-180, -85],
+          ]],
+        },
+      };
+
+      addLayer({
+        id: GLOBAL_LAYER_ID,
+        name: GLOBAL_LAYER_NAME,
+        type: "vector",
+        visible: true,
+        tileUrl: gadm.url,
+        sourceLayer: gadm.sourceLayer,
+      });
+
+      flyToGeoJsonWithRetry(worldBbox);
+
+      upsertContextByType({
+        contextType: "area",
+        content: GLOBAL_LAYER_NAME,
+        isAiContext: true,
+        aoiSelection: aoiSelection ?? { name: GLOBAL_LAYER_NAME, aois },
+      });
+
+      return;
     }
 
     // Build an AOISelection to store on the context (even for single-AOI fallback)

--- a/app/store/layerManagerSlice.ts
+++ b/app/store/layerManagerSlice.ts
@@ -16,7 +16,7 @@ export interface GeoJsonEntry {
   subtype?: string;
 }
 
-export type LayerType = "raster" | "geojson";
+export type LayerType = "raster" | "geojson" | "vector";
 
 export interface Layer {
   id: string;
@@ -25,6 +25,7 @@ export interface Layer {
   visible: boolean;
   opacity?: number;
   tileUrl?: string;
+  sourceLayer?: string;
   featureRefs?: FeatureRef[];
   selectionName?: string;
   aoiSelection?: AOISelection;


### PR DESCRIPTION
This PR enables global queries to solve #448 

- detects an aoi selection name "all countries in the world"
- adds a togglable global layer in the layer manager and zooms out to extent which is also added in the context
- you can test it by adding `?debug=1` in the URL

One nitpick here: if a global layer is added by the LLM, it's added to the context as "Global Layer". However if the user removes the Global Layer from the context by clicking the context chip, there's no good way of adding it again because we are not going to add a clickable bounding box over the whole world. I'm not sure how to solve this but we need to think about the whole area / context chip section @faustoperez for bringing back deselected areas.