### PR TITLE
Adds a transparent sentinel layer before DynamicTileLayers in Map.tsx.

### DIFF
--- a/app/components/Map.tsx
+++ b/app/components/Map.tsx
@@ -23,7 +23,9 @@ import { ListDashesIcon, PlusIcon, XIcon } from "@phosphor-icons/react";
 import useMapStore from "@/app/store/mapStore";
 import MapAreaControls from "./MapAreaControls";
 import useContextStore from "@/app/store/contextStore";
-import DynamicTileLayers from "./map/layers/DynamicTileLayers";
+import DynamicTileLayers, {
+  RASTER_TOP_SENTINEL_ID,
+} from "./map/layers/DynamicTileLayers";
 import VectorTileLayers from "./map/layers/VectorTileLayers";
 import SelectAreaLayer from "./map/layers/select-area-layer";
 import { useLegendHook } from "@/app/components/legend/useLegendHook";
@@ -38,7 +40,7 @@ function Map({ disableMapAreaControls }: { disableMapAreaControls?: boolean }) {
   const [showLegend, setShowLegend] = useState(false);
   const isMobile = useBreakpointValue({ base: true, md: false });
   const [basemapTiles, setBasemapTiles] = useState(
-    "devseed/cmazl5ws500bz01scaa27dqi4"
+    "devseed/cmazl5ws500bz01scaa27dqi4",
   );
   const { setMapRef, initializeTerraDraw } = useMapStore();
   const { layers, handleLayerAction } = useLegendHook();
@@ -163,6 +165,16 @@ function Map({ disableMapAreaControls }: { disableMapAreaControls?: boolean }) {
           <Legend layers={layers} onLayerAction={handleLayerAction} />
         </Box>
 
+        {/* Sentinel layer: caps raster layers below AOI/GeoJSON outlines.
+            Must be added before DynamicTileLayers so the sentinel exists
+            when the topmost raster layer references it as beforeId. */}
+        <Source
+          id="raster-top-sentinel-source"
+          type="geojson"
+          data={{ type: "FeatureCollection", features: [] }}
+        >
+          <Layer id={RASTER_TOP_SENTINEL_ID} type="line" paint={{}} />
+        </Source>
         <DynamicTileLayers />
         <VectorTileLayers areas={areas} />
         <GeoJsonLayers areas={areas} />

--- a/app/components/map/layers/DynamicTileLayers.tsx
+++ b/app/components/map/layers/DynamicTileLayers.tsx
@@ -3,6 +3,11 @@ import { Layer, Source } from "react-map-gl/maplibre";
 import useMapStore from "@/app/store/mapStore";
 import type { Layer as ManagedLayer } from "@/app/store/layerManagerSlice";
 
+// Sentinel layer ID used to cap raster layers below GeoJSON/AOI layers.
+// Map.tsx adds this sentinel layer before DynamicTileLayers so it exists
+// when the first raster layer references it as beforeId.
+export const RASTER_TOP_SENTINEL_ID = "raster-top-sentinel";
+
 function layerId(id: string) {
   return `tile-layer-${id}`;
 }
@@ -18,10 +23,12 @@ function layerId(id: string) {
 function DynamicTileLayers() {
   const allLayers = useMapStore((s) => s.layers);
   const rasterLayers = useMemo(
-    () => allLayers.filter(
-      (l): l is ManagedLayer & { tileUrl: string } => l.type === "raster" && !!l.tileUrl
-    ),
-    [allLayers]
+    () =>
+      allLayers.filter(
+        (l): l is ManagedLayer & { tileUrl: string } =>
+          l.type === "raster" && !!l.tileUrl,
+      ),
+    [allLayers],
   );
 
   return (
@@ -30,12 +37,13 @@ function DynamicTileLayers() {
         const id = layerId(rasterLayer.id);
 
         // Place this layer below the previous one in the array.
-        // rasterLayers[0] has no beforeId (topmost).
+        // rasterLayers[0] is anchored below the sentinel (so GeoJSON/AOI layers
+        // added after the sentinel remain on top).
         // rasterLayers[1] has beforeId = rasterLayers[0]'s id (placed below it).
         const aboveLayer = index > 0 ? rasterLayers[index - 1] : undefined;
         const beforeId = aboveLayer
           ? layerId(aboveLayer.id)
-          : undefined;
+          : RASTER_TOP_SENTINEL_ID;
 
         return (
           <Source
@@ -51,7 +59,7 @@ function DynamicTileLayers() {
               beforeId={beforeId}
               paint={{
                 "raster-opacity": rasterLayer.visible
-                  ? rasterLayer.opacity ?? 0.8
+                  ? (rasterLayer.opacity ?? 0.8)
                   : 0,
               }}
             />


### PR DESCRIPTION
## Summary                                                                      
                                                                             
- Adds an invisible sentinel layer in Map.tsx between the basemap and        
DynamicTileLayers                                                            
- Updates DynamicTileLayers to anchor the topmost raster layer below the     
sentinel via beforeId, instead of leaving it undefined                       
- GeoJSON/AOI layers (added after, without beforeId) naturally sit above
everything                                                                   
                                                          
## Why                                                                          
                                                          
When beforeId is undefined, MapLibre appends the layer to the very top of the
 stack, overriding JSX render order. This caused dataset raster layers (e.g.
SBTN Natural Lands Map) to obscure AOI outlines like country borders.        
                                                          
Z-order after fix: basemap → raster layers → sentinel → AOI/GeoJSON outlines 
 
## Test plan                                                                    
                                                          
- Load a dataset raster layer (e.g. SBTN Natural Lands Map) via the AI       
- Confirm the AOI outline (e.g. Bolivia border) is visible on top of the
raster tile                                                                  
- Add multiple raster layers — confirm legend order matches map z-order
- Toggle raster layer visibility — confirm no z-order regression             
                                                                             
Closes #446