### PR TITLE
Fix bbox for antimeridian crossings

### DIFF
--- a/app/components/map/layers/GeoJsonLayers.tsx
+++ b/app/components/map/layers/GeoJsonLayers.tsx
@@ -16,6 +16,7 @@ import {
   FeatureRef,
 } from "@/app/store/layerManagerSlice";
 import bbox from "@turf/bbox";
+import { unionAoiBboxes } from "@/app/utils/bboxUtils";
 
 // Create a rectangle polygon from bbox coordinates
 function createBboxPolygon(
@@ -196,18 +197,10 @@ function GeoJsonLayerGroup({ layer, entries, areas }: GeoJsonLayerGroupProps) {
   // Prefer backend-provided bbox (handles antimeridian); fall back to turf.
   const bboxCoords: [number, number, number, number] | null = (() => {
     const aois = layer.aoiSelection?.aois;
-    if (aois && aois.length > 0 && aois.every((a) => a.bbox)) {
-      let west = Infinity, south = Infinity, east = -Infinity, north = -Infinity;
-      for (const aoi of aois) {
-        const [w, s, e, n] = aoi.bbox!;
-        if (w < west) west = w;
-        if (s < south) south = s;
-        if (e > east) east = e;
-        if (n > north) north = n;
-      }
-      // Normalise antimeridian crossing: west > east means bbox crosses the dateline.
-      if (west > east) east += 360;
-      return [west, south, east, north];
+    if (aois && aois.length > 0) {
+      // east may exceed 180 for antimeridian-crossing unions — createBboxPolygon
+      // and MapLibre GeoJSON both handle coords > 180 natively.
+      return unionAoiBboxes(aois);
     }
     return computeCombinedBbox(entries.map((e) => ({ id: e.ref.name, data: e.data })));
   })();

--- a/app/components/map/layers/GeoJsonLayers.tsx
+++ b/app/components/map/layers/GeoJsonLayers.tsx
@@ -193,9 +193,24 @@ function GeoJsonLayerGroup({ layer, entries, areas }: GeoJsonLayerGroupProps) {
       }
     }
   };
-  const bboxCoords = computeCombinedBbox(
-    entries.map((e) => ({ id: e.ref.name, data: e.data })),
-  );
+  // Prefer backend-provided bbox (handles antimeridian); fall back to turf.
+  const bboxCoords: [number, number, number, number] | null = (() => {
+    const aois = layer.aoiSelection?.aois;
+    if (aois && aois.length > 0 && aois.every((a) => a.bbox)) {
+      let west = Infinity, south = Infinity, east = -Infinity, north = -Infinity;
+      for (const aoi of aois) {
+        const [w, s, e, n] = aoi.bbox!;
+        if (w < west) west = w;
+        if (s < south) south = s;
+        if (e > east) east = e;
+        if (n > north) north = n;
+      }
+      // Normalise antimeridian crossing: west > east means bbox crosses the dateline.
+      if (west > east) east += 360;
+      return [west, south, east, north];
+    }
+    return computeCombinedBbox(entries.map((e) => ({ id: e.ref.name, data: e.data })));
+  })();
   const bboxPolygon = bboxCoords ? createBboxPolygon(bboxCoords) : null;
   const groupId = layer.id.replace(/\s+/g, "-").toLowerCase();
   return (

--- a/app/store/chat-tools/pickAoi.ts
+++ b/app/store/chat-tools/pickAoi.ts
@@ -3,7 +3,6 @@ import { ChatMessage, StreamMessage, AOI, AOISelection } from "@/app/types/chat"
 import useMapStore from "../mapStore";
 import useContextStore from "../contextStore";
 import { fetchGeometry } from "@/app/utils/geometryClient";
-import bbox from "@turf/bbox";
 import { GeoJsonEntry } from "../layerManagerSlice";
 import { selectLayerOptions } from "@/app/types/map";
 
@@ -50,8 +49,9 @@ export async function pickAoiTool(
   streamMessage: StreamMessage,
   addMessage: (message: Omit<ChatMessage, "id">) => void
 ) {
+  console.log("[pickAoi] called with:", JSON.stringify({ aoi: streamMessage.aoi, aoi_selection: streamMessage.aoi_selection }, null, 2));
   try {
-    const { flyToGeoJsonWithRetry, addToRegistry, addLayer } = useMapStore.getState();
+    const { flyToGeoJsonWithRetry, flyToBounds, addToRegistry, addLayer } = useMapStore.getState();
     const { upsertContextByType } = useContextStore.getState();
 
     // Prefer the new multi-AOI aoi_selection, fall back to single aoi
@@ -134,41 +134,30 @@ export async function pickAoiTool(
         type: "geojson",
         visible: true,
         featureRefs: successfulRefs,
-        ...(successfulAois.length > 1 && {
-          selectionName,
-          aoiSelection: { name: selectionName, aois: successfulAois },
-        }),
+        selectionName,
+        aoiSelection: { name: selectionName, aois: successfulAois },
       });
     }
 
-    // Compute a single combined bounding box across all geometries and fly to it
-    if (allGeoData.length > 0) {
-      // Compute individual bboxes and merge into one encompassing bbox
-      let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
-      for (const geoData of allGeoData) {
-        const b = bbox(geoData);
-        if (b[0] < minX) minX = b[0];
-        if (b[1] < minY) minY = b[1];
-        if (b[2] > maxX) maxX = b[2];
-        if (b[3] > maxY) maxY = b[3];
-      }
+    console.log("[pickAoi] successfulAois bbox check:", successfulAois.map((a) => ({ name: a.name, bbox: a.bbox })));
 
-      // Create a simple bbox polygon feature to fly to
-      const bboxFeature: Feature = {
-        type: "Feature",
-        properties: {},
-        geometry: {
-          type: "Polygon",
-          coordinates: [[
-            [minX, minY],
-            [maxX, minY],
-            [maxX, maxY],
-            [minX, maxY],
-            [minX, minY],
-          ]],
-        },
-      };
-      flyToGeoJsonWithRetry(bboxFeature);
+    // Fly to the combined bounds using backend-provided bbox values.
+    // Using aoi.bbox directly preserves dateline-crossing extents (west > east),
+    // which fitBounds handles natively. Turf bbox would wrap around the world instead.
+    const successfulBboxAois = successfulAois.filter((aoi) => aoi.bbox);
+    if (successfulBboxAois.length > 0) {
+      let west = Infinity, south = Infinity, east = -Infinity, north = -Infinity;
+      for (const aoi of successfulBboxAois) {
+        const [w, s, e, n] = aoi.bbox!;
+        if (w < west) west = w;
+        if (s < south) south = s;
+        if (e > east) east = e;
+        if (n > north) north = n;
+      }
+      console.log("[pickAoi] calling flyToBounds:", typeof flyToBounds, [[west, south], [east, north]]);
+      flyToBounds([[west, south], [east, north]]);
+    } else if (allGeoData.length > 0) {
+      flyToGeoJsonWithRetry(allGeoData[0]);
     }
 
     // Update area context with the selection name and full AOI selection data

--- a/app/store/chat-tools/pickAoi.ts
+++ b/app/store/chat-tools/pickAoi.ts
@@ -147,7 +147,8 @@ export async function pickAoiTool(
     // which fitBounds handles natively. Turf bbox would wrap around the world instead.
     const unionBbox = unionAoiBboxes(successfulAois);
     if (unionBbox) {
-      let [west, south, east, north] = unionBbox;
+      const [west, south, north] = [unionBbox[0], unionBbox[1], unionBbox[3]];
+      let east = unionBbox[2];
       // flyToBounds (and mapStore's fitBounds wrapper) expects east <= 180;
       // subtract 360 to re-wrap when the union crossed the antimeridian.
       if (east > 180) east -= 360;

--- a/app/store/chat-tools/pickAoi.ts
+++ b/app/store/chat-tools/pickAoi.ts
@@ -3,6 +3,7 @@ import { ChatMessage, StreamMessage, AOI, AOISelection } from "@/app/types/chat"
 import useMapStore from "../mapStore";
 import useContextStore from "../contextStore";
 import { fetchGeometry } from "@/app/utils/geometryClient";
+import { unionAoiBboxes } from "@/app/utils/bboxUtils";
 import { GeoJsonEntry } from "../layerManagerSlice";
 import { selectLayerOptions } from "@/app/types/map";
 
@@ -144,16 +145,12 @@ export async function pickAoiTool(
     // Fly to the combined bounds using backend-provided bbox values.
     // Using aoi.bbox directly preserves dateline-crossing extents (west > east),
     // which fitBounds handles natively. Turf bbox would wrap around the world instead.
-    const successfulBboxAois = successfulAois.filter((aoi) => aoi.bbox);
-    if (successfulBboxAois.length > 0) {
-      let west = Infinity, south = Infinity, east = -Infinity, north = -Infinity;
-      for (const aoi of successfulBboxAois) {
-        const [w, s, e, n] = aoi.bbox!;
-        if (w < west) west = w;
-        if (s < south) south = s;
-        if (e > east) east = e;
-        if (n > north) north = n;
-      }
+    const unionBbox = unionAoiBboxes(successfulAois);
+    if (unionBbox) {
+      let [west, south, east, north] = unionBbox;
+      // flyToBounds (and mapStore's fitBounds wrapper) expects east <= 180;
+      // subtract 360 to re-wrap when the union crossed the antimeridian.
+      if (east > 180) east -= 360;
       console.log("[pickAoi] calling flyToBounds:", typeof flyToBounds, [[west, south], [east, north]]);
       flyToBounds([[west, south], [east, north]]);
     } else if (allGeoData.length > 0) {

--- a/app/store/mapStore.ts
+++ b/app/store/mapStore.ts
@@ -120,10 +120,11 @@ const createMapSlice: StateCreator<MapState, [], [], MapSlice> = (
       console.warn("Map ref not available for flyToBounds");
       return;
     }
-    let [[west, south], [east, north]] = bounds;
+    const [[west, south], [east, north]] = bounds;
+    let eastUpdated = east;
     // MapLibre doesn't handle west > east wrapping — normalise by adding 360 to east.
-    if (west > east) east += 360;
-    mapRef.getMap().fitBounds([[west, south], [east, north]], {
+    if (west > east) eastUpdated += 360;
+    mapRef.getMap().fitBounds([[west, south], [eastUpdated, north]], {
       linear: true,
       padding: { top: 50, bottom: 50, left: 50, right: 50 },
       maxZoom: 16,

--- a/app/store/mapStore.ts
+++ b/app/store/mapStore.ts
@@ -29,6 +29,7 @@ interface MapSlice {
     geoJson: GeoJSON.FeatureCollection | GeoJSON.Feature,
     maxRetries?: number
   ) => void;
+  flyToBounds: (bounds: [[number, number], [number, number]]) => void;
 
   selectionMode: SelectionMode | undefined;
   setSelectionMode: (mode: SelectionMode | undefined) => void;
@@ -111,6 +112,22 @@ const createMapSlice: StateCreator<MapState, [], [], MapSlice> = (
         duration: 5000,
       });
     }
+  },
+
+  flyToBounds: (bounds) => {
+    const { mapRef } = get();
+    if (!mapRef) {
+      console.warn("Map ref not available for flyToBounds");
+      return;
+    }
+    let [[west, south], [east, north]] = bounds;
+    // MapLibre doesn't handle west > east wrapping — normalise by adding 360 to east.
+    if (west > east) east += 360;
+    mapRef.getMap().fitBounds([[west, south], [east, north]], {
+      linear: true,
+      padding: { top: 50, bottom: 50, left: 50, right: 50 },
+      maxZoom: 16,
+    });
   },
 
   flyToGeoJsonWithRetry: (geoJson, maxRetries = 5) => {

--- a/app/types/chat.ts
+++ b/app/types/chat.ts
@@ -126,6 +126,7 @@ export interface AOI {
   source: string;
   subtype: string;
   geometry?: FeatureCollection; // Optional since it may not be included in the initial response
+  bbox?: [number, number, number, number]; // [west, south, east, north] — may cross dateline (west > east)
 }
 
 export interface AOISelection {

--- a/app/utils/bboxUtils.ts
+++ b/app/utils/bboxUtils.ts
@@ -1,0 +1,25 @@
+/**
+ * Union multiple AOI bboxes into one, handling antimeridian crossings.
+ *
+ * Returns [west, south, east, north] where east may exceed 180 when the
+ * union crosses the dateline. Callers that need normalized coords (e.g.
+ * flyToBounds) should subtract 360 from east if east > 180.
+ */
+export function unionAoiBboxes(
+  aois: { bbox?: [number, number, number, number] }[],
+): [number, number, number, number] | null {
+  let west = Infinity, south = Infinity, east = -Infinity, north = -Infinity;
+  let found = false;
+  for (const aoi of aois) {
+    if (!aoi.bbox) continue;
+    found = true;
+    const [w, s, e, n] = aoi.bbox;
+    if (w < west) west = w;
+    if (s < south) south = s;
+    // Unwrap antimeridian-crossing bboxes (w > e) before comparing east values.
+    const eNorm = w > e ? e + 360 : e;
+    if (eNorm > east) east = eNorm;
+    if (n > north) north = n;
+  }
+  return found ? [west, south, east, north] : null;
+}


### PR DESCRIPTION
- Adds bbox: `[number, number, number, number]` to the AOI type the backend already provides this field in `[west, south, east, north]` format where west > east signals antimeridian crossing          
- Adds flyToBounds action to mapStore that normalises antimeridian-crossing bounds before calling fitBounds (east += 360 when west > east, which MapLibre handles correctly)                  
- Updates pickAoi to use backend-provided bbox values to compute combined fly-to bounds instead of Turf's bbox (which returns [-180, s, 180, n] for antimeridian geometries)                           
- Updates GeoJsonLayers bbox overlay to prefer backend bbox values with the same normalisation, falling back to Turf for layers without a backend bbox (e.g. custom drawn areas)

| Before | After |
| --- | --- |
| <img width="1919" height="948" alt="Screenshot 2026-04-20 at 11 25 02" src="https://github.com/user-attachments/assets/4a0abc8e-b11c-45e5-9513-230c168950d3" /> | <img width="1435" height="953" alt="Screenshot 2026-04-20 at 11 23 48" src="https://github.com/user-attachments/assets/c19db4d3-1938-44f6-b663-60ae03eda4c3" /> |

This PR **MUST ship** before the backend fix `project-zeno` [fix/antimeridian-bbox](https://github.com/wri/project-zeno/pull/630) both the fly-to and overlay paths fall back to the existing Turf-based behaviour when aoi.bbox is absent or a plain non-crossing bbox.