### PR TITLE
Feat/content aware charts

### DIFF
--- a/app/chart-debug/ChartDebugPanel.tsx
+++ b/app/chart-debug/ChartDebugPanel.tsx
@@ -121,6 +121,36 @@ const AREA_DATA = [
   { year: 2023, forest_area_km2: 35600 },
 ];
 
+// Long year span (25 points) — exercises tick-interval logic, last-tick clipping,
+// and angled-label placement on year axes.
+const TCL_LONG_YEARS = [
+  { year: 2001, area_ha: 1_320_000 },
+  { year: 2002, area_ha: 1_810_000 },
+  { year: 2003, area_ha: 2_460_000 },
+  { year: 2004, area_ha: 2_870_000 },
+  { year: 2005, area_ha: 3_290_000 },
+  { year: 2006, area_ha: 2_710_000 },
+  { year: 2007, area_ha: 2_290_000 },
+  { year: 2008, area_ha: 2_640_000 },
+  { year: 2009, area_ha: 2_180_000 },
+  { year: 2010, area_ha: 2_460_000 },
+  { year: 2011, area_ha: 2_120_000 },
+  { year: 2012, area_ha: 1_960_000 },
+  { year: 2013, area_ha: 2_330_000 },
+  { year: 2014, area_ha: 2_780_000 },
+  { year: 2015, area_ha: 3_120_000 },
+  { year: 2016, area_ha: 5_380_000 },
+  { year: 2017, area_ha: 4_490_000 },
+  { year: 2018, area_ha: 3_270_000 },
+  { year: 2019, area_ha: 3_950_000 },
+  { year: 2020, area_ha: 4_180_000 },
+  { year: 2021, area_ha: 3_710_000 },
+  { year: 2022, area_ha: 3_540_000 },
+  { year: 2023, area_ha: 3_280_000 },
+  { year: 2024, area_ha: 4_220_000 },
+  { year: 2025, area_ha: 4_510_000 },
+];
+
 const PIE_LAND_COVER = [
   { land_cover_type: "Tree cover", area_km2: 42000 },
   { land_cover_type: "Short vegetation", area_km2: 18500 },
@@ -312,6 +342,32 @@ const RAW_FIXTURES: { label: string; notes: string; widget: InsightWidget }[] = 
       data: LINE_DATA,
       xAxis: "year",
       yAxis: "carbon_emissions_mt",
+    },
+  },
+  {
+    label: "Line chart — long year span (2001–2025)",
+    notes: "25 yearly points. Tests angled-tick placement, last-tick clipping at the right edge, and ensures every other year stays in sync with the final year.",
+    widget: {
+      type: "line",
+      title: "Annual tree cover loss in Brazil (2001–2025)",
+      description: "Annual tree cover loss for Brazil over a 25-year span.",
+      data: TCL_LONG_YEARS,
+      xAxis: "year",
+      yAxis: "area_ha",
+      datasetName: "Tree cover loss",
+    },
+  },
+  {
+    label: "Bar chart — long year span (2001–2025)",
+    notes: "Same 25-year data as a bar chart. The last bar (2025) often gets its label clipped at the chart's right edge.",
+    widget: {
+      type: "bar",
+      title: "Annual tree cover loss in Brazil (2001–2025)",
+      description: "Annual tree cover loss for Brazil shown as bars.",
+      data: TCL_LONG_YEARS,
+      xAxis: "year",
+      yAxis: "area_ha",
+      datasetName: "Tree cover loss",
     },
   },
   {
@@ -646,7 +702,7 @@ export default function ChartDebugPanel() {
 
   return (
     <Box bg="bg.subtle" minH="100vh" py={8}>
-      <Container maxW="4xl">
+      <Container maxW="592px">
         <Flex align="center" gap={3} mb={2}>
           <Heading size="lg" m={0}>
             Chart Debug Panel

--- a/app/components/widgets/ChartWidget.tsx
+++ b/app/components/widgets/ChartWidget.tsx
@@ -42,6 +42,7 @@ const CHAR_PX = 6.5; // empirical sans-serif glyph width at 11px
 const TICK_MARGIN = 6; // gap between tick text and axis line
 const TITLE_BAND = 22; // reserved column: title (~14px) + breathing room
 const TICK_ANGLE_RAD = (35 * Math.PI) / 180;
+const MAX_X_TICKS = 12; // density target before we thin tick labels
 
 // Chart wrapper components
 type ChartWrapperComponent =
@@ -279,11 +280,11 @@ export default function ChartWidget({
     (!isNumericXAxis && formattedData.length > 4) ||
     (isNumericXAxis && formattedData.length > 10);
 
-  // Compute explicit ticks for dense numeric axes so the last data point is
-  // always labeled and Recharts' preserveStartEnd doesn't drop a tick mid-axis.
+  // preserveStartEnd silently drops a mid-axis tick when (N-1) doesn't
+  // divide evenly; build explicit ticks so the last data point is labeled.
   let xTicks: (string | number)[] | undefined;
   if (isNumericXAxis && type !== "scatter" && formattedData.length > 10) {
-    const step = Math.ceil((formattedData.length - 1) / 12);
+    const step = Math.ceil((formattedData.length - 1) / MAX_X_TICKS);
     xTicks = [];
     for (let i = 0; i < formattedData.length; i += step) {
       xTicks.push(formattedData[i][xAxis] as string | number);

--- a/app/components/widgets/ChartWidget.tsx
+++ b/app/components/widgets/ChartWidget.tsx
@@ -37,6 +37,12 @@ type ChartType =
   | "pie"
   | "scatter";
 
+const TICK_FONT_PX = 11;
+const CHAR_PX = 6.5; // empirical sans-serif glyph width at 11px
+const TICK_MARGIN = 6; // gap between tick text and axis line
+const TITLE_BAND = 22; // reserved column: title (~14px) + breathing room
+const TICK_ANGLE_RAD = (35 * Math.PI) / 180;
+
 // Chart wrapper components
 type ChartWrapperComponent =
   | typeof BarChart
@@ -275,6 +281,41 @@ export default function ChartWidget({
   const xAxisInterval: number | "preserveStartEnd" =
     isNumericXAxis && formattedData.length > 10 ? "preserveStartEnd" : 0;
 
+  // Sized from the longest formatted tick so titles hug the ticks regardless
+  // of content — fixed sizes leave dead bands or cause overlap.
+  const yKeys = type === "scatter" ? [yAxis] : series.map((s) => s.name);
+  let longestXTickChars = 0;
+  let longestYTickChars = 0;
+  for (const row of formattedData) {
+    const xFormatted =
+      type === "scatter"
+        ? formatYAxisLabel(Number(row[xAxis]), xAxis)
+        : formatXAxisLabel(row[xAxis] as string | number, xAxis);
+    longestXTickChars = Math.max(longestXTickChars, String(xFormatted).length);
+
+    for (const k of yKeys) {
+      const v = Number(row[k]);
+      if (!Number.isFinite(v)) continue;
+      longestYTickChars = Math.max(
+        longestYTickChars,
+        formatYAxisLabel(v, yAxis).length,
+      );
+    }
+  }
+
+  const xAxisHeight = needsAngledTicks
+    ? Math.ceil(
+        TICK_MARGIN +
+          longestXTickChars * CHAR_PX * Math.sin(TICK_ANGLE_RAD) +
+          TICK_FONT_PX * Math.cos(TICK_ANGLE_RAD) +
+          TITLE_BAND,
+      )
+    : TICK_MARGIN + TICK_FONT_PX + TITLE_BAND;
+
+  const yAxisWidth = Math.ceil(
+    longestYTickChars * CHAR_PX + TICK_MARGIN + TITLE_BAND,
+  );
+
   const renderChartItems = () => {
     switch (type) {
       case "pie": {
@@ -410,6 +451,7 @@ export default function ChartWidget({
                 name={xAxis}
                 axisLine={false}
                 tickLine={false}
+                tickMargin={TICK_MARGIN}
                 tickFormatter={(value: number) =>
                   type === "scatter"
                     ? String(formatYAxisLabel(value, chart.key(xAxis)))
@@ -418,17 +460,17 @@ export default function ChartWidget({
                 domain={type === "scatter" ? ["auto", "auto"] : undefined}
                 angle={needsAngledTicks ? -35 : 0}
                 textAnchor={needsAngledTicks ? "end" : "middle"}
-                height={needsAngledTicks ? 90 : 40}
+                height={xAxisHeight}
                 interval={xAxisInterval}
-                fontSize={11}
+                fontSize={TICK_FONT_PX}
               >
                 {xAxis && (
                   <Label
                     value={toAxisLabel(xAxis)}
                     position="insideBottom"
-                    offset={-5}
+                    offset={2}
                     style={{
-                      fontSize: 11,
+                      fontSize: TICK_FONT_PX,
                       fill: "var(--chakra-colors-fg-muted)",
                     }}
                   />
@@ -438,21 +480,24 @@ export default function ChartWidget({
                 dataKey={type === "scatter" ? chart.key(yAxis) : undefined}
                 type="number"
                 name={yAxis}
+                width={yAxisWidth}
+                tickMargin={TICK_MARGIN}
                 tickFormatter={(value: number) =>
                   String(formatYAxisLabel(value, chart.key(yAxis)))
                 }
                 axisLine={false}
                 tickLine={false}
                 domain={[0, "auto"]}
+                fontSize={TICK_FONT_PX}
               >
                 {yAxis && (
                   <Label
                     value={toAxisLabel(yAxis)}
                     angle={-90}
                     position="insideLeft"
-                    offset={10}
+                    offset={0}
                     style={{
-                      fontSize: 11,
+                      fontSize: TICK_FONT_PX,
                       fill: "var(--chakra-colors-fg-muted)",
                       textAnchor: "middle",
                     }}

--- a/app/components/widgets/ChartWidget.tsx
+++ b/app/components/widgets/ChartWidget.tsx
@@ -278,8 +278,21 @@ export default function ChartWidget({
   const needsAngledTicks =
     (!isNumericXAxis && formattedData.length > 4) ||
     (isNumericXAxis && formattedData.length > 10);
-  const xAxisInterval: number | "preserveStartEnd" =
-    isNumericXAxis && formattedData.length > 10 ? "preserveStartEnd" : 0;
+
+  // Compute explicit ticks for dense numeric axes so the last data point is
+  // always labeled and Recharts' preserveStartEnd doesn't drop a tick mid-axis.
+  let xTicks: (string | number)[] | undefined;
+  if (isNumericXAxis && type !== "scatter" && formattedData.length > 10) {
+    const step = Math.ceil((formattedData.length - 1) / 12);
+    xTicks = [];
+    for (let i = 0; i < formattedData.length; i += step) {
+      xTicks.push(formattedData[i][xAxis] as string | number);
+    }
+    const last = formattedData[formattedData.length - 1][xAxis] as
+      | string
+      | number;
+    if (xTicks[xTicks.length - 1] !== last) xTicks.push(last);
+  }
 
   // Sized from the longest formatted tick so titles hug the ticks regardless
   // of content — fixed sizes leave dead bands or cause overlap.
@@ -452,6 +465,11 @@ export default function ChartWidget({
                 axisLine={false}
                 tickLine={false}
                 tickMargin={TICK_MARGIN}
+                tick={
+                  needsAngledTicks
+                    ? { dx: -3, dy: 4, fontSize: TICK_FONT_PX }
+                    : { fontSize: TICK_FONT_PX }
+                }
                 tickFormatter={(value: number) =>
                   type === "scatter"
                     ? String(formatYAxisLabel(value, chart.key(xAxis)))
@@ -461,7 +479,13 @@ export default function ChartWidget({
                 angle={needsAngledTicks ? -35 : 0}
                 textAnchor={needsAngledTicks ? "end" : "middle"}
                 height={xAxisHeight}
-                interval={xAxisInterval}
+                ticks={xTicks}
+                interval={0}
+                padding={
+                  isNumericXAxis
+                    ? { left: 10, right: needsAngledTicks ? 14 : 18 }
+                    : undefined
+                }
                 fontSize={TICK_FONT_PX}
               >
                 {xAxis && (


### PR DESCRIPTION
## Summary

Three layout bugs that surfaced on year axes with >10 points, plus a chart-debug improvement so future review catches these earlier.

| <b>Current Behaviour with Bugs</b> |
|:--:|
| <img width="517" height="233" alt="Screenshot 2026-04-27 at 17 37 19" src="https://github.com/user-attachments/assets/555c00b0-0506-4995-9c6e-f0202d96d5b8" /> |

### Bugs fixed 

0. **X-axis Label collisions** Compute `yAxisWidth` from the longest formatted tick label plus a fixed TITLE_BAND reserved for the rotated title, so the title and ticks always sit in separate columns regardless of value width.  

1. **Rotated tick label fused with the data point.** `textAnchor="end"` pinned the right end of each rotated label exactly at the bar/data centre, so the label visually attached to the bar. Now offset by `(dx: -3, dy: 4)` so the right end clears the data point and the label "drops" diagonally away from it.

<img width="135" height="121" alt="Screenshot 2026-04-27 at 17 35 45" src="https://github.com/user-attachments/assets/d153a9c6-bf0a-42e1-ad69-2ae0ce4fd343" />

2. **Last year label clipped at the chart's right edge.** With no `padding` on the X-axis, the rightmost tick (e.g. `2025`) sat at the very edge — the centred upright label spilled beyond the SVG, and the rotated label's descender + `Chart.Root overflow="hidden"` clipped the trailing glyph. Added `padding={{ left: 10, right: needsAngledTicks ? 14 : 18 }}` for numeric axes.

3. **Missing x-axis ticks**          
`interval="preserveStartEnd"` dropped a tick whenever `(N-1)` didn't divide evenly across the auto-fit count (e.g. 24 years rendered `2001 … 2021 _ 2024` with `2023` silently missing). Compute the tick list ourselves with `step = ceil((N-1)/12)` and force-append the last data point so the end of the axis is always labeled.

<img width="506" height="294" alt="Screenshot 2026-04-27 at 17 36 45" src="https://github.com/user-attachments/assets/ee0c55ad-939b-459e-8d95-5ec76d3eca3f" />

### Test
Visual test can be carried out in `gnw.org/chart-debug`