### PR TITLE
key black to alpha for primary forest tiles

### DIFF
--- a/app/components/Map.tsx
+++ b/app/components/Map.tsx
@@ -8,7 +8,8 @@ import MapGl, {
   ScaleControl,
   MapRef,
 } from "react-map-gl/maplibre";
-import { useState, useRef } from "react";
+import { useState, useRef, useEffect } from "react";
+import { registerPrimaryForestProtocol } from "@/app/utils/primaryForestTileProtocol";
 import {
   AbsoluteCenter,
   Code,
@@ -43,6 +44,9 @@ function Map({ disableMapAreaControls }: { disableMapAreaControls?: boolean }) {
     "devseed/cmazl5ws500bz01scaa27dqi4",
   );
   const { setMapRef, initializeTerraDraw } = useMapStore();
+  useEffect(() => {
+    registerPrimaryForestProtocol();
+  }, []);
   const { layers, handleLayerAction } = useLegendHook();
   const { context } = useContextStore();
   const areas = context.filter((c) => c.contextType === "area");

--- a/app/utils/datasetLayerContext.ts
+++ b/app/utils/datasetLayerContext.ts
@@ -1,4 +1,12 @@
 import type { DatasetInfo } from "@/app/types/chat";
+import { wrapPrimaryForestTileUrl } from "./primaryForestTileProtocol";
+
+// Route primary forest tiles through the `pf://` protocol so the
+// black-background PNGs render with alpha — see primaryForestTileProtocol.
+function patchPrimaryForestTileUrl(url: string): string {
+  if (!url.includes("umd_regional_primary_forest")) return url;
+  return wrapPrimaryForestTileUrl(url);
+}
 
 export function getDatasetLayerContextProps(dataset: DatasetInfo) {
   // In the example of primary_forest, context_layer is "primary_forest" and context_layers is an array of context layers.
@@ -19,7 +27,10 @@ export function getDatasetLayerContextProps(dataset: DatasetInfo) {
 
   return {
     contextLayer: ctxMeta
-      ? { name: ctxMeta.name, tileUrl: ctxMeta.tile_url }
+      ? {
+          name: ctxMeta.name,
+          tileUrl: patchPrimaryForestTileUrl(ctxMeta.tile_url),
+        }
       : undefined,
     parameters:
       parameters && Object.keys(parameters).length > 0 ? parameters : undefined,

--- a/app/utils/primaryForestTileProtocol.ts
+++ b/app/utils/primaryForestTileProtocol.ts
@@ -1,0 +1,52 @@
+import maplibregl from "maplibre-gl";
+
+const PRIMARY_FOREST_PROTOCOL = "pf";
+
+export function wrapPrimaryForestTileUrl(url: string): string {
+  return `${PRIMARY_FOREST_PROTOCOL}://${url}`;
+}
+
+let registered = false;
+
+// The primary forest tile service serves PNGs with a black background.
+// This protocol rewrites pure-black pixels to alpha=0 so the layer
+// composites cleanly over the basemap.
+export function registerPrimaryForestProtocol(): void {
+  if (registered || typeof window === "undefined") return;
+  registered = true;
+
+  maplibregl.addProtocol(
+    PRIMARY_FOREST_PROTOCOL,
+    async (params, abortController) => {
+      const url = params.url.replace(/^pf:\/\//, "");
+      const response = await fetch(url, { signal: abortController.signal });
+      if (!response.ok) {
+        throw new Error(`Tile fetch failed: ${response.status}`);
+      }
+      const blob = await response.blob();
+      const sourceBitmap = await createImageBitmap(blob, {
+        imageOrientation: "none",
+        premultiplyAlpha: "none",
+      });
+
+      const canvas = document.createElement("canvas");
+      canvas.width = sourceBitmap.width;
+      canvas.height = sourceBitmap.height;
+      const ctx = canvas.getContext("2d");
+      if (!ctx) throw new Error("2D canvas context unavailable");
+      ctx.drawImage(sourceBitmap, 0, 0);
+      sourceBitmap.close();
+
+      const imageData = ctx.getImageData(0, 0, canvas.width, canvas.height);
+      const pixels = imageData.data;
+      for (let i = 0; i < pixels.length; i += 4) {
+        if (pixels[i] === 0 && pixels[i + 1] === 0 && pixels[i + 2] === 0) {
+          pixels[i + 3] = 0;
+        }
+      }
+
+      const data = await createImageBitmap(imageData);
+      return { data };
+    }
+  );
+}


### PR DESCRIPTION
If this cant be resolved with a tile cache change, adds pixel encoding to set black pixel to alpha=0

<img width="555" height="697" alt="Screenshot 2026-04-28 at 18 21 01" src="https://github.com/user-attachments/assets/8a4b3650-5032-4cf8-8609-785dd980eb1a" />
