### PR TITLE
PZB-896 - Redirect to / and extract to handler

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ PRD.md
 PLAN.md
 NOTES.md
 PRD_*.md
+
+# claude code local folders
+.claude/*/

--- a/app/components/PageHeader.tsx
+++ b/app/components/PageHeader.tsx
@@ -23,30 +23,14 @@ import { Tooltip } from "./ui/tooltip";
 
 import useAuthStore from "../store/authStore";
 import Link from "next/link";
-import { toaster } from "@/app/components/ui/toaster";
+import { useLogout } from "@/app/hooks/useLogout";
 
 const isPrototype = process.env.NEXT_PUBLIC_PROTOTYPE_MODE === "true";
 
 function PageHeader() {
   const { userEmail, usedPrompts, totalPrompts, isAuthenticated } =
     useAuthStore();
-  const handleLogout = async () => {
-    try {
-      toaster.create({
-        title: "Logging out",
-        description: "Signing you out and redirecting…",
-        type: "info",
-        duration: 8000,
-      });
-    } catch {}
-    try {
-      await fetch("/api/auth/logout", { method: "POST" });
-    } catch {}
-    const url = new URL("https://api.resourcewatch.org/auth/logout");
-    url.searchParams.set("callbackUrl", `${window.location.origin}/`);
-    url.searchParams.set("origin", "gnw");
-    window.location.href = url.toString();
-  };
+  const { logout } = useLogout();
   return (
     <Flex
       alignItems="center"
@@ -202,7 +186,7 @@ function PageHeader() {
                     cursor="pointer"
                     color="fg.error"
                     _hover={{ bg: "bg.error", color: "fg.error" }}
-                    onClick={handleLogout}
+                    onClick={logout}
                     title="Log Out"
                   >
                     <SignOutIcon />

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -32,6 +32,7 @@ import Link from "next/link";
 import LclLogo from "../components/LclLogo";
 import { PatchProfileRequestSchema } from "@/app/schemas/api/auth/profile/patch";
 import { toaster } from "@/app/components/ui/toaster";
+import { useLogout } from "@/app/hooks/useLogout";
 
 type ProfileConfig = {
   sectors: Record<string, string>;
@@ -109,13 +110,14 @@ export default function UserSettingsPage() {
             company: user?.companyOrganization ?? p.company,
             country: user?.countryCode ?? p.country,
             expertise: user?.gisExpertiseLevel ?? p.expertise,
-            preferredLanguage: user?.preferredLanguageCode ?? p.preferredLanguage,
+            preferredLanguage:
+              user?.preferredLanguageCode ?? p.preferredLanguage,
             topics: Array.isArray(user?.topics) ? user.topics : p.topics,
             receiveNewsEmails: Boolean(
-              user?.receiveNewsEmails ?? p.receiveNewsEmails
+              user?.receiveNewsEmails ?? p.receiveNewsEmails,
             ),
             helpTestFeatures: Boolean(
-              user?.helpTestFeatures ?? p.helpTestFeatures
+              user?.helpTestFeatures ?? p.helpTestFeatures,
             ),
           }));
 
@@ -228,25 +230,32 @@ export default function UserSettingsPage() {
 
       // Submit to Ortto directly from client (no secrets needed)
       const topicLabels = form.topics.map(
-        (code) => config?.topics?.[code] || code
+        (code) => config?.topics?.[code] || code,
       );
       try {
-        const orttoRes = await fetch("https://ortto.wri.org/custom-forms/gnw/", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            email: form.email,
-            firstName: form.firstName,
-            lastName: form.lastName,
-            sector: form.sector,
-            jobTitle: form.jobTitle,
-            companyOrganization: form.company,
-            countryCode: form.country,
-            Topics: topicLabels,
-            receiveNewsEmails: form.receiveNewsEmails,
-          }),
-        });
-        console.log("[Client] Ortto submission status:", orttoRes.status, orttoRes.ok ? "OK" : "FAILED");
+        const orttoRes = await fetch(
+          "https://ortto.wri.org/custom-forms/gnw/",
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              email: form.email,
+              firstName: form.firstName,
+              lastName: form.lastName,
+              sector: form.sector,
+              jobTitle: form.jobTitle,
+              companyOrganization: form.company,
+              countryCode: form.country,
+              Topics: topicLabels,
+              receiveNewsEmails: form.receiveNewsEmails,
+            }),
+          },
+        );
+        console.log(
+          "[Client] Ortto submission status:",
+          orttoRes.status,
+          orttoRes.ok ? "OK" : "FAILED",
+        );
       } catch (e) {
         console.error("[Client] Ortto submission error:", e);
       }
@@ -270,25 +279,7 @@ export default function UserSettingsPage() {
     }
   };
 
-  const handleLogout = () => {
-    try {
-      toaster.create({
-        title: "Logging out",
-        description: "Signing you out and redirecting…",
-        type: "info",
-        duration: 8000,
-      });
-    } catch {}
-    (async () => {
-      try {
-        await fetch("/api/auth/logout", { method: "POST" });
-      } catch {}
-      const url = new URL("https://api.resourcewatch.org/auth/logout");
-      url.searchParams.set("callbackUrl", `${window.location.origin}/`);
-      url.searchParams.set("origin", "gnw");
-      window.location.href = url.toString();
-    })();
-  };
+  const { logout } = useLogout();
 
   return (
     <Box
@@ -385,7 +376,7 @@ export default function UserSettingsPage() {
           gap={2}
           variant="outline"
           justifyContent="flex-start"
-          onClick={handleLogout}
+          onClick={logout}
           title="Sign Out"
         >
           <UserIcon />
@@ -675,7 +666,10 @@ export default function UserSettingsPage() {
                   width="320px"
                   value={form.preferredLanguage ? [form.preferredLanguage] : []}
                   onValueChange={(d: ValueChangeDetails) =>
-                    setForm((p) => ({ ...p, preferredLanguage: d.value[0] ?? "" }))
+                    setForm((p) => ({
+                      ...p,
+                      preferredLanguage: d.value[0] ?? "",
+                    }))
                   }
                 >
                   <Select.HiddenSelect />

--- a/app/hooks/useLogout.ts
+++ b/app/hooks/useLogout.ts
@@ -1,0 +1,27 @@
+import { useState } from "react";
+import { toaster } from "@/app/components/ui/toaster";
+
+export function useLogout() {
+  const [isLoggingOut, setIsLoggingOut] = useState(false);
+
+  const logout = () => {
+    if (isLoggingOut) return;
+    setIsLoggingOut(true);
+    try {
+      toaster.create({
+        title: "Logging out",
+        description: "Signing you out and redirecting…",
+        type: "info",
+        duration: 8000,
+      });
+    } catch {}
+    (async () => {
+      try {
+        await fetch("/api/auth/logout", { method: "POST" });
+      } catch {}
+      window.location.href = "/";
+    })();
+  };
+
+  return { logout, isLoggingOut };
+}

--- a/app/sidebar.tsx
+++ b/app/sidebar.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import {
   Button,
   Flex,
@@ -28,7 +28,7 @@ import {
 import useSidebarStore from "./store/sidebarStore";
 import useAuthStore from "./store/authStore";
 import useChatStore from "./store/chatStore";
-import { toaster } from "@/app/components/ui/toaster";
+import { useLogout } from "./hooks/useLogout";
 import ThreadActionsMenu from "./components/ThreadActionsMenu";
 import LclLogo from "./components/LclLogo";
 
@@ -161,28 +161,7 @@ export function Sidebar() {
     fetchApiStatus();
   }, [fetchThreads, fetchApiStatus]);
 
-  const [isLoggingOut, setIsLoggingOut] = useState(false);
-  const handleLogout = () => {
-    if (isLoggingOut) return;
-    setIsLoggingOut(true);
-    try {
-      toaster.create({
-        title: "Logging out",
-        description: "Signing you out and redirecting…",
-        type: "info",
-        duration: 8000,
-      });
-    } catch {}
-    (async () => {
-      try {
-        await fetch("/api/auth/logout", { method: "POST" });
-      } catch {}
-      const url = new URL("https://api.resourcewatch.org/auth/logout");
-      url.searchParams.set("callbackUrl", `${window.location.origin}/`);
-      url.searchParams.set("origin", "gnw");
-      window.location.href = url.toString();
-    })();
-  };
+  const { logout, isLoggingOut } = useLogout();
 
   const hasTodayThreads = threadGroups.today.length > 0;
   const hasPreviousWeekThreads = threadGroups.previousWeek.length > 0;
@@ -354,7 +333,7 @@ export function Sidebar() {
           </Button>
           <Button
             variant="ghost"
-            onClick={handleLogout}
+            onClick={logout}
             size="sm"
             loading={isLoggingOut}
             disabled={isLoggingOut}


### PR DESCRIPTION
## Summary
Fixes logout redirect issue.

- Wire the `useLogout` hook into the three logout call sites (sidebar, PageHeader, dashboard) so logout redirects to `/`instead of the RW logout URL.
- Removes the duplicated inline logout logic that previously lived in each component.