### PR TITLE
[PZB-775] Render updated insight cards in map workspace

### DIFF
--- a/app/components/InsightWorkspace.tsx
+++ b/app/components/InsightWorkspace.tsx
@@ -6,7 +6,6 @@ import {
   Text,
   Heading,
   IconButton,
-  Button,
   useDisclosure,
 } from "@chakra-ui/react";
 import {
@@ -14,8 +13,6 @@ import {
   ArrowArcLeftIcon,
   ArrowArcRightIcon,
 } from "@phosphor-icons/react";
-import Markdown from "react-markdown";
-import remarkBreaks from "remark-breaks";
 import useInsightStore from "@/app/store/insightStore";
 import WidgetMessage from "./WidgetMessage";
 import InsightProvenanceDrawer from "./InsightProvenanceDrawer";
@@ -27,7 +24,7 @@ import { buildChips } from "./widgets/analysis-params-utils";
 export default function InsightWorkspace() {
   const { insights } = useInsightStore();
   const [currentIndex, setCurrentIndex] = useState(0);
-  const { open, onOpen, onClose } = useDisclosure();
+  const { open, onClose } = useDisclosure();
   const [paramsExpanded, setParamsExpanded] = useState(false);
 
   useEffect(() => {

--- a/app/components/InsightWorkspace.tsx
+++ b/app/components/InsightWorkspace.tsx
@@ -1,0 +1,128 @@
+"use client";
+import { useState, useEffect } from "react";
+import { Box, Flex, Text, IconButton, Link, Separator } from "@chakra-ui/react";
+import {
+  CaretDownIcon,
+  CaretUpIcon,
+  ArrowLeftIcon,
+  ArrowRightIcon,
+} from "@phosphor-icons/react";
+import useInsightStore from "@/app/store/insightStore";
+import WidgetMessage from "./WidgetMessage";
+
+export default function InsightWorkspace() {
+  const { insights } = useInsightStore();
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [isCollapsed, setIsCollapsed] = useState(false);
+
+  // Jump to the most recent insight whenever a new one arrives
+  useEffect(() => {
+    setCurrentIndex(0);
+  }, [insights.length]);
+
+  const total = insights.length;
+  if (total === 0) return null;
+
+  // currentIndex 0 = newest, total-1 = oldest
+  const widget = insights[total - 1 - currentIndex];
+  const canGoPrev = currentIndex < total - 1;
+  const canGoNext = currentIndex > 0;
+
+  return (
+    <Box
+      position="absolute"
+      top={4}
+      right={4}
+      w="380px"
+      maxH="calc(100vh - 6rem)"
+      overflowY="auto"
+      zIndex={400}
+      bg="bg"
+      border="1px solid"
+      borderColor="border"
+      borderRadius="md"
+      boxShadow="md"
+      pointerEvents="all"
+    >
+      {/* Header */}
+      <Flex
+        px={3}
+        py={2}
+        justify="space-between"
+        align="center"
+        borderBottom="1px solid"
+        borderColor="border"
+      >
+        <Text
+          fontSize="xs"
+          color="fg.muted"
+          textTransform="uppercase"
+          letterSpacing="wider"
+          fontWeight="medium"
+        >
+          AI-Assisted Analysis
+          {" · "}
+          <Link
+            href="https://help.globalnaturewatch.org"
+            target="_blank"
+            rel="noopener noreferrer"
+            fontSize="xs"
+            color="primary.solid"
+            textDecoration="underline"
+          >
+            learn more
+          </Link>
+        </Text>
+        <IconButton
+          size="xs"
+          variant="ghost"
+          aria-label={isCollapsed ? "Expand insight" : "Collapse insight"}
+          onClick={() => setIsCollapsed((prev) => !prev)}
+        >
+          {isCollapsed ? (
+            <CaretDownIcon size={14} />
+          ) : (
+            <CaretUpIcon size={14} />
+          )}
+        </IconButton>
+      </Flex>
+
+      {!isCollapsed && (
+        <>
+          {/* Widget body — reuses WidgetMessage as-is */}
+          <WidgetMessage widget={widget} />
+
+          {/* Navigation footer */}
+          {total > 1 && (
+            <>
+              <Separator />
+              <Flex px={3} py={2} justify="space-between" align="center">
+                <IconButton
+                  size="xs"
+                  variant="ghost"
+                  aria-label="Previous insight"
+                  disabled={!canGoPrev}
+                  onClick={() => setCurrentIndex((i) => i + 1)}
+                >
+                  <ArrowLeftIcon size={14} />
+                </IconButton>
+                <Text fontSize="xs" color="fg.muted">
+                  {currentIndex + 1} of {total} available analyses
+                </Text>
+                <IconButton
+                  size="xs"
+                  variant="ghost"
+                  aria-label="Next insight"
+                  disabled={!canGoNext}
+                  onClick={() => setCurrentIndex((i) => i - 1)}
+                >
+                  <ArrowRightIcon size={14} />
+                </IconButton>
+              </Flex>
+            </>
+          )}
+        </>
+      )}
+    </Box>
+  );
+}

--- a/app/components/InsightWorkspace.tsx
+++ b/app/components/InsightWorkspace.tsx
@@ -1,21 +1,35 @@
 "use client";
 import { useState, useEffect } from "react";
-import { Box, Flex, Text, IconButton, Link, Separator } from "@chakra-ui/react";
 import {
-  CaretDownIcon,
-  CaretUpIcon,
-  ArrowLeftIcon,
-  ArrowRightIcon,
+  Box,
+  Flex,
+  Text,
+  Heading,
+  IconButton,
+  Button,
+  useDisclosure,
+} from "@chakra-ui/react";
+import {
+  SparkleIcon,
+  ArrowArcLeftIcon,
+  ArrowArcRightIcon,
 } from "@phosphor-icons/react";
+import Markdown from "react-markdown";
+import remarkBreaks from "remark-breaks";
 import useInsightStore from "@/app/store/insightStore";
 import WidgetMessage from "./WidgetMessage";
+import InsightProvenanceDrawer from "./InsightProvenanceDrawer";
+import AnalysisParametersToggle, {
+  AnalysisParamsChips,
+} from "./widgets/AnalysisParameters";
+import { buildChips } from "./widgets/analysis-params-utils";
 
 export default function InsightWorkspace() {
   const { insights } = useInsightStore();
   const [currentIndex, setCurrentIndex] = useState(0);
-  const [isCollapsed, setIsCollapsed] = useState(false);
+  const { open, onOpen, onClose } = useDisclosure();
+  const [paramsExpanded, setParamsExpanded] = useState(false);
 
-  // Jump to the most recent insight whenever a new one arrives
   useEffect(() => {
     setCurrentIndex(0);
   }, [insights.length]);
@@ -25,6 +39,8 @@ export default function InsightWorkspace() {
 
   // currentIndex 0 = newest, total-1 = oldest
   const widget = insights[total - 1 - currentIndex];
+  const chips = widget.analysisParams ? buildChips(widget.analysisParams) : [];
+  const hasChips = chips.length > 0;
   const canGoPrev = currentIndex < total - 1;
   const canGoNext = currentIndex > 0;
 
@@ -33,96 +49,109 @@ export default function InsightWorkspace() {
       position="absolute"
       top={4}
       right={4}
-      w="380px"
+      w="420px"
       maxH="calc(100vh - 6rem)"
       overflowY="auto"
       zIndex={400}
-      bg="bg"
-      border="1px solid"
-      borderColor="border"
+      bg="primary.25"
+      border="2px solid"
+      borderColor="primary.solid"
       borderRadius="md"
-      boxShadow="md"
+      boxShadow="0 4px 20px -4px {colors.primary.solid/40}"
       pointerEvents="all"
     >
-      {/* Header */}
-      <Flex
-        px={3}
-        py={2}
-        justify="space-between"
-        align="center"
-        borderBottom="1px solid"
-        borderColor="border"
-      >
-        <Text
-          fontSize="xs"
-          color="fg.muted"
-          textTransform="uppercase"
-          letterSpacing="wider"
-          fontWeight="medium"
+      {/* Title row */}
+      <Flex px={4} pt={3} pb={2} justify="space-between" align="flex-start">
+        <Heading
+          size="sm"
+          fontWeight="semibold"
+          color="#172B7A"
+          flex={1}
+          mr={2}
+          mb={0}
         >
-          AI-Assisted Analysis
-          {" · "}
-          <Link
-            href="https://help.globalnaturewatch.org"
-            target="_blank"
-            rel="noopener noreferrer"
-            fontSize="xs"
-            color="primary.solid"
-            textDecoration="underline"
-          >
-            learn more
-          </Link>
-        </Text>
-        <IconButton
-          size="xs"
-          variant="ghost"
-          aria-label={isCollapsed ? "Expand insight" : "Collapse insight"}
-          onClick={() => setIsCollapsed((prev) => !prev)}
-        >
-          {isCollapsed ? (
-            <CaretDownIcon size={14} />
-          ) : (
-            <CaretUpIcon size={14} />
-          )}
-        </IconButton>
+          {widget.title}
+        </Heading>
+        {total > 1 && (
+          <Flex gap={1} flexShrink={0}>
+            <IconButton
+              size="xs"
+              variant="ghost"
+              aria-label="Previous insight"
+              border="1px solid #E0E2E5"
+              disabled={!canGoPrev}
+              onClick={() => setCurrentIndex((i) => i + 1)}
+            >
+              <ArrowArcLeftIcon size={14} />
+            </IconButton>
+            <IconButton
+              size="xs"
+              variant="ghost"
+              aria-label="Next insight"
+              disabled={!canGoNext}
+              border="1px solid #E0E2E5"
+              onClick={() => setCurrentIndex((i) => i - 1)}
+            >
+              <ArrowArcRightIcon size={14} />
+            </IconButton>
+          </Flex>
+        )}
       </Flex>
 
-      {!isCollapsed && (
-        <>
-          {/* Widget body — reuses WidgetMessage as-is */}
-          <WidgetMessage widget={widget} />
+      {/* Sub-header row */}
+      <Flex
+        px={4}
+        justify="space-between"
+        align="center"
+        borderBottom="1px dashed"
+        borderColor="border"
+      >
+        <Flex align="center" gap={1.5}>
+          <SparkleIcon size={12} weight="fill" />
+          <Text
+            fontSize="10px"
+            fontFamily="mono"
+            textTransform="uppercase"
+            letterSpacing="wider"
+            color="fg.muted"
+          >
+            AI-Assisted Analysis
+          </Text>
+        </Flex>
+        {hasChips && (
+          <AnalysisParametersToggle
+            expanded={paramsExpanded}
+            onToggle={() => setParamsExpanded((v) => !v)}
+          />
+        )}
+        {/* {widget.generation && (
+          <Button
+            size="xs"
+            variant="ghost"
+            color="fg.muted"
+            h={5}
+            px={1}
+            fontWeight="normal"
+            textDecoration="underline"
+            onClick={onOpen}
+          >
+            Parameters
+          </Button>
+        )} */}
+      </Flex>
 
-          {/* Navigation footer */}
-          {total > 1 && (
-            <>
-              <Separator />
-              <Flex px={3} py={2} justify="space-between" align="center">
-                <IconButton
-                  size="xs"
-                  variant="ghost"
-                  aria-label="Previous insight"
-                  disabled={!canGoPrev}
-                  onClick={() => setCurrentIndex((i) => i + 1)}
-                >
-                  <ArrowLeftIcon size={14} />
-                </IconButton>
-                <Text fontSize="xs" color="fg.muted">
-                  {currentIndex + 1} of {total} available analyses
-                </Text>
-                <IconButton
-                  size="xs"
-                  variant="ghost"
-                  aria-label="Next insight"
-                  disabled={!canGoNext}
-                  onClick={() => setCurrentIndex((i) => i - 1)}
-                >
-                  <ArrowRightIcon size={14} />
-                </IconButton>
-              </Flex>
-            </>
-          )}
-        </>
-      )}
+      {/* Inner chart card */}
+      <Box px={2} pb={3} pt={1}>
+        {hasChips && paramsExpanded && <AnalysisParamsChips chips={chips} />}
+        <WidgetMessage widget={widget} inWorkspace />
+      </Box>
+
+      <InsightProvenanceDrawer
+        isOpen={open}
+        onClose={onClose}
+        generation={widget.generation}
+        title="Parameters"
+      />
     </Box>
   );
 }

--- a/app/components/InsightWorkspace.tsx
+++ b/app/components/InsightWorkspace.tsx
@@ -1,21 +1,15 @@
 "use client";
 import { useState, useEffect } from "react";
+import { Box, Flex, Text, Heading, IconButton, Link } from "@chakra-ui/react";
 import {
-  Box,
-  Flex,
-  Text,
-  Heading,
-  IconButton,
-  useDisclosure,
-} from "@chakra-ui/react";
-import {
-  SparkleIcon,
+  CaretDownIcon,
+  CaretUpIcon,
   ArrowArcLeftIcon,
   ArrowArcRightIcon,
 } from "@phosphor-icons/react";
 import useInsightStore from "@/app/store/insightStore";
 import WidgetMessage from "./WidgetMessage";
-import InsightProvenanceDrawer from "./InsightProvenanceDrawer";
+import { WidgetIcons } from "@/app/ChatPanelHeader";
 import AnalysisParametersToggle, {
   AnalysisParamsChips,
 } from "./widgets/AnalysisParameters";
@@ -24,7 +18,7 @@ import { buildChips } from "./widgets/analysis-params-utils";
 export default function InsightWorkspace() {
   const { insights } = useInsightStore();
   const [currentIndex, setCurrentIndex] = useState(0);
-  const { open, onClose } = useDisclosure();
+  const [isCollapsed, setIsCollapsed] = useState(false);
   const [paramsExpanded, setParamsExpanded] = useState(false);
 
   useEffect(() => {
@@ -45,110 +39,152 @@ export default function InsightWorkspace() {
     <Box
       position="absolute"
       top={4}
-      right={4}
-      w="420px"
-      maxH="calc(100vh - 6rem)"
-      overflowY="auto"
+      right={3}
       zIndex={400}
-      bg="primary.25"
-      border="2px solid"
-      borderColor="primary.solid"
-      borderRadius="md"
-      boxShadow="0 4px 20px -4px {colors.primary.solid/40}"
-      pointerEvents="all"
+      pointerEvents="none"
     >
-      {/* Title row */}
-      <Flex px={4} pt={3} pb={2} justify="space-between" align="flex-start">
-        <Heading
-          size="sm"
-          fontWeight="semibold"
-          color="#172B7A"
-          flex={1}
-          mr={2}
-          mb={0}
-        >
-          {widget.title}
-        </Heading>
-        {total > 1 && (
-          <Flex gap={1} flexShrink={0}>
-            <IconButton
-              size="xs"
-              variant="ghost"
-              aria-label="Previous insight"
-              border="1px solid #E0E2E5"
-              disabled={!canGoPrev}
-              onClick={() => setCurrentIndex((i) => i + 1)}
-            >
-              <ArrowArcLeftIcon size={14} />
-            </IconButton>
-            <IconButton
-              size="xs"
-              variant="ghost"
-              aria-label="Next insight"
-              disabled={!canGoNext}
-              border="1px solid #E0E2E5"
-              onClick={() => setCurrentIndex((i) => i - 1)}
-            >
-              <ArrowArcRightIcon size={14} />
-            </IconButton>
-          </Flex>
-        )}
-      </Flex>
-
-      {/* Sub-header row */}
-      <Flex
-        px={4}
-        justify="space-between"
-        align="center"
-        borderBottom="1px dashed"
-        borderColor="border"
+      {/* Panel */}
+      <Box
+        w="420px"
+        maxH="calc(100vh - 6rem)"
+        overflowY="auto"
+        bg="primary.25"
+        border="1px solid"
+        borderColor="#DDE2F5"
+        borderRadius="md"
+        boxShadow="0 4px 20px -4px {colors.primary.solid/40}"
+        pointerEvents="all"
       >
-        <Flex align="center" gap={1.5}>
-          <SparkleIcon size={12} weight="fill" />
-          <Text
-            fontSize="10px"
-            fontFamily="mono"
-            textTransform="uppercase"
-            letterSpacing="wider"
-            color="fg.muted"
-          >
-            AI-Assisted Analysis
-          </Text>
-        </Flex>
-        {hasChips && (
-          <AnalysisParametersToggle
-            expanded={paramsExpanded}
-            onToggle={() => setParamsExpanded((v) => !v)}
-          />
-        )}
-        {/* {widget.generation && (
-          <Button
+        {/* Header row */}
+        <Flex
+          px={4}
+          py={2}
+          justify="space-between"
+          align="center"
+          borderBottom="1px solid"
+          borderColor="#DDE2F5"
+        >
+          <Flex align="center" gap={1.5} flexWrap="nowrap" overflow="hidden">
+            {WidgetIcons[widget.type]}
+            <Text
+              fontSize="10px"
+              fontFamily="mono"
+              textTransform="uppercase"
+              letterSpacing="wider"
+              color="fg.muted"
+              whiteSpace="nowrap"
+            >
+              AI-Assisted Analysis{" · "}
+              <Link
+                href="https://help.globalnaturewatch.org"
+                target="_blank"
+                rel="noopener noreferrer"
+                fontSize="10px"
+                fontFamily="mono"
+                textDecoration="underline"
+                textTransform="none"
+              >
+                learn more
+              </Link>
+            </Text>
+          </Flex>
+          <IconButton
             size="xs"
             variant="ghost"
-            color="fg.muted"
-            h={5}
-            px={1}
-            fontWeight="normal"
-            textDecoration="underline"
-            onClick={onOpen}
+            aria-label={isCollapsed ? "Expand insight" : "Collapse insight"}
+            flexShrink={0}
+            onClick={() => setIsCollapsed((v) => !v)}
           >
-            Parameters
-          </Button>
-        )} */}
-      </Flex>
+            {isCollapsed ? (
+              <CaretDownIcon size={14} />
+            ) : (
+              <CaretUpIcon size={14} />
+            )}
+          </IconButton>
+        </Flex>
 
-      {/* Inner chart card */}
-      <Box px={2} pb={3} pt={1}>
-        {hasChips && paramsExpanded && <AnalysisParamsChips chips={chips} />}
-        <WidgetMessage widget={widget} inWorkspace />
+        {!isCollapsed && (
+          <>
+            {/* Title row */}
+            <Flex
+              px={4}
+              pt={3}
+              pb={2}
+              justify="space-between"
+              align="flex-start"
+              borderBottom="1px solid"
+              borderColor="#DDE2F5"
+            >
+              <Heading
+                size="sm"
+                fontWeight="semibold"
+                color="primary.fg"
+                flex={1}
+                mr={2}
+                mb={0}
+              >
+                {widget.title}
+              </Heading>
+              {hasChips && (
+                <AnalysisParametersToggle
+                  expanded={paramsExpanded}
+                  onToggle={() => setParamsExpanded((v) => !v)}
+                />
+              )}
+            </Flex>
+
+            {/* Params chips section */}
+            {hasChips && paramsExpanded && (
+              <Box px={4} py={2} borderBottom="1px solid" borderColor="#DDE2F5">
+                <AnalysisParamsChips chips={chips} />
+              </Box>
+            )}
+
+            {/* Inner chart card */}
+            <Box px={2} py={2}>
+              <WidgetMessage widget={widget} inWorkspace />
+            </Box>
+
+            {/* Navigation footer */}
+            {total > 1 && (
+              <Flex
+                px={4}
+                py={2}
+                borderTop="1px solid"
+                borderColor="#DDE2F5"
+                justify="space-between"
+                align="center"
+              >
+                <IconButton
+                  size="xs"
+                  variant="ghost"
+                  border="1px solid"
+                  borderColor="border.emphasized"
+                  aria-label="Previous insight"
+                  disabled={!canGoPrev}
+                  onClick={() => setCurrentIndex((i) => i + 1)}
+                >
+                  <ArrowArcLeftIcon size={14} />
+                </IconButton>
+                <Text fontSize="xs" color="neutral.500">
+                  {currentIndex + 1} of {total} available analyses
+                </Text>
+                <IconButton
+                  size="xs"
+                  variant="ghost"
+                  border="1px solid"
+                  borderColor="border.emphasized"
+                  aria-label="Next insight"
+                  disabled={!canGoNext}
+                  onClick={() => setCurrentIndex((i) => i - 1)}
+                >
+                  <ArrowArcRightIcon size={14} />
+                </IconButton>
+              </Flex>
+            )}
+          </>
+        )}
       </Box>
-
-      <InsightProvenanceDrawer
-        isOpen={open}
-        onClose={onClose}
-        generation={widget.generation}
-        title="Parameters"
-      />
     </Box>
   );
 }

--- a/app/components/Map.tsx
+++ b/app/components/Map.tsx
@@ -32,6 +32,7 @@ import SelectAreaLayer from "./map/layers/select-area-layer";
 import { useLegendHook } from "@/app/components/legend/useLegendHook";
 import GeoJsonLayers from "./map/layers/GeoJsonLayers";
 import { Legend } from "@/app/components/legend/Legend";
+import InsightWorkspace from "./InsightWorkspace";
 
 const MAPBOX_ACCESS_TOKEN = process.env.NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN;
 
@@ -210,6 +211,7 @@ function Map({ disableMapAreaControls }: { disableMapAreaControls?: boolean }) {
             <NavigationControl showCompass={false} position="bottom-left" />
           </>
         )}
+        <InsightWorkspace />
         <Flex
           pos="absolute"
           bottom="4"

--- a/app/components/WhatsNewModal.tsx
+++ b/app/components/WhatsNewModal.tsx
@@ -83,7 +83,7 @@ const FEATURES: Feature[] = [
     step: 1,
     title: "A more collaborative assistant",
     description:
-      "The assistant now works more closely with you in conversation, giving you finer control over how it acts. Ask it to zoom to a place (\"zoom to Pará\"), pick a dataset by topic (\"tree cover loss in rainforests\"), or run a full analysis (\"analyze tree cover loss in Pará over the last 5 years\") — and it does exactly that, nothing more.",
+      'The assistant now works more closely with you in conversation, giving you finer control over how it acts. Ask it to zoom to a place ("zoom to Pará"), pick a dataset by topic ("tree cover loss in rainforests"), or run a full analysis ("analyze tree cover loss in Pará over the last 5 years") — and it does exactly that, nothing more.',
     isNew: true,
   },
   {
@@ -98,7 +98,7 @@ const FEATURES: Feature[] = [
     title: "Tree cover loss data updated to 2025",
     description:
       "Tree cover loss now runs through 2025, joining the full record from 2001. Narrow any query to primary forest or intact forest landscapes, as well as set a specific canopy threshold to match how you define forest.",
-      isNew: true,
+    isNew: true,
   },
   {
     step: 4,

--- a/app/components/WidgetMessage.tsx
+++ b/app/components/WidgetMessage.tsx
@@ -104,7 +104,13 @@ export default function WidgetMessage({
       bg="neutral.100"
     >
       {!inWorkspace && (
-        <Flex px={4} py={3} gap={2} bgGradient="LCLGradientLight" align="center">
+        <Flex
+          px={4}
+          py={3}
+          gap={2}
+          bgGradient="LCLGradientLight"
+          align="center"
+        >
           {WidgetIcons[widget.type]}
           <Heading size="xs" fontWeight="medium" color="primary.fg" m={0}>
             {widget.title}

--- a/app/components/WidgetMessage.tsx
+++ b/app/components/WidgetMessage.tsx
@@ -17,6 +17,7 @@ import {
   DownloadSimpleIcon,
   TableIcon,
   ChartBarIcon,
+  CaretDownIcon,
 } from "@phosphor-icons/react";
 import { InsightWidget, DatasetInfo } from "@/app/types/chat";
 import TableWidget from "./widgets/TableWidget";
@@ -27,20 +28,17 @@ import InsightProvenanceDrawer from "./InsightProvenanceDrawer";
 import VisualizationDisclaimer from "./VisualizationDisclaimer";
 import WidgetErrorBoundary from "./widgets/WidgetErrorBoundary";
 import ScrollableTableWrapper from "./widgets/ScrollableTableWrapper";
-import AnalysisParametersToggle, {
-  AnalysisParamsChips,
-} from "./widgets/AnalysisParameters";
-import { buildChips } from "./widgets/analysis-params-utils";
 
 interface WidgetMessageProps {
   widget: InsightWidget;
+  inWorkspace?: boolean;
 }
 
-export default function WidgetMessage({ widget }: WidgetMessageProps) {
+export default function WidgetMessage({
+  widget,
+  inWorkspace,
+}: WidgetMessageProps) {
   const [showAsTable, setShowAsTable] = useState(false);
-  const [paramsExpanded, setParamsExpanded] = useState(false);
-  const chips = widget.analysisParams ? buildChips(widget.analysisParams) : [];
-  const hasChips = chips.length > 0;
   const { open, onOpen, onClose } = useDisclosure();
   const {
     open: expanded,
@@ -101,29 +99,19 @@ export default function WidgetMessage({ widget }: WidgetMessageProps) {
     <Box
       rounded="md"
       border="1px solid"
-      borderColor="blue.fg"
+      borderColor={inWorkspace ? "border.emphasized" : "blue.fg"}
       overflow="hidden"
+      bg="neutral.100"
     >
-      <Flex px={4} py={3} gap={2} bgGradient="LCLGradientLight" align="center">
-        {WidgetIcons[widget.type]}
-        <Heading
-          size="xs"
-          fontWeight="medium"
-          color="primary.fg"
-          m={0}
-          flex={1}
-        >
-          {widget.title}
-        </Heading>
-        {hasChips && (
-          <AnalysisParametersToggle
-            expanded={paramsExpanded}
-            onToggle={() => setParamsExpanded((v) => !v)}
-          />
-        )}
-      </Flex>
+      {!inWorkspace && (
+        <Flex px={4} py={3} gap={2} bgGradient="LCLGradientLight" align="center">
+          {WidgetIcons[widget.type]}
+          <Heading size="xs" fontWeight="medium" color="primary.fg" m={0}>
+            {widget.title}
+          </Heading>
+        </Flex>
+      )}
       <Flex gap={3} px={4} py={3} flexDir="column">
-        {hasChips && paramsExpanded && <AnalysisParamsChips chips={chips} />}
         {hasData && <Separator />}
         {/* Toolbar row — segmented toggle + full-screen */}
         <Flex justify="flex-start" gap={2} flexWrap="wrap" align="center">
@@ -208,7 +196,12 @@ export default function WidgetMessage({ widget }: WidgetMessageProps) {
         )}
         {/* Bottom action row — provenance + download */}
         {(isChartType || widget.type === "table") && hasData && (
-          <Flex justify="flex-start" gap={2} flexWrap="wrap" align="center">
+          <Flex
+            justify="flex-start"
+            gap={2}
+            flexWrap={inWorkspace ? "nowrap" : "wrap"}
+            align="center"
+          >
             {widget.generation && (
               <Button
                 size="xs"
@@ -216,7 +209,7 @@ export default function WidgetMessage({ widget }: WidgetMessageProps) {
                 onClick={handleOpen}
                 bg={open ? "bg.info" : undefined}
                 borderColor={open ? "border.info" : undefined}
-                color={open ? "fg.info" : undefined}
+                color="neutral.500"
                 h={6}
                 rounded="sm"
                 _hover={{
@@ -233,13 +226,15 @@ export default function WidgetMessage({ widget }: WidgetMessageProps) {
               onClick={handleDownloadCsv}
               h={6}
               rounded="sm"
+              color="neutral.500"
             >
               <DownloadSimpleIcon size={14} />
-              Download CSV
+              Download data
+              <CaretDownIcon size={12} />
             </Button>
           </Flex>
         )}
-        {showDisclaimer && <VisualizationDisclaimer />}
+        {showDisclaimer && !inWorkspace && <VisualizationDisclaimer />}
       </Flex>
       <InsightProvenanceDrawer
         isOpen={open}

--- a/app/components/WidgetMessage.tsx
+++ b/app/components/WidgetMessage.tsx
@@ -164,6 +164,7 @@ export default function WidgetMessage({
               onClick={onExpand}
               h={6}
               rounded="sm"
+              color="neutral.500"
             >
               <ArrowsOutIcon size={14} />
               Show full-screen
@@ -235,7 +236,7 @@ export default function WidgetMessage({
               color="neutral.500"
             >
               <DownloadSimpleIcon size={14} />
-              Download data
+              Download
               <CaretDownIcon size={12} />
             </Button>
           </Flex>

--- a/app/store/__tests__/insightStore.test.ts
+++ b/app/store/__tests__/insightStore.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import useInsightStore from "../insightStore";
+import { InsightWidget } from "@/app/types/chat";
+
+const widget = (title: string): InsightWidget => ({
+  type: "bar",
+  title,
+  description: "",
+  data: [],
+  xAxis: "year",
+  yAxis: "area",
+});
+
+describe("insightStore", () => {
+  beforeEach(() => {
+    useInsightStore.getState().clearInsights();
+  });
+
+  it("addInsights accumulates across calls and preserves order", () => {
+    useInsightStore.getState().addInsights([widget("A")]);
+    useInsightStore.getState().addInsights([widget("B")]);
+    const { insights } = useInsightStore.getState();
+    expect(insights).toHaveLength(2);
+    expect(insights[0].title).toBe("A");
+    expect(insights[1].title).toBe("B");
+  });
+
+  it("addInsights appends all widgets from a single call atomically", () => {
+    useInsightStore
+      .getState()
+      .addInsights([widget("A"), widget("B"), widget("C")]);
+    expect(useInsightStore.getState().insights).toHaveLength(3);
+  });
+
+  it("clearInsights resets to empty", () => {
+    useInsightStore.getState().addInsights([widget("A")]);
+    useInsightStore.getState().clearInsights();
+    expect(useInsightStore.getState().insights).toEqual([]);
+  });
+});

--- a/app/store/chat-tools/__tests__/generateInsights.test.ts
+++ b/app/store/chat-tools/__tests__/generateInsights.test.ts
@@ -22,12 +22,14 @@ const chartData = (title = "Forest Loss") => ({
   yAxis: "area",
 });
 
+type AddMessageFn = (message: Omit<ChatMessage, "id">) => void;
+
 describe("generateInsightsTool", () => {
-  let addMessage: ReturnType<typeof vi.fn>;
+  let addMessage: ReturnType<typeof vi.fn<AddMessageFn>>;
 
   beforeEach(() => {
     useInsightStore.getState().clearInsights();
-    addMessage = vi.fn();
+    addMessage = vi.fn<AddMessageFn>();
   });
 
   it("stores widgets in insightStore when charts_data is present", () => {

--- a/app/store/chat-tools/__tests__/generateInsights.test.ts
+++ b/app/store/chat-tools/__tests__/generateInsights.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { generateInsightsTool } from "../generateInsights";
+import useInsightStore from "../../insightStore";
+import { StreamMessage, ChatMessage } from "@/app/types/chat";
+
+const baseMessage = (
+  overrides: Partial<StreamMessage> = {}
+): StreamMessage => ({
+  type: "tool",
+  name: "generate_insights",
+  timestamp: new Date().toISOString(),
+  ...overrides,
+});
+
+const chartData = (title = "Forest Loss") => ({
+  id: "1",
+  title,
+  type: "bar" as const,
+  insight: "some description",
+  data: [{ year: 2020, area: 100 }],
+  xAxis: "year",
+  yAxis: "area",
+});
+
+describe("generateInsightsTool", () => {
+  let addMessage: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    useInsightStore.getState().clearInsights();
+    addMessage = vi.fn();
+  });
+
+  it("stores widgets in insightStore when charts_data is present", () => {
+    generateInsightsTool(
+      baseMessage({ charts_data: [chartData()] }),
+      addMessage
+    );
+    const { insights } = useInsightStore.getState();
+    expect(insights).toHaveLength(1);
+    expect(insights[0].title).toBe("Forest Loss");
+  });
+
+  it("adds the static reference message to chat as assistant type", () => {
+    generateInsightsTool(
+      baseMessage({ charts_data: [chartData()] }),
+      addMessage
+    );
+    expect(addMessage).toHaveBeenCalledOnce();
+    const msg = addMessage.mock.calls[0][0] as Omit<ChatMessage, "id">;
+    expect(msg.type).toBe("assistant");
+    expect(msg.message).toBe(
+      "I've created an insight you can view on the map."
+    );
+  });
+
+  it("does nothing when charts_data is absent", () => {
+    generateInsightsTool(baseMessage(), addMessage);
+    expect(useInsightStore.getState().insights).toHaveLength(0);
+    expect(addMessage).not.toHaveBeenCalled();
+  });
+
+  it("adds an error message and does not throw when chart items are malformed", () => {
+    generateInsightsTool(
+      baseMessage({ charts_data: [null as unknown as object] }),
+      addMessage
+    );
+    expect(addMessage).toHaveBeenCalledOnce();
+    const msg = addMessage.mock.calls[0][0] as Omit<ChatMessage, "id">;
+    expect(msg.type).toBe("error");
+  });
+});

--- a/app/store/chat-tools/__tests__/generateInsights.test.ts
+++ b/app/store/chat-tools/__tests__/generateInsights.test.ts
@@ -1,4 +1,11 @@
 import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// contextStore imports a React component (ContextButton) — mock to avoid JSX
+// in the node test environment
+vi.mock("@/app/store/contextStore", () => ({
+  default: { getState: () => ({ context: [] }) },
+}));
+
 import { generateInsightsTool } from "../generateInsights";
 import useInsightStore from "../../insightStore";
 import { StreamMessage, ChatMessage } from "@/app/types/chat";

--- a/app/store/chat-tools/generateInsights.ts
+++ b/app/store/chat-tools/generateInsights.ts
@@ -6,6 +6,7 @@ import {
   DatasetInfo,
 } from "@/app/types/chat";
 import useContextStore from "../contextStore";
+import useInsightStore from "../insightStore";
 
 interface ChartData {
   id: string;
@@ -93,10 +94,11 @@ export function generateInsightsTool(
 
       console.log("FRONTEND: Received charts_data message:", widgets);
 
+      useInsightStore.getState().addInsights(widgets);
+
       addMessage({
-        type: "widget",
-        message: "Charts generated",
-        widgets: widgets,
+        type: "assistant",
+        message: "I've created an insight you can view on the map.",
         timestamp: streamMessage.timestamp,
       });
     }

--- a/app/store/chatStore.ts
+++ b/app/store/chatStore.ts
@@ -30,6 +30,7 @@ import {
   showServiceUnavailableError,
 } from "@/app/hooks/useErrorHandler";
 import useAuthStore from "./authStore";
+import useInsightStore from "./insightStore";
 
 interface ChatState {
   messages: ChatMessage[];
@@ -225,7 +226,10 @@ async function processStreamMessage(
 const useChatStore = create<ChatState & ChatActions>((set, get) => ({
   ...initialState,
 
-  reset: () => set(initialState),
+  reset: () => {
+    set(initialState);
+    useInsightStore.getState().clearInsights();
+  },
 
   addMessage: (message) => {
     const newMessage: ChatMessage = {

--- a/app/store/insightStore.ts
+++ b/app/store/insightStore.ts
@@ -1,0 +1,17 @@
+import { create } from "zustand";
+import { InsightWidget } from "@/app/types/chat";
+
+interface InsightState {
+  insights: InsightWidget[];
+  addInsights: (widgets: InsightWidget[]) => void;
+  clearInsights: () => void;
+}
+
+const useInsightStore = create<InsightState>((set) => ({
+  insights: [],
+  addInsights: (widgets) =>
+    set((state) => ({ insights: [...state.insights, ...widgets] })),
+  clearInsights: () => set({ insights: [] }),
+}));
+
+export default useInsightStore;

--- a/app/theme/index.tsx
+++ b/app/theme/index.tsx
@@ -50,6 +50,7 @@ export const config = defineConfig({
       },
       colors: {
         primary: {
+          25: { value: "#F7F9FF" },
           50: { value: "#E0E8FF" },
           100: { value: "#D7DFF2" },
           200: { value: "#AFBFE6" },
@@ -68,7 +69,7 @@ export const config = defineConfig({
           200: { value: "#F4F5F7" },
           300: { value: "#E1E2E6" },
           400: { value: "#B2B7BD" },
-          500: { value: "#666E7B" },
+          500: { value: "#656E7B" },
           600: { value: "#394048" },
           700: { value: "#282D33" },
           800: { value: "#212629" },

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,12 @@
 import { defineConfig } from "vitest/config";
+import path from "path";
 
 export default defineConfig({
+  resolve: {
+    alias: {
+      "@": path.resolve(__dirname, "."),
+    },
+  },
   test: {
     environment: "node",
     coverage: {


### PR DESCRIPTION
### User Stories & Acceptance Criteria

When the agent generates an insight, I want it to appear on the map workspace rather than inline in the chat, so that my analysis outputs live where I can see them alongside the spatial context.

**Given** the agent generates an insight (chart, findings) **when** the response is delivered **then** the insight card renders in the workspace area, not inline in the chat thread.

**Given** the agent generates an insight **when** chat narration is delivered **then** chat references the insight (e.g. "I've created an insight you can view on the map") without rendering its content.

When I've generated multiple insights in a single session, I want to navigate between them with next / prev controls, so that I can revisit earlier findings and compare them without re-running analyses or scrolling through chat history.

**Given** multiple insights are generated in a session **when** they render **then** they stack with the most recent visible and users can navigate through older ones using next / prev toggles.

**Given** multiple insights are generated in a session **when** they render **then** the number of items in the stack renders at the bottom

**Given** multiple insights are generated in a session **when** a user clicks through them **then** the number increments accordingly

**Given** multiple insights are generated in a session **when** the user clicks through them with prev/next controls **then** they render one by one, iterating through the stack

**Given** multiple insights are generated in a session **when** the user clicks reaches the end of the stack (or start of) **then** the next control (or previous) becomes inactive

### Tests

- Insight cards render in the workspace, not in chat.
- Stack and next / prev navigation works for multiple insights.
- Chat reference message is shown when an insight is created.
- Existing insight content (chart, findings) renders unchanged in the new location.

###  Dependencies / Notes

- Hi-fi designs now available: https://www.figma.com/design/fUyMHyhGck5FmGEg0HlNHa/-Global-Nature-Watch--Playground?node-id=314-924 (was previously blocked on PZB-737).
- Scope note: the chat reference ("I've created an insight you can view on the map") is a static frontend AI message in this iteration. Backend-generated narration is out of scope here.
- Pipeline decoupling (charts_data flow) is PZB-744; this story is the rendering-location half only.

