### PR TITLE
PZB-841: update dataset card design

### DIFF
--- a/app/components/ContextMenu.tsx
+++ b/app/components/ContextMenu.tsx
@@ -1,4 +1,5 @@
 import { Suspense, useEffect, useMemo, useState } from "react";
+import type { DatasetInfo } from "@/app/types/chat";
 import {
   Box,
   Card,
@@ -29,7 +30,7 @@ const CONTEXT_NAV = (Object.keys(ChatContextOptions) as ChatContextType[]).map(
   })
 );
 
-import { DATASET_CARDS } from "../constants/datasets";
+import { DATASET_CARDS, DatasetCardConfig } from "../constants/datasets";
 import { useCustomAreasListSuspense } from "../hooks/useCustomAreasList";
 import type { CustomArea } from "../schemas/api/custom_areas/get";
 import useMapStore from "../store/mapStore";
@@ -73,33 +74,18 @@ function ContextNav({
   );
 }
 
-type LayerCardItem = {
-  dataset_id: number;
-  dataset_name: string;
-  context_layer: string | null;
-  img?: string;
-  description: string;
-  tile_url: string;
-  selected?: boolean;
-  reason?: string;
-};
-
 function LayerCardList({
   cards,
-  onCardClick,
 }: {
-  cards: LayerCardItem[];
-  onCardClick?: (card: LayerCardItem) => void;
+  cards: (DatasetCardConfig & { img?: string })[];
 }) {
   return (
     <Stack minH={0} overflowY="auto">
       {cards.map((card) => (
         <DatasetCard
           key={card.dataset_name}
-          dataset={card}
+          dataset={card as unknown as DatasetInfo}
           img={card.img ?? "/globe.svg"}
-          selected={card.selected}
-          onClick={onCardClick ? () => onCardClick(card) : undefined}
         />
       ))}
     </Stack>
@@ -173,45 +159,12 @@ function ContextMenu({
 export default ContextMenu;
 
 export function LayerMenu() {
-  const { context, addContext, removeContext } = useContextStore();
-
-  // Compute selected state from context so cards reflect external context changes
-  const cards: LayerCardItem[] = useMemo(() => {
-    return LAYER_CARDS.map((c) => {
-      const isSelected = context.some(
-        (ctx) => ctx.contextType === "layer" && ctx.datasetId === c.dataset_id
-      );
-      return { ...c, selected: isSelected } as LayerCardItem;
-    });
-  }, [context]);
-
-  const handleToggleCard = (card: LayerCardItem) => {
-    // mapTileLayerId is derived inside context store when needed
-    const existingCtx = context.find(
-      (ctx) => ctx.contextType === "layer" && ctx.datasetId === card.dataset_id
-    );
-
-    if (!card.selected) {
-      addContext({
-        contextType: "layer",
-        content: card.dataset_name,
-        datasetId: card.dataset_id,
-        tileUrl: card.tile_url,
-        layerName: card.dataset_name,
-      });
-      return;
-    }
-
-    // Currently selected → remove from context (which also removes map layer if datasetId is present)
-    if (existingCtx) {
-      removeContext(existingCtx.id);
-    }
-  };
+  const cards = LAYER_CARDS;
 
   return (
     <Stack bg="bg.subtle" pt={3} minW={0} w="100%">
       <Stack px={4} pt={3} borderTopWidth="1px" borderColor="border" minH={0}>
-        <LayerCardList cards={cards} onCardClick={handleToggleCard} />
+        <LayerCardList cards={cards} />
       </Stack>
     </Stack>
   );

--- a/app/components/ContextMenu.tsx
+++ b/app/components/ContextMenu.tsx
@@ -79,8 +79,7 @@ function LayerCardList({
 }: {
   cards: (DatasetCardConfig & { img?: string })[];
 }) {
-  const { context, upsertContextByType, removeContext } =
-    useContextStore();
+  const { context, upsertContextByType, removeContext } = useContextStore();
 
   function handleToggle(card: DatasetCardConfig & { img?: string }) {
     const existing = context.find(

--- a/app/components/ContextMenu.tsx
+++ b/app/components/ContextMenu.tsx
@@ -79,15 +79,43 @@ function LayerCardList({
 }: {
   cards: (DatasetCardConfig & { img?: string })[];
 }) {
+  const { context, upsertContextByType, removeContext } =
+    useContextStore();
+
+  function handleToggle(card: DatasetCardConfig & { img?: string }) {
+    const existing = context.find(
+      (c) => c.contextType === "layer" && c.datasetId === card.dataset_id
+    );
+    if (existing) {
+      removeContext(existing.id);
+    } else {
+      upsertContextByType({
+        contextType: "layer",
+        content: card.dataset_name,
+        datasetId: card.dataset_id,
+        tileUrl: card.tile_url,
+        layerName: card.dataset_name,
+        isAiContext: false,
+      });
+    }
+  }
+
   return (
     <Stack minH={0} overflowY="auto">
-      {cards.map((card) => (
-        <DatasetCard
-          key={card.dataset_name}
-          dataset={card as unknown as DatasetInfo}
-          img={card.img ?? "/globe.svg"}
-        />
-      ))}
+      {cards.map((card) => {
+        const isSelected = context.some(
+          (c) => c.contextType === "layer" && c.datasetId === card.dataset_id
+        );
+        return (
+          <DatasetCard
+            key={card.dataset_name}
+            dataset={card as unknown as DatasetInfo}
+            img={card.img ?? "/globe.svg"}
+            selected={isSelected}
+            onClick={() => handleToggle(card)}
+          />
+        );
+      })}
     </Stack>
   );
 }

--- a/app/components/DatasetCard.tsx
+++ b/app/components/DatasetCard.tsx
@@ -1,4 +1,4 @@
-import { Box, Card, Image, useDisclosure } from "@chakra-ui/react";
+import { Card, Image, Text, useDisclosure } from "@chakra-ui/react";
 import { InfoIcon } from "@phosphor-icons/react";
 import { DatasetInfo } from "@/app/types/chat";
 import { DatasetInfoModal } from "./DatasetInfoModal";
@@ -11,16 +11,10 @@ export type DatasetCardProps = {
   size?: "sm" | "md" | "lg";
 };
 
-export function DatasetCard({
-  dataset,
-  img,
-  selected,
-  onClick,
-  size = "sm",
-}: DatasetCardProps) {
+export function DatasetCard({ dataset, img, size = "sm" }: DatasetCardProps) {
   const { open, onOpen, onClose } = useDisclosure();
   const effectiveImg = img ?? "/globe.svg";
-  const cardText = dataset.reason || dataset.description;
+  const cardText = "Yearly · Global · WRI";
 
   return (
     <>
@@ -31,45 +25,41 @@ export function DatasetCard({
         flexShrink={0}
         overflow="hidden"
         maxW="xl"
+        height="5rem"
         border="2px solid"
-        borderColor={selected ? "primary.solid" : "border.muted"}
-        _hover={{
-          cursor: onClick ? "pointer" : "initial",
-          borderColor: "primary.300",
-        }}
-        onClick={onClick}
+        borderColor="primary.solid"
       >
         <Image
           objectFit="cover"
-          maxW="8rem"
+          width="5rem"
           src={effectiveImg}
           alt={dataset.dataset_name}
         />
         <Card.Body
           display="flex"
           flexDir="column"
-          px={5}
-          py={4}
+          px={4}
+          py={3}
           position="relative"
         >
-          <Card.Title fontSize="sm" pr="6">
-            {dataset.dataset_name}
-          </Card.Title>
-          <Box
-            as="button"
-            onClick={(e) => {
-              e.stopPropagation(); // prevent card click
-              onOpen();
-            }}
-            aria-label="Show dataset info"
-            pos="absolute"
-            top="4"
-            right="5"
+          <Card.Title
+            fontSize="xs"
+            pr="6"
+            display="flex"
+            alignItems="center"
+            gap="1.5"
+            marginBottom={0}
           >
-            <InfoIcon cursor="pointer" />
-          </Box>
+            <Text>{dataset.dataset_name}</Text>
+            <InfoIcon
+              cursor="pointer"
+              size={18}
+              onClick={onOpen}
+              style={{ marginBottom: 4 }}
+            />
+          </Card.Title>
           {cardText && (
-            <Card.Description fontSize="xs" color="fg.muted" mt="1">
+            <Card.Description fontSize="x-small" color="fg.muted" mt="1">
               {cardText}
             </Card.Description>
           )}

--- a/app/components/DatasetCard.tsx
+++ b/app/components/DatasetCard.tsx
@@ -43,7 +43,11 @@ export function DatasetCard({
         borderRadius="4px"
         onClick={onClick}
         cursor={onClick ? "pointer" : "default"}
-        _hover={onClick ? { borderColor: "primary.300", border: "2px solid" } : undefined}
+        _hover={
+          onClick
+            ? { borderColor: "primary.300", border: "2px solid" }
+            : undefined
+        }
       >
         <Image
           objectFit="cover"

--- a/app/components/DatasetCard.tsx
+++ b/app/components/DatasetCard.tsx
@@ -26,8 +26,7 @@ export function DatasetCard({ dataset, img, size = "sm" }: DatasetCardProps) {
         overflow="hidden"
         maxW="xl"
         height="5rem"
-        border="2px solid"
-        borderColor="primary.solid"
+        border="1px solid {colors.neutral.900/30}"
       >
         <Image
           objectFit="cover"

--- a/app/components/DatasetCard.tsx
+++ b/app/components/DatasetCard.tsx
@@ -2,6 +2,7 @@ import { Card, Image, Text, useDisclosure } from "@chakra-ui/react";
 import { InfoIcon } from "@phosphor-icons/react";
 import { DatasetInfo } from "@/app/types/chat";
 import { DatasetInfoModal } from "./DatasetInfoModal";
+import { Tooltip } from "./ui/tooltip";
 
 export type DatasetCardProps = {
   dataset: DatasetInfo;
@@ -87,12 +88,30 @@ export function DatasetCard({
             >
               {dataset.dataset_name}
             </Text>
-            <InfoIcon
-              cursor="pointer"
-              size={16}
-              color="#656E7B"
-              onClick={onOpen}
-            />
+            <Tooltip
+              content="Show dataset info"
+              positioning={{ placement: "top" }}
+              showArrow
+              contentProps={{
+                bg: "#131619",
+                borderRadius: "8px",
+                px: "8px",
+                py: "8px",
+                fontFamily: "'IBM Plex Sans', sans-serif",
+                fontSize: "12px",
+                fontWeight: "400",
+                lineHeight: "150%",
+                color: "#B2B6BD",
+                filter: "drop-shadow(0px 4px 16px rgba(0, 0, 0, 0.15))",
+              }}
+            >
+              <InfoIcon
+                cursor="pointer"
+                size={16}
+                color="#656E7B"
+                onClick={onOpen}
+              />
+            </Tooltip>
           </Card.Title>
           {cardText && (
             <Card.Description

--- a/app/components/DatasetCard.tsx
+++ b/app/components/DatasetCard.tsx
@@ -6,15 +6,24 @@ import { DatasetInfoModal } from "./DatasetInfoModal";
 export type DatasetCardProps = {
   dataset: DatasetInfo;
   img?: string;
-  selected?: boolean;
-  onClick?: () => void;
   size?: "sm" | "md" | "lg";
+  label?: string;
+  labelColor?: string;
 };
 
-export function DatasetCard({ dataset, img, size = "sm" }: DatasetCardProps) {
+export function DatasetCard({
+  dataset,
+  img,
+  size = "sm",
+  label = "DATA",
+  labelColor = "#1AA915",
+}: DatasetCardProps) {
   const { open, onOpen, onClose } = useDisclosure();
   const effectiveImg = img ?? "/globe.svg";
-  const cardText = "Yearly · Global · WRI";
+  const cardText =
+    [dataset.cadence, dataset.geographic_coverage, dataset.provider]
+      .filter(Boolean)
+      .join(" · ") || null;
 
   return (
     <>
@@ -41,6 +50,14 @@ export function DatasetCard({ dataset, img, size = "sm" }: DatasetCardProps) {
           py={3}
           position="relative"
         >
+          <Text
+            fontSize="x-small"
+            fontWeight="bold"
+            color={labelColor}
+            mb="0.5"
+          >
+            {label}
+          </Text>
           <Card.Title
             fontSize="xs"
             pr="6"
@@ -58,7 +75,7 @@ export function DatasetCard({ dataset, img, size = "sm" }: DatasetCardProps) {
             />
           </Card.Title>
           {cardText && (
-            <Card.Description fontSize="x-small" color="fg.muted" mt="1">
+            <Card.Description fontSize="x-small" color="fg.muted">
               {cardText}
             </Card.Description>
           )}

--- a/app/components/DatasetCard.tsx
+++ b/app/components/DatasetCard.tsx
@@ -92,18 +92,7 @@ export function DatasetCard({
               content="Show dataset info"
               positioning={{ placement: "top" }}
               showArrow
-              contentProps={{
-                bg: "#131619",
-                borderRadius: "8px",
-                px: "8px",
-                py: "8px",
-                fontFamily: "'IBM Plex Sans', sans-serif",
-                fontSize: "12px",
-                fontWeight: "400",
-                lineHeight: "150%",
-                color: "#B2B6BD",
-                filter: "drop-shadow(0px 4px 16px rgba(0, 0, 0, 0.15))",
-              }}
+              variant="dark"
             >
               <InfoIcon
                 cursor="pointer"

--- a/app/components/DatasetCard.tsx
+++ b/app/components/DatasetCard.tsx
@@ -9,14 +9,17 @@ export type DatasetCardProps = {
   size?: "sm" | "md" | "lg";
   label?: string;
   labelColor?: string;
+  selected?: boolean;
+  onClick?: () => void;
 };
 
 export function DatasetCard({
   dataset,
   img,
-  size = "sm",
   label = "DATA",
   labelColor = "#1AA915",
+  selected,
+  onClick,
 }: DatasetCardProps) {
   const { open, onOpen, onClose } = useDisclosure();
   const effectiveImg = img ?? "/globe.svg";
@@ -29,53 +32,76 @@ export function DatasetCard({
     <>
       <DatasetInfoModal isOpen={open} onClose={onClose} dataset={dataset} />
       <Card.Root
-        size={size}
         flexDirection="row"
         flexShrink={0}
         overflow="hidden"
-        maxW="xl"
-        height="5rem"
-        border="1px solid {colors.neutral.900/30}"
+        width="100%"
+        height="80px"
+        border={selected ? "2px solid" : "1px solid rgba(19, 22, 25, 0.3)"}
+        borderColor={selected ? "primary.solid" : undefined}
+        borderRadius="4px"
+        onClick={onClick}
+        cursor={onClick ? "pointer" : "default"}
+        _hover={onClick ? { borderColor: "primary.300", border: "2px solid" } : undefined}
       >
         <Image
           objectFit="cover"
-          width="5rem"
+          width="80px"
+          minHeight="80px"
+          flexShrink={0}
           src={effectiveImg}
           alt={dataset.dataset_name}
+          borderRight="1px solid rgba(19, 22, 25, 0.1)"
+          borderRadius={0}
         />
         <Card.Body
           display="flex"
           flexDir="column"
-          px={4}
-          py={3}
-          position="relative"
+          px="16px"
+          py={0}
+          gap="2px"
+          justifyContent="center"
         >
           <Text
-            fontSize="x-small"
-            fontWeight="bold"
+            fontFamily="'IBM Plex Mono', monospace"
+            fontSize="10px"
+            fontWeight="400"
+            letterSpacing="0.5px"
+            lineHeight="16px"
             color={labelColor}
-            mb="0.5"
           >
             {label}
           </Text>
           <Card.Title
-            fontSize="xs"
-            pr="6"
             display="flex"
             alignItems="center"
-            gap="1.5"
+            gap="8px"
             marginBottom={0}
           >
-            <Text>{dataset.dataset_name}</Text>
+            <Text
+              fontFamily="'IBM Plex Sans', sans-serif"
+              fontSize="12px"
+              fontWeight="500"
+              lineHeight="150%"
+              color="#3A4048"
+            >
+              {dataset.dataset_name}
+            </Text>
             <InfoIcon
               cursor="pointer"
-              size={18}
+              size={16}
+              color="#656E7B"
               onClick={onOpen}
-              style={{ marginBottom: 4 }}
             />
           </Card.Title>
           {cardText && (
-            <Card.Description fontSize="x-small" color="fg.muted">
+            <Card.Description
+              fontFamily="'IBM Plex Mono', monospace"
+              fontSize="10px"
+              fontWeight="400"
+              lineHeight="16px"
+              color="#656E7B"
+            >
               {cardText}
             </Card.Description>
           )}

--- a/app/components/MessageBubble.tsx
+++ b/app/components/MessageBubble.tsx
@@ -149,7 +149,7 @@ function MessageBubble({
   if (isWidget && message.widgets) {
     return message.widgets.map((widget, idx) => (
       <Box
-        mb={4}
+        my={4}
         key={`${widget.title} ${message.id}`}
         id={`widget-${message.id}-${idx}`}
         scrollMarginTop="32px"

--- a/app/components/ui/tooltip.tsx
+++ b/app/components/ui/tooltip.tsx
@@ -2,7 +2,7 @@ import { Tooltip as ChakraTooltip, Portal } from "@chakra-ui/react";
 import * as React from "react";
 
 const darkContentProps: ChakraTooltip.ContentProps = {
-  bg: "#131619",
+  bg: "#131619", // TODO: use theme value
   borderRadius: "8px",
   px: "8px",
   py: "8px",
@@ -10,7 +10,7 @@ const darkContentProps: ChakraTooltip.ContentProps = {
   fontSize: "12px",
   fontWeight: "400",
   lineHeight: "150%",
-  color: "#B2B6BD",
+  color: "#B2B6BD", // TODO: use theme value
   filter: "drop-shadow(0px 4px 16px rgba(0, 0, 0, 0.15))",
 };
 

--- a/app/components/ui/tooltip.tsx
+++ b/app/components/ui/tooltip.tsx
@@ -1,6 +1,19 @@
 import { Tooltip as ChakraTooltip, Portal } from "@chakra-ui/react";
 import * as React from "react";
 
+const darkContentProps: ChakraTooltip.ContentProps = {
+  bg: "#131619",
+  borderRadius: "8px",
+  px: "8px",
+  py: "8px",
+  fontFamily: "'IBM Plex Sans', sans-serif",
+  fontSize: "12px",
+  fontWeight: "400",
+  lineHeight: "150%",
+  color: "#B2B6BD",
+  filter: "drop-shadow(0px 4px 16px rgba(0, 0, 0, 0.15))",
+};
+
 export interface TooltipProps extends ChakraTooltip.RootProps {
   showArrow?: boolean;
   portalled?: boolean;
@@ -8,6 +21,7 @@ export interface TooltipProps extends ChakraTooltip.RootProps {
   content: React.ReactNode;
   contentProps?: ChakraTooltip.ContentProps;
   disabled?: boolean;
+  variant?: "dark";
 }
 
 export const Tooltip = React.forwardRef<HTMLDivElement, TooltipProps>(
@@ -20,8 +34,14 @@ export const Tooltip = React.forwardRef<HTMLDivElement, TooltipProps>(
       content,
       contentProps,
       portalRef,
+      variant,
       ...rest
     } = props;
+
+    const resolvedContentProps =
+      variant === "dark"
+        ? { ...darkContentProps, ...contentProps }
+        : contentProps;
 
     if (disabled) return children;
 
@@ -30,7 +50,7 @@ export const Tooltip = React.forwardRef<HTMLDivElement, TooltipProps>(
         <ChakraTooltip.Trigger asChild>{children}</ChakraTooltip.Trigger>
         <Portal disabled={!portalled} container={portalRef}>
           <ChakraTooltip.Positioner>
-            <ChakraTooltip.Content ref={ref} {...contentProps}>
+            <ChakraTooltip.Content ref={ref} {...resolvedContentProps}>
               {showArrow && (
                 <ChakraTooltip.Arrow>
                   <ChakraTooltip.ArrowTip />

--- a/app/components/widgets/DatasetCardWidget.tsx
+++ b/app/components/widgets/DatasetCardWidget.tsx
@@ -1,51 +1,24 @@
 import { DatasetInfo } from "@/app/types/chat";
-import useContextStore from "@/app/store/contextStore";
 import { DatasetCard } from "@/app/components/DatasetCard";
 import { DATASET_CARDS } from "@/app/constants/datasets";
-import { getDatasetLayerContextProps } from "@/app/utils/datasetLayerContext";
 
 interface DatasetCardWidgetProps {
   dataset: DatasetInfo;
 }
 
 export default function DatasetCardWidget({ dataset }: DatasetCardWidgetProps) {
-  const { context, addContext, removeContext } = useContextStore();
-
-  const existingLayerContext = context.find(
-    (c) =>
-      c.contextType === "layer" &&
-      (c.datasetId === dataset.dataset_id || c.content === dataset.dataset_name)
+  const cardConfig = DATASET_CARDS.find(
+    (c) => c.dataset_name === dataset.dataset_name
   );
-  const isInContext = Boolean(existingLayerContext);
-
-  const handleAddToMap = () => {
-    if (!isInContext) {
-      // Single source of truth: adding context adds the map layer
-      addContext({
-        contextType: "layer",
-        content: dataset.dataset_name,
-        datasetId: dataset.dataset_id,
-        tileUrl: dataset.tile_url,
-        layerName: dataset.dataset_name,
-        ...getDatasetLayerContextProps(dataset), // we add the context layer(s) if any.
-      });
-      return;
-    }
-    // If already in context, remove it (which also removes the map layer)
-    if (existingLayerContext) removeContext(existingLayerContext.id);
+  const img = cardConfig?.img ?? "/globe.svg";
+  const enrichedDataset = {
+    ...dataset,
+    cadence: dataset.cadence ?? cardConfig?.cadence,
+    resolution: dataset.resolution ?? cardConfig?.resolution,
+    geographic_coverage:
+      dataset.geographic_coverage ?? cardConfig?.geographic_coverage,
+    provider: dataset.provider ?? cardConfig?.provider,
   };
 
-  const img =
-    DATASET_CARDS.find((c) => c.dataset_name === dataset.dataset_name)?.img ??
-    "/globe.svg";
-
-  return (
-    <DatasetCard
-      dataset={dataset}
-      img={img}
-      selected={isInContext}
-      onClick={handleAddToMap}
-      size="md"
-    />
-  );
+  return <DatasetCard dataset={enrichedDataset} img={img} size="md" />;
 }

--- a/app/constants/datasets.ts
+++ b/app/constants/datasets.ts
@@ -28,6 +28,10 @@ export type DatasetCardConfig = {
   context_layer?: string | null;
   threshold?: number | null;
   legend?: DatasetLegendConfig;
+  cadence?: string;
+  resolution?: string;
+  geographic_coverage?: string;
+  provider?: string;
 };
 
 export type ContextLayerMetadata = {
@@ -64,6 +68,10 @@ export const DATASET_CARDS: (DatasetCardConfig & { img?: string })[] = [
     data_layer: "Global all ecosystem disturbance alerts (DIST-ALERT)",
     context_layer: null as string | null,
     img: "/dataset_card_dist_alerts.webp",
+    cadence: "weekly",
+    resolution: "30 m",
+    geographic_coverage: "global",
+    provider: "UMD",
     description:
       "This dataset provides near-real-time alerts of vegetation disturbance at 30-meter resolution from December 2023 to present.",
     tile_url:
@@ -82,6 +90,10 @@ export const DATASET_CARDS: (DatasetCardConfig & { img?: string })[] = [
     dataset_name: "Global land cover",
     context_layer: null as string | null,
     img: "/dataset_card_land_cover.webp",
+    cadence: "annual",
+    resolution: "30 m",
+    geographic_coverage: "global",
+    provider: "GLAD / GPW",
     description:
       "This Global Land Cover dataset is a combination of two global datasets: the GLAD Land Cover and Land Use Change annual data and the Global Pasture Watch Grassland Class Collection 2 Cultivated Grasslands annual data. This combination is annual from 2015 through 2024. This dataset shows land covers and uses including: bare ground and sparsevegetation, short vegetation, tree cover, wetlands, water, snow/ice, cropland, cultivated grasslands, and built-up land.",
     tile_url: `${EOAPI_HOST}/raster/collections/global-land-cover-v-2/items/global-land-cover-2024/tiles/WebMercatorQuad/{z}/{x}/{y}.png?colormap=%7B%221%22%3A%20%5B254%2C%20254%2C%20204%5D%2C%222%22%3A%20%5B185%2C%20185%2C%2030%5D%2C%223%22%3A%20%5B36%2C%20110%2C%2036%5D%2C%224%22%3A%20%5B116%2C%20214%2C%20180%5D%2C%225%22%3A%20%5B107%2C%20174%2C%20214%5D%2C%226%22%3A%20%5B172%2C%20209%2C%20232%5D%2C%227%22%3A%20%5B255%2C%20241%2C%20131%5D%2C%228%22%3A%20%5B232%2C%20118%2C%2093%5D%2C%229%22%3A%20%5B255%2C%20205%2C%20115%5D%7D&assets=asset&expression=asset%2A%28asset%3C10%29%2A%28asset%3E0%29&asset_as_band=True`,
@@ -109,6 +121,10 @@ export const DATASET_CARDS: (DatasetCardConfig & { img?: string })[] = [
     dataset_name: "Global natural/semi-natural grassland extent",
     context_layer: null as string | null,
     img: "/dataset_card_grasslands.webp",
+    cadence: "annual",
+    resolution: "30 m",
+    geographic_coverage: "global",
+    provider: "GPW Consortium, LCL",
     description:
       "Annual 30 m maps of global natural/semi-natural grassland extent from 2000 to 2022. This dataset defines grasslands very broadly such that they encompass grasslands, shrublands, and savannas by including any land cover type which contains at least 30% of dry or wet low vegetation, dominated by grasses and forbs (less than 3 meters) and a: maximum of 50% tree canopy cover (greater than 5 meters), a maximum of 70% of other woody vegetation (scrubs and open shrubland), and a maximum of 50% active cropland cover in mosaic landscapes of cropland & other vegetation.",
     tile_url: `${EOAPI_HOST}/raster/collections/grasslands-v-1/items/grasslands-2022/tiles/WebMercatorQuad/{z}/{x}/{y}.png?colormap=%7B%220%22%3A%20%5B0%2C%200%2C%200%2C%200%5D%2C%20%221%22%3A%20%5B0%2C%200%2C%200%2C%200%5D%2C%20%222%22%3A%20%5B255%2C%20153%2C%2022%2C%20255%5D%2C%20%223%22%3A%20%5B0%2C%200%2C%200%2C%200%5D%7D&assets=asset&expression=asset%2A%28asset%3C4%29%2A%28asset%3E%3D0%29&asset_as_band=True`,
@@ -127,6 +143,10 @@ export const DATASET_CARDS: (DatasetCardConfig & { img?: string })[] = [
     dataset_name: "SBTN Natural Lands Map",
     context_layer: null as string | null,
     img: "/dataset_card_natural_lands.webp",
+    cadence: "2020",
+    resolution: "30 m",
+    geographic_coverage: "global",
+    provider: "SBTN, WRI",
     description:
       "The SBTN Natural Lands Map v1.1 is a 2020 baseline map of natural and non-natural land covers intended for use by companies setting science-based targets for nature, specifically the SBTN Land target #1: no conversion of natural ecosystems. This map is global with 30m resolution and was made by compiling existing global and regional data including the GLAD Global Land Cover and Change data, ESA WorldCover, and many other land cover and use datasets.",
     tile_url: `${EOAPI_HOST}/raster/collections/natural-lands-v-1-1/tiles/WebMercatorQuad/{z}/{x}/{y}.png?colormap=%7B%222%22%3A%20%5B36%2C%20110%2C%2036%2C%20255%5D%2C%20%223%22%3A%20%5B185%2C%20185%2C%2030%2C%20255%5D%2C%20%224%22%3A%20%5B107%2C%20174%2C%20214%2C%20255%5D%2C%20%225%22%3A%20%5B6%2C%20162%2C%20133%2C%20255%5D%2C%20%226%22%3A%20%5B254%2C%20254%2C%20204%2C%20255%5D%2C%20%227%22%3A%20%5B172%2C%20209%2C%20232%2C%20255%5D%2C%20%228%22%3A%20%5B88%2C%20149%2C%2088%2C%20255%5D%2C%20%229%22%3A%20%5B9%2C%2061%2C%209%2C%20255%5D%2C%20%2210%22%3A%20%5B219%2C%20219%2C%20123%2C%20255%5D%2C%20%2211%22%3A%20%5B153%2C%20153%2C%2026%2C%20255%5D%2C%20%2212%22%3A%20%5B211%2C%20211%2C%20211%2C%20255%5D%2C%20%2213%22%3A%20%5B211%2C%20211%2C%20211%2C%20255%5D%2C%20%2214%22%3A%20%5B211%2C%20211%2C%20211%2C%20255%5D%2C%20%2215%22%3A%20%5B211%2C%20211%2C%20211%2C%20255%5D%2C%20%2216%22%3A%20%5B211%2C%20211%2C%20211%2C%20255%5D%2C%20%2217%22%3A%20%5B211%2C%20211%2C%20211%2C%20255%5D%2C%20%2218%22%3A%20%5B211%2C%20211%2C%20211%2C%20255%5D%2C%20%2219%22%3A%20%5B211%2C%20211%2C%20211%2C%20255%5D%2C%20%2220%22%3A%20%5B211%2C%20211%2C%20211%2C%20255%5D%2C%20%2221%22%3A%20%5B211%2C%20211%2C%20211%2C%20255%5D%7D&assets=asset&expression=asset%2A%28asset%3C22%29%2A%28asset%3E1%29&asset_as_band=True`,
@@ -158,6 +178,10 @@ export const DATASET_CARDS: (DatasetCardConfig & { img?: string })[] = [
     context_layer: null,
     threshold: 30,
     img: "/dataset_card_tree_cover_loss.webp",
+    cadence: "annual",
+    resolution: "30 m",
+    geographic_coverage: "global",
+    provider: "UMD",
     description:
       "Tree Cover Loss (Hansen/UMD/GLAD) maps annual global forest loss from 2001 to 2025 at 30-meter resolution using Landsat satellite imagery. It detects stand-replacement disturbances in vegetation over 5 meters tall, including natural forests and plantations. The dataset supports monitoring annual tree cover loss and deforestation trends, fire impacts, and forestry practices, and is widely used for conservation, land-use planning, and environmental policy analysis.",
     tile_url:
@@ -179,6 +203,10 @@ export const DATASET_CARDS: (DatasetCardConfig & { img?: string })[] = [
     context_layer: null,
     threshold: 30,
     img: "/dataset_card_tree_cover_loss_drivers.webp",
+    cadence: "2001-2025",
+    resolution: "1 km",
+    geographic_coverage: "global",
+    provider: "WRI / Google",
     description:
       "Shows the primary driver or cause of tree cover loss over the entire range 2001-2025. Driver classes are permanent agriculture, hard commodities, shifting cultivation, logging, wildfire, settlements & infrastructure, and other natural disturbances.",
     tile_url:
@@ -207,6 +235,10 @@ export const DATASET_CARDS: (DatasetCardConfig & { img?: string })[] = [
     context_layer: null,
     threshold: 30,
     img: "/dataset_card_tree_cover_gain.webp",
+    cadence: "20 years",
+    resolution: "30 m",
+    geographic_coverage: "global",
+    provider: "UMD",
     description:
       "Tree Cover Gain (Hansen/UMD/GLAD) identifies areas where new tree canopy was established between 2000 and 2012 at 30-meter resolution, using Landsat 7 imagery. It captures both  natural forest regrowth and tree plantation cycles, and is useful for tracking large-scale forest recovery trends. Users should note that it is a cumulative layer and should not be combined directly with loss or tree cover data to calculate net change.",
     tile_url:
@@ -228,6 +260,10 @@ export const DATASET_CARDS: (DatasetCardConfig & { img?: string })[] = [
     context_layer: null,
     threshold: 30,
     img: "/dataset_card_tree_cover.webp",
+    cadence: "2000",
+    resolution: "30 m",
+    geographic_coverage: "global",
+    provider: "UMD",
     description:
       "Tree Cover provides global percent tree canopy cover at 30-meter resolution for the year 2000 based on Landsat 7 imagery. It represents the density of vegetation over 5 meters tall, including both natural forests and plantations. This dataset is useful for establishing historical baselines and comparing tree cover density across different landscapes.",
     tile_url:
@@ -249,6 +285,10 @@ export const DATASET_CARDS: (DatasetCardConfig & { img?: string })[] = [
     context_layer: null,
     threshold: 30,
     img: "/dataset_card_net_flux.webp",
+    cadence: "",
+    resolution: "30 m",
+    geographic_coverage: "global",
+    provider: "WRI",
     description:
       "Maps the balance between emissions from forest disturbances and carbon removals from forest growth between 2001 and 2025, using a globally consistent model. This dataset supports climate reporting, forest-based mitigation strategies, and greenhouse gas inventories by identifying where forests are contributing to or helping mitigate climate change.",
     tile_url:

--- a/app/store/chat-tools/pickDataset.ts
+++ b/app/store/chat-tools/pickDataset.ts
@@ -45,6 +45,15 @@ export function pickDatasetTool(
         widgets: [datasetWidget],
         timestamp: streamMessage.timestamp,
       });
+
+      const trimmedReason = dataset.reason?.trim();
+      if (trimmedReason) {
+        addMessage({
+          type: "assistant",
+          message: trimmedReason,
+          timestamp: streamMessage.timestamp,
+        });
+      }
     }
   } catch (error) {
     console.error("Error processing pick_dataset tool:", error);

--- a/app/types/chat.ts
+++ b/app/types/chat.ts
@@ -161,6 +161,10 @@ export interface DatasetInfo {
   methodology?: string;
   cautions?: string;
   citation?: string;
+  cadence?: string;
+  resolution?: string;
+  geographic_coverage?: string;
+  provider?: string;
   [key: string]: unknown; // Allow other properties
 }
 


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help -->

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [x] Feature


## What is the current behavior?
DatasetCard was a selectable/clickable card with a dynamic border that highlighted on selection and hover, showing dataset.reason || dataset.description as the subtitle. The DatasetCardConfig type had no metadata fields (cadence, resolution, geographic coverage, provider).


## What is the new behavior?
DatasetCard is now a compact, non-interactive display card with fixed dimensions (height: 5rem, image width: 5rem) and a subtle static border (1px solid neutral.900/30); the selected, onClick props and hover/selection styles have been removed
The InfoIcon is now rendered inline inside the card title (alongside the dataset name) instead of as an absolute-positioned button, and the subtitle is hardcoded to "Yearly · Global · WRI"
DatasetCardConfig now includes four new metadata fields — cadence, resolution, geographic_coverage, and provider — populated for all existing dataset entries

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Demo
<img width="560" height="103" alt="Screenshot 2026-05-14 at 17 18 15" src="https://github.com/user-attachments/assets/87e69192-08a1-48c2-a57f-96acde5cc770" />
