### PR TITLE
Feat/slash commands

### DIFF
--- a/app/components/ChatInput.tsx
+++ b/app/components/ChatInput.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import {
   Button,
   Flex,
@@ -15,6 +15,10 @@ import useChatStore from "@/app/store/chatStore";
 import ContextButton, { ChatContextType } from "./ContextButton";
 import ContextTag from "./ContextTag";
 import ContextMenu from "./ContextMenu";
+import SlashCommandMenu, {
+  parseSlashCommand,
+  type SlashCommandMenuHandle,
+} from "./SlashCommandMenu";
 import useContextStore from "../store/contextStore";
 import { useRouter } from "next/navigation";
 
@@ -27,7 +31,8 @@ export default function ChatInput({
   const [contextModalOpen, setContextModalOpen] = useState(false);
   const [selectedContextType, setSelectedContextType] =
     useState<ChatContextType | null>(null);
-
+  const [slashActiveIndex, setSlashActiveIndex] = useState(0);
+  const slashMenuRef = useRef<SlashCommandMenuHandle>(null);
   const router = useRouter();
 
   // Hooks for responsive modal behavior
@@ -42,6 +47,8 @@ export default function ChatInput({
 
   const { sendMessage, isLoading } = useChatStore();
   const { context, removeContext } = useContextStore();
+
+  const slashState = useMemo(() => parseSlashCommand(inputValue), [inputValue]);
 
   const openContextMenu = (type: ChatContextType) => {
     setSelectedContextType(type);
@@ -70,20 +77,47 @@ export default function ChatInput({
     }
   };
 
+  const handleCommandSelect = (cmd: string) => {
+    setInputValue(`/${cmd} `);
+    setSlashActiveIndex(0);
+  };
+
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (slashState) {
+      if (e.key === "ArrowDown") {
+        e.preventDefault();
+        setSlashActiveIndex((i) => i + 1);
+        return;
+      }
+      if (e.key === "ArrowUp") {
+        e.preventDefault();
+        setSlashActiveIndex((i) => i - 1);
+        return;
+      }
+      if (e.key === "Escape") {
+        e.preventDefault();
+        setInputValue("");
+        return;
+      }
+      if (e.key === "Tab" || (e.key === "Enter" && !e.shiftKey)) {
+        e.preventDefault();
+        slashMenuRef.current?.selectActive();
+        return;
+      }
+    }
     // Submit on Enter (without Shift) or Command+Enter
     if (
       (e.key === "Enter" && !e.shiftKey && !e.metaKey) ||
       (e.key === "Enter" && e.metaKey)
     ) {
-      e.preventDefault(); // Prevents newline
+      e.preventDefault();
       submitPrompt();
     }
     // If Shift+Enter, do nothing: allow newline
   };
 
   const disabled = isLoading || isChatDisabled;
-  const message = isLoading ? "Sending..." : "Ask a question...";
+  const message = isLoading ? "Sending..." : "Ask a question or try / to focus on a dataset or area...";
 
   const isButtonDisabled = disabled || !inputValue?.trim();
   const hasContext = context.length > 0;
@@ -126,6 +160,15 @@ export default function ChatInput({
           ))}
         </Flex>
       )}
+      {slashState && !disabled && (
+        <SlashCommandMenu
+          ref={slashMenuRef}
+          slashState={slashState}
+          activeIndex={slashActiveIndex}
+          onClose={() => setInputValue("")}
+          onCommandSelect={handleCommandSelect}
+        />
+      )}
       <Textarea
         ref={setFocusEl}
         aria-label="Ask a question..."
@@ -137,7 +180,10 @@ export default function ChatInput({
         border="none"
         p={0}
         value={inputValue}
-        onChange={(e) => setInputValue(e.target.value)}
+        onChange={(e) => {
+          if (slashState) setSlashActiveIndex(0);
+          setInputValue(e.target.value);
+        }}
         onKeyDown={handleKeyDown}
         disabled={disabled}
         _disabled={{ opacity: 1 }}

--- a/app/components/SlashCommandMenu.tsx
+++ b/app/components/SlashCommandMenu.tsx
@@ -1,0 +1,299 @@
+"use client";
+
+import { forwardRef, useEffect, useImperativeHandle, useMemo, useRef } from "react";
+import { Box, Flex, Text } from "@chakra-ui/react";
+import { MapPinIcon, StackSimpleIcon } from "@phosphor-icons/react";
+import { DATASET_CARDS } from "../constants/datasets";
+import { useCustomAreasList } from "../hooks/useCustomAreasList";
+import { useSelectCustomArea } from "../hooks/useSelectCustomArea";
+import type { CustomArea } from "../schemas/api/custom_areas/get";
+import useContextStore from "../store/contextStore";
+
+export type SlashState =
+  | { phase: "command"; query: string }
+  | { phase: "area"; query: string }
+  | { phase: "dataset"; query: string };
+
+export function parseSlashCommand(value: string): SlashState | null {
+  if (!value.startsWith("/")) return null;
+  const rest = value.slice(1);
+  const spaceIdx = rest.indexOf(" ");
+  if (spaceIdx === -1) {
+    return { phase: "command", query: rest.toLowerCase() };
+  }
+  const cmd = rest.slice(0, spaceIdx).toLowerCase();
+  const query = rest.slice(spaceIdx + 1);
+  if (cmd === "area") return { phase: "area", query };
+  if (cmd === "dataset") return { phase: "dataset", query };
+  return null;
+}
+
+export interface SlashCommandMenuHandle {
+  selectActive: () => void;
+}
+
+const COMMANDS = [
+  { id: "area", label: "/area", sublabel: "Select a saved area", Icon: MapPinIcon },
+  {
+    id: "dataset",
+    label: "/dataset",
+    sublabel: "Select a dataset layer",
+    Icon: StackSimpleIcon,
+  },
+];
+
+function EmptyState({ text }: { text: string }) {
+  return (
+    <Box px={3} py={2}>
+      <Text fontSize="sm" color="fg.muted">
+        {text}
+      </Text>
+    </Box>
+  );
+}
+
+function Item({
+  label,
+  sublabel,
+  Icon,
+  color,
+  active,
+  onClick,
+}: {
+  label: string;
+  sublabel?: string;
+  Icon?: React.ComponentType<{ size?: number }>;
+  color?: string;
+  active: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <Flex
+      px={3}
+      py={1.5}
+      gap={2}
+      alignItems="center"
+      cursor="pointer"
+      bg={active ? "gray.100" : undefined}
+      _hover={{ bg: "gray.50" }}
+      onClick={onClick}
+      data-active={String(active)}
+    >
+      {color && (
+        <Box
+          flexShrink={0}
+          w="10px"
+          h="10px"
+          borderRadius="full"
+          bg={color}
+        />
+      )}
+      {!color && Icon && (
+        <Box color="gray.400" flexShrink={0}>
+          <Icon size={14} />
+        </Box>
+      )}
+      <Box minW={0}>
+        <Text fontSize="sm" lineClamp={1}>
+          {label}
+        </Text>
+        {sublabel && (
+          <Text fontSize="xs" color="fg.muted" lineClamp={1}>
+            {sublabel}
+          </Text>
+        )}
+      </Box>
+    </Flex>
+  );
+}
+
+function CommandList({
+  query,
+  activeIndex,
+  onSelect,
+}: {
+  query: string;
+  activeIndex: number;
+  onSelect: (cmd: string) => void;
+}) {
+  const items = query
+    ? COMMANDS.filter((c) => c.id.startsWith(query))
+    : COMMANDS;
+
+  if (items.length === 0) return null;
+
+  return (
+    <>
+      {items.map((cmd, i) => (
+        <Item
+          key={cmd.id}
+          label={cmd.label}
+          sublabel={cmd.sublabel}
+          Icon={cmd.Icon}
+          active={i === ((activeIndex % items.length) + items.length) % items.length}
+          onClick={() => onSelect(cmd.id)}
+        />
+      ))}
+    </>
+  );
+}
+
+function AreaResults({
+  query,
+  activeIndex,
+  onClose,
+}: {
+  query: string;
+  activeIndex: number;
+  onClose: () => void;
+}) {
+  const { customAreas, isLoading } = useCustomAreasList();
+  const selectArea = useSelectCustomArea();
+
+  const filtered = useMemo(() => {
+    const areas: CustomArea[] = (customAreas as CustomArea[] | undefined) ?? [];
+    if (!query) return areas;
+    const q = query.toLowerCase();
+    return areas.filter((a) => a.name.toLowerCase().includes(q));
+  }, [customAreas, query]);
+
+  if (isLoading) return <EmptyState text="Loading areas…" />;
+  if (filtered.length === 0) return <EmptyState text="No custom areas found" />;
+
+  return (
+    <>
+      {filtered.map((area, i) => (
+        <Item
+          key={area.id}
+          label={area.name}
+          active={i === ((activeIndex % filtered.length) + filtered.length) % filtered.length}
+          onClick={() => {
+            selectArea(area);
+            onClose();
+          }}
+        />
+      ))}
+    </>
+  );
+}
+
+function DatasetResults({
+  query,
+  activeIndex,
+  onClose,
+}: {
+  query: string;
+  activeIndex: number;
+  onClose: () => void;
+}) {
+  const { addContext } = useContextStore();
+
+  const filtered = useMemo(() => {
+    if (!query) return DATASET_CARDS;
+    const q = query.toLowerCase();
+    return DATASET_CARDS.filter((d) =>
+      d.dataset_name.toLowerCase().includes(q)
+    );
+  }, [query]);
+
+  if (filtered.length === 0) return <EmptyState text="No datasets found" />;
+
+  return (
+    <>
+      {filtered.map((card, i) => (
+        <Item
+          key={card.dataset_id}
+          label={card.dataset_name}
+          color={card.legend?.color ?? "#cccccc"}
+          active={i === ((activeIndex % filtered.length) + filtered.length) % filtered.length}
+          onClick={() => {
+            addContext({
+              contextType: "layer",
+              content: card.dataset_name,
+              datasetId: card.dataset_id,
+              tileUrl: card.tile_url ?? "",
+              layerName: card.dataset_name,
+            });
+            onClose();
+          }}
+        />
+      ))}
+    </>
+  );
+}
+
+const SlashCommandMenu = forwardRef<
+  SlashCommandMenuHandle,
+  {
+    slashState: SlashState;
+    activeIndex: number;
+    onClose: () => void;
+    onCommandSelect: (cmd: string) => void;
+  }
+>(function SlashCommandMenu(
+  { slashState, activeIndex, onClose, onCommandSelect },
+  ref
+) {
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    containerRef.current
+      ?.querySelector<HTMLElement>("[data-active='true']")
+      ?.scrollIntoView({ block: "nearest" });
+  }, [activeIndex, slashState]);
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      selectActive: () => {
+        containerRef.current
+          ?.querySelector<HTMLElement>("[data-active='true']")
+          ?.click();
+      },
+    }),
+    []
+  );
+
+  return (
+    <Box
+      ref={containerRef}
+      position="absolute"
+      bottom="calc(100% + 4px)"
+      left={0}
+      right={0}
+      bg="bg"
+      borderWidth="1px"
+      borderColor="border"
+      borderRadius="md"
+      boxShadow="md"
+      zIndex={100}
+      maxH="16rem"
+      overflowY="auto"
+      py={1}
+    >
+      {slashState.phase === "command" && (
+        <CommandList
+          query={slashState.query}
+          activeIndex={activeIndex}
+          onSelect={onCommandSelect}
+        />
+      )}
+      {slashState.phase === "area" && (
+        <AreaResults
+          query={slashState.query}
+          activeIndex={activeIndex}
+          onClose={onClose}
+        />
+      )}
+      {slashState.phase === "dataset" && (
+        <DatasetResults
+          query={slashState.query}
+          activeIndex={activeIndex}
+          onClose={onClose}
+        />
+      )}
+    </Box>
+  );
+});
+
+export default SlashCommandMenu;

--- a/app/constants/custom-areas.ts
+++ b/app/constants/custom-areas.ts
@@ -1,3 +1,6 @@
+export const CUSTOM_AREA_SOURCE = "custom" as const;
+export const CUSTOM_AREA_SUBTYPE = "custom-area" as const;
+
 export const ACCEPTED_FILE_TYPES = [".geojson"];
 export const MAX_FILE_SIZE_MB = 1;
 export const MAX_FILE_SIZE = MAX_FILE_SIZE_MB * 1024 * 1024;

--- a/app/hooks/useSelectCustomArea.ts
+++ b/app/hooks/useSelectCustomArea.ts
@@ -1,0 +1,54 @@
+import { useCallback } from "react";
+import type { Feature, MultiPolygon } from "geojson";
+import {
+  CUSTOM_AREA_SOURCE,
+  CUSTOM_AREA_SUBTYPE,
+} from "../constants/custom-areas";
+import type { CustomArea } from "../schemas/api/custom_areas/get";
+import useContextStore from "../store/contextStore";
+import useMapStore from "../store/mapStore";
+
+export function useSelectCustomArea() {
+  const { upsertContextByType } = useContextStore();
+  const { addToRegistry, addLayer, flyToGeoJsonWithRetry } = useMapStore();
+
+  return useCallback(
+    (area: CustomArea) => {
+      upsertContextByType({
+        contextType: "area",
+        content: area.name,
+        aoiData: {
+          src_id: area.id,
+          name: area.name,
+          source: CUSTOM_AREA_SOURCE,
+          subtype: CUSTOM_AREA_SUBTYPE,
+        },
+      });
+      const multi: MultiPolygon = {
+        type: "MultiPolygon",
+        coordinates: area.geometries.map((poly) => poly.coordinates),
+      };
+      const feature: Feature = {
+        type: "Feature",
+        id: area.id,
+        geometry: multi,
+        properties: { id: area.id, name: area.name },
+      };
+      addToRegistry({
+        ref: { name: area.name, source: CUSTOM_AREA_SOURCE },
+        data: feature,
+        srcId: area.id,
+        subtype: CUSTOM_AREA_SUBTYPE,
+      });
+      addLayer({
+        id: area.id,
+        name: area.name,
+        type: "geojson",
+        visible: true,
+        featureRefs: [{ name: area.name, source: CUSTOM_AREA_SOURCE }],
+      });
+      flyToGeoJsonWithRetry(feature);
+    },
+    [upsertContextByType, addToRegistry, addLayer, flyToGeoJsonWithRetry]
+  );
+}


### PR DESCRIPTION
### Summary

<img width="383" height="280" alt="ezgif com-optimize" src="https://github.com/user-attachments/assets/9c3172f4-10fa-4d3d-8170-f2e8a6953300" />

PoC to add FE slack commands that surface context-setting tools:
- Add datasets to context with `/dataset`
- Add user's custom area with `/area`

The problem this solves - hopefully this provides a slightly more visible way of surfacing what datasets we have (as well as make it easier to access them using keyboard only)

### Todo / future
- Design review
- Add GADM look up (most common query type) - likely requires new endpoint