### PR TITLE
PZB-897: Frontend for Manage Users screen for superusers to change users type

### DIFF
--- a/app/components/SettingsShell.tsx
+++ b/app/components/SettingsShell.tsx
@@ -1,0 +1,149 @@
+"use client";
+import { ReactNode } from "react";
+import {
+  Box,
+  Button,
+  ButtonGroup,
+  Flex,
+  Heading,
+  Progress,
+  Text,
+  Link as ChakraLink,
+} from "@chakra-ui/react";
+import {
+  GearIcon,
+  LifebuoyIcon,
+  MapTrifoldIcon,
+  SignOutIcon,
+  UserIcon,
+  UsersThreeIcon,
+} from "@phosphor-icons/react";
+import Link from "next/link";
+import LclLogo from "@/app/components/LclLogo";
+import useAuthStore from "@/app/store/authStore";
+import { useLogout } from "@/app/hooks/useLogout";
+
+type SettingsPath = "/dashboard" | "/manage-users";
+
+interface SettingsShellProps {
+  activePath: SettingsPath;
+  children: ReactNode;
+}
+
+export default function SettingsShell({
+  activePath,
+  children,
+}: SettingsShellProps) {
+  const { userEmail, userType, usedPrompts, totalPrompts } = useAuthStore();
+  const { logout } = useLogout();
+
+  return (
+    <Box
+      display="grid"
+      gridTemplateColumns="20rem 1fr"
+      height="100vh"
+      maxH="100vh"
+    >
+      <Flex flexDir="column" bg="bg.subtle" px={6} py={8} maxH="100%" gap={6}>
+        <ChakraLink
+          as={Link}
+          href="/"
+          display="flex"
+          alignItems="center"
+          gap="2"
+          transition="opacity 0.24s ease"
+          _hover={{ opacity: 0.8, textDecor: "none" }}
+        >
+          <LclLogo width={16} avatarOnly />
+          <Heading m={0}>Global Nature Watch</Heading>
+        </ChakraLink>
+        <ButtonGroup
+          size="sm"
+          w="full"
+          gap={2}
+          variant="outline"
+          _hover={{ "& > :not(:hover)": { opacity: "0.5" } }}
+          css={{ "& > *": { justifyContent: "flex-start", width: "100%" } }}
+          colorPalette="gray"
+          orientation="vertical"
+          alignItems="stretch"
+        >
+          <Button
+            asChild
+            bg={activePath === "/dashboard" ? "white" : undefined}
+          >
+            <Link href="/dashboard">
+              <GearIcon />
+              User Settings
+            </Link>
+          </Button>
+          {userType === "superuser" && (
+            <Button
+              asChild
+              bg={activePath === "/manage-users" ? "white" : undefined}
+            >
+              <Link href="/manage-users">
+                <UsersThreeIcon />
+                Manage Users
+              </Link>
+            </Button>
+          )}
+          <Button asChild>
+            <Link href="https://help.globalnaturewatch.org/" target="_blank">
+              <LifebuoyIcon />
+              Help
+            </Link>
+          </Button>
+          <Button asChild>
+            <Link href="/app">
+              <MapTrifoldIcon />
+              Back to Application
+            </Link>
+          </Button>
+        </ButtonGroup>
+        <Box p={4} mt="auto" bg="bg" rounded="lg">
+          <Heading size="xs" as="p" color="fg.muted">
+            Available Prompts
+          </Heading>
+          <Progress.Root
+            size="xs"
+            min={0}
+            max={totalPrompts}
+            value={usedPrompts}
+            minW="6rem"
+            rounded="full"
+            colorPalette="primary"
+          >
+            <Progress.Label
+              mb={2}
+              fontSize="xs"
+              fontWeight="normal"
+              color="fg.subtle"
+            >
+              {usedPrompts}/{totalPrompts}
+            </Progress.Label>
+            <Progress.Track>
+              <Progress.Range />
+            </Progress.Track>
+          </Progress.Root>
+        </Box>
+        <Button
+          size="sm"
+          w="full"
+          gap={2}
+          variant="outline"
+          justifyContent="flex-start"
+          onClick={logout}
+          title="Sign Out"
+        >
+          <UserIcon />
+          <Text mr="auto">{userEmail || "User"}</Text>
+          <SignOutIcon />
+        </Button>
+      </Flex>
+      <Box maxH="100%" overflowY="auto">
+        {children}
+      </Box>
+    </Box>
+  );
+}

--- a/app/components/SettingsShell.tsx
+++ b/app/components/SettingsShell.tsx
@@ -70,7 +70,7 @@ export default function SettingsShell({
         >
           <Button
             asChild
-            bg={activePath === "/dashboard" ? "white" : undefined}
+            bg={activePath === "/dashboard" ? "bg.muted" : undefined}
           >
             <Link href="/dashboard">
               <GearIcon />
@@ -80,7 +80,7 @@ export default function SettingsShell({
           {userType === "superuser" && (
             <Button
               asChild
-              bg={activePath === "/manage-users" ? "white" : undefined}
+              bg={activePath === "/manage-users" ? "bg.muted" : undefined}
             >
               <Link href="/manage-users">
                 <UsersThreeIcon />

--- a/app/components/providers/index.tsx
+++ b/app/components/providers/index.tsx
@@ -8,22 +8,12 @@ import { jwtDecode } from "jwt-decode";
 import theme from "@/app/theme";
 import { Toaster } from "@/app/components/ui/toaster";
 import DebugToastsPanel from "@/app/components/DebugToastsPanel";
-import useAuthStore, { type UserType } from "@/app/store/authStore";
+import useAuthStore from "@/app/store/authStore";
+import { UserTypeEnum, type UserType } from "@/app/schemas/api/admin/users/get";
 import { getToken, clearToken, apiFetch } from "@/app/lib/api-client";
 
-const VALID_USER_TYPES: ReadonlyArray<UserType> = [
-  "regular",
-  "admin",
-  "pro",
-  "superuser",
-  "machine",
-];
-
 function coerceUserType(value: unknown): UserType | null {
-  return typeof value === "string" &&
-    (VALID_USER_TYPES as ReadonlyArray<string>).includes(value)
-    ? (value as UserType)
-    : null;
+  return UserTypeEnum.safeParse(value).data ?? null;
 }
 
 const queryClient = new QueryClient();

--- a/app/components/providers/index.tsx
+++ b/app/components/providers/index.tsx
@@ -8,8 +8,23 @@ import { jwtDecode } from "jwt-decode";
 import theme from "@/app/theme";
 import { Toaster } from "@/app/components/ui/toaster";
 import DebugToastsPanel from "@/app/components/DebugToastsPanel";
-import useAuthStore from "@/app/store/authStore";
+import useAuthStore, { type UserType } from "@/app/store/authStore";
 import { getToken, clearToken, apiFetch } from "@/app/lib/api-client";
+
+const VALID_USER_TYPES: ReadonlyArray<UserType> = [
+  "regular",
+  "admin",
+  "pro",
+  "superuser",
+  "machine",
+];
+
+function coerceUserType(value: unknown): UserType | null {
+  return typeof value === "string" &&
+    (VALID_USER_TYPES as ReadonlyArray<string>).includes(value)
+    ? (value as UserType)
+    : null;
+}
 
 const queryClient = new QueryClient();
 
@@ -64,8 +79,9 @@ function AuthBootstrapper() {
         const email = data?.email as string | undefined;
         const id = data?.id as string | undefined;
         const hasProfile = Boolean(data?.hasProfile);
+        const userType = coerceUserType(data?.userType);
         if (email) {
-          setAuthStatus(email, id ?? "", hasProfile);
+          setAuthStatus({ email, id: id ?? "", hasProfile, userType });
         } else {
           setAuthLoaded();
         }

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -209,22 +209,29 @@ export default function UserSettingsPage() {
         (code) => config?.topics?.[code] || code
       );
       try {
-        const orttoRes = await fetch("https://ortto.wri.org/custom-forms/gnw/", {
-          method: "POST",
-          headers: { "Content-Type": "application/json" },
-          body: JSON.stringify({
-            email: form.email,
-            firstName: form.firstName,
-            lastName: form.lastName,
-            sector: form.sector,
-            jobTitle: form.jobTitle,
-            companyOrganization: form.company,
-            countryCode: form.country,
-            Topics: topicLabels,
-            receiveNewsEmails: form.receiveNewsEmails,
-          }),
-        });
-        console.log("[Client] Ortto submission status:", orttoRes.status, orttoRes.ok ? "OK" : "FAILED");
+        const orttoRes = await fetch(
+          "https://ortto.wri.org/custom-forms/gnw/",
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              email: form.email,
+              firstName: form.firstName,
+              lastName: form.lastName,
+              sector: form.sector,
+              jobTitle: form.jobTitle,
+              companyOrganization: form.company,
+              countryCode: form.country,
+              Topics: topicLabels,
+              receiveNewsEmails: form.receiveNewsEmails,
+            }),
+          }
+        );
+        console.log(
+          "[Client] Ortto submission status:",
+          orttoRes.status,
+          orttoRes.ok ? "OK" : "FAILED"
+        );
       } catch (e) {
         console.error("[Client] Ortto submission error:", e);
       }
@@ -253,388 +260,391 @@ export default function UserSettingsPage() {
   return (
     <SettingsShell activePath="/dashboard">
       <Container maxW="4xl" display="flex" flexDirection="column" py={16}>
-          {/* Header Section */}
-          <Flex
-            justifyContent="space-between"
-            alignItems="center"
-            mb={8}
-            flexWrap="wrap"
-          >
-            <Flex alignItems="center" gap={2} color="fg.muted">
-              <GearIcon size={24} />
-              <Heading as="h1" size="2xl" fontWeight="normal">
-                User Settings
-              </Heading>
-            </Flex>
-            <Button
-              colorPalette="primary"
-              mt={{ base: 4, md: 0 }}
-              size="sm"
-              onClick={handleSave}
-              loading={isSaving}
-              disabled={isSaving}
-            >
-              <FloppyDiskIcon />
-              Save changes
-            </Button>
+        {/* Header Section */}
+        <Flex
+          justifyContent="space-between"
+          alignItems="center"
+          mb={8}
+          flexWrap="wrap"
+        >
+          <Flex alignItems="center" gap={2} color="fg.muted">
+            <GearIcon size={24} />
+            <Heading as="h1" size="2xl" fontWeight="normal">
+              User Settings
+            </Heading>
           </Flex>
+          <Button
+            colorPalette="primary"
+            mt={{ base: 4, md: 0 }}
+            size="sm"
+            onClick={handleSave}
+            loading={isSaving}
+            disabled={isSaving}
+          >
+            <FloppyDiskIcon />
+            Save changes
+          </Button>
+        </Flex>
 
-          {/* Form Grid Layout */}
-          <Grid templateColumns={{ base: "1fr", md: "repeat(2, 1fr)" }} gap={6}>
-            {/* First Name */}
-            <GridItem>
-              <Field.Root id="first-name">
-                <Field.Label>First name</Field.Label>
-                <Input
-                  type="text"
-                  width="320px"
-                  value={form.firstName}
-                  onChange={(e) =>
-                    setForm((p) => ({ ...p, firstName: e.target.value }))
-                  }
-                />
-              </Field.Root>
-            </GridItem>
+        {/* Form Grid Layout */}
+        <Grid templateColumns={{ base: "1fr", md: "repeat(2, 1fr)" }} gap={6}>
+          {/* First Name */}
+          <GridItem>
+            <Field.Root id="first-name">
+              <Field.Label>First name</Field.Label>
+              <Input
+                type="text"
+                width="320px"
+                value={form.firstName}
+                onChange={(e) =>
+                  setForm((p) => ({ ...p, firstName: e.target.value }))
+                }
+              />
+            </Field.Root>
+          </GridItem>
 
-            {/* Last Name */}
-            <GridItem>
-              <Field.Root id="last-name">
-                <Field.Label>Last name</Field.Label>
-                <Input
-                  type="text"
-                  width="320px"
-                  value={form.lastName}
-                  onChange={(e) =>
-                    setForm((p) => ({ ...p, lastName: e.target.value }))
-                  }
-                />
-              </Field.Root>
-            </GridItem>
+          {/* Last Name */}
+          <GridItem>
+            <Field.Root id="last-name">
+              <Field.Label>Last name</Field.Label>
+              <Input
+                type="text"
+                width="320px"
+                value={form.lastName}
+                onChange={(e) =>
+                  setForm((p) => ({ ...p, lastName: e.target.value }))
+                }
+              />
+            </Field.Root>
+          </GridItem>
 
-            {/* Email Address */}
-            <GridItem>
-              <Field.Root id="email">
-                <Field.Label>Email address</Field.Label>
-                <Input
-                  type="email"
-                  width="320px"
-                  value={form.email}
-                  readOnly
-                  _readOnly={{
+          {/* Email Address */}
+          <GridItem>
+            <Field.Root id="email">
+              <Field.Label>Email address</Field.Label>
+              <Input
+                type="email"
+                width="320px"
+                value={form.email}
+                readOnly
+                _readOnly={{
+                  bg: "bg.subtle",
+                  color: "fg.muted",
+                  cursor: "not-allowed",
+                }}
+              />
+            </Field.Root>
+          </GridItem>
+        </Grid>
+
+        <Separator borderColor="border" my={8} />
+
+        {/* Second Section of the Form */}
+        <Heading size="xs" color="fg.subtle" fontWeight="normal">
+          Additional Details (Optional)
+        </Heading>
+        <Grid templateColumns={{ base: "1fr", md: "repeat(2, 1fr)" }} gap={6}>
+          {/* Sector */}
+          <GridItem>
+            <Field.Root id="sector">
+              <Select.Root
+                collection={sectors}
+                size="sm"
+                width="320px"
+                value={form.sector ? [form.sector] : []}
+                onValueChange={(d: ValueChangeDetails) =>
+                  setForm((p) => ({ ...p, sector: d.value[0] ?? "" }))
+                }
+              >
+                <Select.HiddenSelect />
+                <Select.Label>Sector</Select.Label>
+                <Select.Control>
+                  <Select.Trigger>
+                    <Select.ValueText placeholder="Select Sector" />
+                  </Select.Trigger>
+                  <Select.IndicatorGroup>
+                    <Select.Indicator />
+                  </Select.IndicatorGroup>
+                </Select.Control>
+                <Portal>
+                  <Select.Positioner>
+                    <Select.Content>
+                      {sectors.items.map((sector) => (
+                        <Select.Item item={sector} key={sector.value}>
+                          {sector.label}
+                          <Select.ItemIndicator />
+                        </Select.Item>
+                      ))}
+                    </Select.Content>
+                  </Select.Positioner>
+                </Portal>
+              </Select.Root>
+            </Field.Root>
+          </GridItem>
+
+          {/* Role */}
+          <GridItem>
+            <Field.Root id="role">
+              <Select.Root
+                collection={roles}
+                size="sm"
+                width="320px"
+                disabled={!form.sector}
+                value={form.role ? [form.role] : []}
+                onValueChange={(d: ValueChangeDetails) =>
+                  setForm((p) => ({ ...p, role: d.value[0] ?? "" }))
+                }
+              >
+                <Select.HiddenSelect />
+                <Select.Label>Role</Select.Label>
+                <Select.Control
+                  _disabled={{
                     bg: "bg.subtle",
-                    color: "fg.muted",
-                    cursor: "not-allowed",
                   }}
-                />
-              </Field.Root>
-            </GridItem>
-          </Grid>
-
-          <Separator borderColor="border" my={8} />
-
-          {/* Second Section of the Form */}
-          <Heading size="xs" color="fg.subtle" fontWeight="normal">
-            Additional Details (Optional)
-          </Heading>
-          <Grid templateColumns={{ base: "1fr", md: "repeat(2, 1fr)" }} gap={6}>
-            {/* Sector */}
-            <GridItem>
-              <Field.Root id="sector">
-                <Select.Root
-                  collection={sectors}
-                  size="sm"
-                  width="320px"
-                  value={form.sector ? [form.sector] : []}
-                  onValueChange={(d: ValueChangeDetails) =>
-                    setForm((p) => ({ ...p, sector: d.value[0] ?? "" }))
-                  }
                 >
-                  <Select.HiddenSelect />
-                  <Select.Label>Sector</Select.Label>
-                  <Select.Control>
-                    <Select.Trigger>
-                      <Select.ValueText placeholder="Select Sector" />
-                    </Select.Trigger>
-                    <Select.IndicatorGroup>
-                      <Select.Indicator />
-                    </Select.IndicatorGroup>
-                  </Select.Control>
-                  <Portal>
-                    <Select.Positioner>
-                      <Select.Content>
-                        {sectors.items.map((sector) => (
-                          <Select.Item item={sector} key={sector.value}>
-                            {sector.label}
-                            <Select.ItemIndicator />
-                          </Select.Item>
-                        ))}
-                      </Select.Content>
-                    </Select.Positioner>
-                  </Portal>
-                </Select.Root>
-              </Field.Root>
-            </GridItem>
+                  <Select.Trigger>
+                    <Select.ValueText placeholder="Select Role" />
+                  </Select.Trigger>
+                  <Select.IndicatorGroup>
+                    <Select.Indicator />
+                  </Select.IndicatorGroup>
+                </Select.Control>
+                <Portal>
+                  <Select.Positioner>
+                    <Select.Content>
+                      {roles.items.map((role) => (
+                        <Select.Item item={role} key={role.value}>
+                          {role.label}
+                          <Select.ItemIndicator />
+                        </Select.Item>
+                      ))}
+                    </Select.Content>
+                  </Select.Positioner>
+                </Portal>
+              </Select.Root>
+            </Field.Root>
+          </GridItem>
 
-            {/* Role */}
-            <GridItem>
-              <Field.Root id="role">
-                <Select.Root
-                  collection={roles}
-                  size="sm"
-                  width="320px"
-                  disabled={!form.sector}
-                  value={form.role ? [form.role] : []}
-                  onValueChange={(d: ValueChangeDetails) =>
-                    setForm((p) => ({ ...p, role: d.value[0] ?? "" }))
-                  }
-                >
-                  <Select.HiddenSelect />
-                  <Select.Label>Role</Select.Label>
-                  <Select.Control
-                    _disabled={{
-                      bg: "bg.subtle",
-                    }}
-                  >
-                    <Select.Trigger>
-                      <Select.ValueText placeholder="Select Role" />
-                    </Select.Trigger>
-                    <Select.IndicatorGroup>
-                      <Select.Indicator />
-                    </Select.IndicatorGroup>
-                  </Select.Control>
-                  <Portal>
-                    <Select.Positioner>
-                      <Select.Content>
-                        {roles.items.map((role) => (
-                          <Select.Item item={role} key={role.value}>
-                            {role.label}
-                            <Select.ItemIndicator />
-                          </Select.Item>
-                        ))}
-                      </Select.Content>
-                    </Select.Positioner>
-                  </Portal>
-                </Select.Root>
-              </Field.Root>
-            </GridItem>
+          {/* Job Title */}
+          <GridItem>
+            <Field.Root id="job-title">
+              <Field.Label>Job title</Field.Label>
+              <Input
+                type="text"
+                width="320px"
+                value={form.jobTitle}
+                onChange={(e) =>
+                  setForm((p) => ({ ...p, jobTitle: e.target.value }))
+                }
+              />
+            </Field.Root>
+          </GridItem>
 
-            {/* Job Title */}
-            <GridItem>
-              <Field.Root id="job-title">
-                <Field.Label>Job title</Field.Label>
-                <Input
-                  type="text"
-                  width="320px"
-                  value={form.jobTitle}
-                  onChange={(e) =>
-                    setForm((p) => ({ ...p, jobTitle: e.target.value }))
-                  }
-                />
-              </Field.Root>
-            </GridItem>
+          {/* Company / Organization */}
+          <GridItem>
+            <Field.Root id="company">
+              <Field.Label>Company / Organization</Field.Label>
+              <Input
+                type="text"
+                width="320px"
+                value={form.company}
+                onChange={(e) =>
+                  setForm((p) => ({ ...p, company: e.target.value }))
+                }
+              />
+            </Field.Root>
+          </GridItem>
 
-            {/* Company / Organization */}
-            <GridItem>
-              <Field.Root id="company">
-                <Field.Label>Company / Organization</Field.Label>
-                <Input
-                  type="text"
-                  width="320px"
-                  value={form.company}
-                  onChange={(e) =>
-                    setForm((p) => ({ ...p, company: e.target.value }))
-                  }
-                />
-              </Field.Root>
-            </GridItem>
+          {/* Country */}
+          <GridItem>
+            <Field.Root id="country">
+              <Select.Root
+                collection={countries}
+                size="sm"
+                width="320px"
+                value={form.country ? [form.country] : []}
+                onValueChange={(d: ValueChangeDetails) =>
+                  setForm((p) => ({ ...p, country: d.value[0] ?? "" }))
+                }
+              >
+                <Select.HiddenSelect />
+                <Select.Label>Country</Select.Label>
+                <Select.Control>
+                  <Select.Trigger>
+                    <Select.ValueText placeholder="Select Country" />
+                  </Select.Trigger>
+                  <Select.IndicatorGroup>
+                    <Select.Indicator />
+                  </Select.IndicatorGroup>
+                </Select.Control>
+                <Portal>
+                  <Select.Positioner>
+                    <Select.Content>
+                      {countries.items.map((country) => (
+                        <Select.Item item={country} key={country.value}>
+                          {country.label}
+                          <Select.ItemIndicator />
+                        </Select.Item>
+                      ))}
+                    </Select.Content>
+                  </Select.Positioner>
+                </Portal>
+              </Select.Root>
+            </Field.Root>
+          </GridItem>
 
-            {/* Country */}
-            <GridItem>
-              <Field.Root id="country">
-                <Select.Root
-                  collection={countries}
-                  size="sm"
-                  width="320px"
-                  value={form.country ? [form.country] : []}
-                  onValueChange={(d: ValueChangeDetails) =>
-                    setForm((p) => ({ ...p, country: d.value[0] ?? "" }))
-                  }
-                >
-                  <Select.HiddenSelect />
-                  <Select.Label>Country</Select.Label>
-                  <Select.Control>
-                    <Select.Trigger>
-                      <Select.ValueText placeholder="Select Country" />
-                    </Select.Trigger>
-                    <Select.IndicatorGroup>
-                      <Select.Indicator />
-                    </Select.IndicatorGroup>
-                  </Select.Control>
-                  <Portal>
-                    <Select.Positioner>
-                      <Select.Content>
-                        {countries.items.map((country) => (
-                          <Select.Item item={country} key={country.value}>
-                            {country.label}
-                            <Select.ItemIndicator />
-                          </Select.Item>
-                        ))}
-                      </Select.Content>
-                    </Select.Positioner>
-                  </Portal>
-                </Select.Root>
-              </Field.Root>
-            </GridItem>
+          {/* Level of technical expertise */}
+          <GridItem>
+            <Field.Root id="expertise">
+              <Select.Root
+                collection={expertises}
+                size="sm"
+                width="320px"
+                value={form.expertise ? [form.expertise] : []}
+                onValueChange={(d: ValueChangeDetails) =>
+                  setForm((p) => ({ ...p, expertise: d.value[0] ?? "" }))
+                }
+              >
+                <Select.HiddenSelect />
+                <Select.Label>Level of technical expertise</Select.Label>
+                <Select.Control>
+                  <Select.Trigger>
+                    <Select.ValueText placeholder="Select Level of technical expertise" />
+                  </Select.Trigger>
+                  <Select.IndicatorGroup>
+                    <Select.Indicator />
+                  </Select.IndicatorGroup>
+                </Select.Control>
+                <Portal>
+                  <Select.Positioner>
+                    <Select.Content>
+                      {expertises.items.map((expertise) => (
+                        <Select.Item item={expertise} key={expertise.value}>
+                          {expertise.label}
+                          <Select.ItemIndicator />
+                        </Select.Item>
+                      ))}
+                    </Select.Content>
+                  </Select.Positioner>
+                </Portal>
+              </Select.Root>
+            </Field.Root>
+          </GridItem>
 
-            {/* Level of technical expertise */}
-            <GridItem>
-              <Field.Root id="expertise">
-                <Select.Root
-                  collection={expertises}
-                  size="sm"
-                  width="320px"
-                  value={form.expertise ? [form.expertise] : []}
-                  onValueChange={(d: ValueChangeDetails) =>
-                    setForm((p) => ({ ...p, expertise: d.value[0] ?? "" }))
-                  }
-                >
-                  <Select.HiddenSelect />
-                  <Select.Label>Level of technical expertise</Select.Label>
-                  <Select.Control>
-                    <Select.Trigger>
-                      <Select.ValueText placeholder="Select Level of technical expertise" />
-                    </Select.Trigger>
-                    <Select.IndicatorGroup>
-                      <Select.Indicator />
-                    </Select.IndicatorGroup>
-                  </Select.Control>
-                  <Portal>
-                    <Select.Positioner>
-                      <Select.Content>
-                        {expertises.items.map((expertise) => (
-                          <Select.Item item={expertise} key={expertise.value}>
-                            {expertise.label}
-                            <Select.ItemIndicator />
-                          </Select.Item>
-                        ))}
-                      </Select.Content>
-                    </Select.Positioner>
-                  </Portal>
-                </Select.Root>
-              </Field.Root>
-            </GridItem>
+          {/* Preferred Language */}
+          <GridItem>
+            <Field.Root id="preferred-language">
+              <Select.Root
+                collection={languages}
+                size="sm"
+                width="320px"
+                value={form.preferredLanguage ? [form.preferredLanguage] : []}
+                onValueChange={(d: ValueChangeDetails) =>
+                  setForm((p) => ({
+                    ...p,
+                    preferredLanguage: d.value[0] ?? "",
+                  }))
+                }
+              >
+                <Select.HiddenSelect />
+                <Select.Label>Preferred language</Select.Label>
+                <Select.Control>
+                  <Select.Trigger>
+                    <Select.ValueText placeholder="Select Language" />
+                  </Select.Trigger>
+                  <Select.IndicatorGroup>
+                    <Select.Indicator />
+                  </Select.IndicatorGroup>
+                </Select.Control>
+                <Portal>
+                  <Select.Positioner>
+                    <Select.Content>
+                      {languages.items.map((lang) => (
+                        <Select.Item item={lang} key={lang.value}>
+                          {lang.label}
+                          <Select.ItemIndicator />
+                        </Select.Item>
+                      ))}
+                    </Select.Content>
+                  </Select.Positioner>
+                </Portal>
+              </Select.Root>
+              <Field.HelperText color="fg.muted" fontSize="xs" mt={1}>
+                Please note most of our communications are in English.
+              </Field.HelperText>
+            </Field.Root>
+          </GridItem>
 
-            {/* Preferred Language */}
-            <GridItem>
-              <Field.Root id="preferred-language">
-                <Select.Root
-                  collection={languages}
-                  size="sm"
-                  width="320px"
-                  value={form.preferredLanguage ? [form.preferredLanguage] : []}
-                  onValueChange={(d: ValueChangeDetails) =>
-                    setForm((p) => ({ ...p, preferredLanguage: d.value[0] ?? "" }))
-                  }
-                >
-                  <Select.HiddenSelect />
-                  <Select.Label>Preferred language</Select.Label>
-                  <Select.Control>
-                    <Select.Trigger>
-                      <Select.ValueText placeholder="Select Language" />
-                    </Select.Trigger>
-                    <Select.IndicatorGroup>
-                      <Select.Indicator />
-                    </Select.IndicatorGroup>
-                  </Select.Control>
-                  <Portal>
-                    <Select.Positioner>
-                      <Select.Content>
-                        {languages.items.map((lang) => (
-                          <Select.Item item={lang} key={lang.value}>
-                            {lang.label}
-                            <Select.ItemIndicator />
-                          </Select.Item>
-                        ))}
-                      </Select.Content>
-                    </Select.Positioner>
-                  </Portal>
-                </Select.Root>
-                <Field.HelperText color="fg.muted" fontSize="xs" mt={1}>
-                  Please note most of our communications are in English.
-                </Field.HelperText>
-              </Field.Root>
-            </GridItem>
-
-            {/* Topics (from profile) */}
-            <GridItem colSpan={{ base: 1, md: 2 }}>
-              <Field.Root id="topics">
-                <Field.Label>
-                  What area(s) are you most interested in?
-                </Field.Label>
-                <Flex gap={2} flexWrap="wrap" pt={2}>
-                  {Object.entries(config?.topics || {}).map(([code, label]) => {
-                    const selected = form.topics.includes(code);
-                    return (
-                      <Button
-                        key={code}
-                        size="xs"
-                        h={6}
-                        borderRadius="full"
-                        colorPalette={selected ? "primary" : undefined}
-                        variant={selected ? undefined : "outline"}
-                        onClick={() =>
-                          setForm((p) => ({
-                            ...p,
-                            topics: selected
-                              ? p.topics.filter((i) => i !== code)
-                              : [...p.topics, code],
-                          }))
-                        }
-                      >
-                        {label}
-                      </Button>
-                    );
-                  })}
-                </Flex>
-              </Field.Root>
-            </GridItem>
-            {/* Opt-in Checkboxes */}
-            <GridItem colSpan={{ base: 1, md: 2 }}>
-              <Flex direction="column" gap={2} pt={2}>
-                <Checkbox.Root
-                  checked={form.receiveNewsEmails}
-                  onCheckedChange={(e) =>
-                    setForm((p) => ({
-                      ...p,
-                      receiveNewsEmails: Boolean(e.checked),
-                    }))
-                  }
-                >
-                  <Checkbox.HiddenInput />
-                  <Checkbox.Control />
-                  <Checkbox.Label>
-                    Send me news, resources, and opportunities from Land &
-                    Carbon Lab.
-                  </Checkbox.Label>
-                </Checkbox.Root>
-                <Checkbox.Root
-                  checked={form.helpTestFeatures}
-                  onCheckedChange={(e) =>
-                    setForm((p) => ({
-                      ...p,
-                      helpTestFeatures: Boolean(e.checked),
-                    }))
-                  }
-                >
-                  <Checkbox.HiddenInput />
-                  <Checkbox.Control />
-                  <Checkbox.Label>
-                    Contact me about testing new features.
-                  </Checkbox.Label>
-                </Checkbox.Root>
+          {/* Topics (from profile) */}
+          <GridItem colSpan={{ base: 1, md: 2 }}>
+            <Field.Root id="topics">
+              <Field.Label>
+                What area(s) are you most interested in?
+              </Field.Label>
+              <Flex gap={2} flexWrap="wrap" pt={2}>
+                {Object.entries(config?.topics || {}).map(([code, label]) => {
+                  const selected = form.topics.includes(code);
+                  return (
+                    <Button
+                      key={code}
+                      size="xs"
+                      h={6}
+                      borderRadius="full"
+                      colorPalette={selected ? "primary" : undefined}
+                      variant={selected ? undefined : "outline"}
+                      onClick={() =>
+                        setForm((p) => ({
+                          ...p,
+                          topics: selected
+                            ? p.topics.filter((i) => i !== code)
+                            : [...p.topics, code],
+                        }))
+                      }
+                    >
+                      {label}
+                    </Button>
+                  );
+                })}
               </Flex>
-            </GridItem>
-          </Grid>
+            </Field.Root>
+          </GridItem>
+          {/* Opt-in Checkboxes */}
+          <GridItem colSpan={{ base: 1, md: 2 }}>
+            <Flex direction="column" gap={2} pt={2}>
+              <Checkbox.Root
+                checked={form.receiveNewsEmails}
+                onCheckedChange={(e) =>
+                  setForm((p) => ({
+                    ...p,
+                    receiveNewsEmails: Boolean(e.checked),
+                  }))
+                }
+              >
+                <Checkbox.HiddenInput />
+                <Checkbox.Control />
+                <Checkbox.Label>
+                  Send me news, resources, and opportunities from Land & Carbon
+                  Lab.
+                </Checkbox.Label>
+              </Checkbox.Root>
+              <Checkbox.Root
+                checked={form.helpTestFeatures}
+                onCheckedChange={(e) =>
+                  setForm((p) => ({
+                    ...p,
+                    helpTestFeatures: Boolean(e.checked),
+                  }))
+                }
+              >
+                <Checkbox.HiddenInput />
+                <Checkbox.Control />
+                <Checkbox.Label>
+                  Contact me about testing new features.
+                </Checkbox.Label>
+              </Checkbox.Root>
+            </Flex>
+          </GridItem>
+        </Grid>
       </Container>
     </SettingsShell>
   );

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -1,13 +1,10 @@
 "use client";
 import { useEffect, useMemo, useState } from "react";
 import {
-  Box,
   Button,
-  ButtonGroup,
   Flex,
   Heading,
   Select,
-  Progress,
   Checkbox,
   Grid,
   GridItem,
@@ -16,25 +13,14 @@ import {
   Field,
   Separator,
   createListCollection,
-  Text,
   Container,
-  Link as ChakraLink,
 } from "@chakra-ui/react";
-import {
-  FloppyDiskIcon,
-  GearIcon,
-  LifebuoyIcon,
-  MapTrifoldIcon,
-  SignOutIcon,
-  UserIcon,
-} from "@phosphor-icons/react";
-import Link from "next/link";
-import LclLogo from "../components/LclLogo";
+import { FloppyDiskIcon, GearIcon } from "@phosphor-icons/react";
 import { PatchProfileRequestSchema } from "@/app/schemas/api/auth/profile/patch";
 import { toaster } from "@/app/components/ui/toaster";
 import { apiFetch } from "@/app/lib/api-client";
 import { useAuthGuard } from "@/app/hooks/useAuthGuard";
-import { useLogout } from "@/app/hooks/useLogout";
+import SettingsShell from "@/app/components/SettingsShell";
 
 type ProfileConfig = {
   sectors: Record<string, string>;
@@ -82,10 +68,6 @@ export default function UserSettingsPage() {
     helpTestFeatures: false,
   });
   const [isSaving, setIsSaving] = useState(false);
-  const [promptUsage, setPromptUsage] = useState<{
-    used: number;
-    quota: number;
-  }>({ used: 0, quota: 100 });
 
   useEffect(() => {
     const load = async () => {
@@ -99,9 +81,7 @@ export default function UserSettingsPage() {
           setConfig(cfg);
         }
         if (meRes.ok) {
-          const data = await meRes.json();
-          const user = data;
-          console.log("user", user);
+          const user = await meRes.json();
           setForm((p) => ({
             ...p,
             firstName: user?.firstName ?? p.firstName,
@@ -123,13 +103,6 @@ export default function UserSettingsPage() {
               user?.helpTestFeatures ?? p.helpTestFeatures
             ),
           }));
-
-          const used =
-            typeof user?.promptsUsed === "number" ? user.promptsUsed : 0;
-          const quotaRaw =
-            typeof user?.promptQuota === "number" ? user.promptQuota : 0;
-          const quota = quotaRaw > 0 ? quotaRaw : 100;
-          setPromptUsage({ used: Math.max(0, Math.min(used, quota)), quota });
         }
       } catch {
         // ignore
@@ -236,29 +209,22 @@ export default function UserSettingsPage() {
         (code) => config?.topics?.[code] || code
       );
       try {
-        const orttoRes = await fetch(
-          "https://ortto.wri.org/custom-forms/gnw/",
-          {
-            method: "POST",
-            headers: { "Content-Type": "application/json" },
-            body: JSON.stringify({
-              email: form.email,
-              firstName: form.firstName,
-              lastName: form.lastName,
-              sector: form.sector,
-              jobTitle: form.jobTitle,
-              companyOrganization: form.company,
-              countryCode: form.country,
-              Topics: topicLabels,
-              receiveNewsEmails: form.receiveNewsEmails,
-            }),
-          }
-        );
-        console.log(
-          "[Client] Ortto submission status:",
-          orttoRes.status,
-          orttoRes.ok ? "OK" : "FAILED"
-        );
+        const orttoRes = await fetch("https://ortto.wri.org/custom-forms/gnw/", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            email: form.email,
+            firstName: form.firstName,
+            lastName: form.lastName,
+            sector: form.sector,
+            jobTitle: form.jobTitle,
+            companyOrganization: form.company,
+            countryCode: form.country,
+            Topics: topicLabels,
+            receiveNewsEmails: form.receiveNewsEmails,
+          }),
+        });
+        console.log("[Client] Ortto submission status:", orttoRes.status, orttoRes.ok ? "OK" : "FAILED");
       } catch (e) {
         console.error("[Client] Ortto submission error:", e);
       }
@@ -282,115 +248,11 @@ export default function UserSettingsPage() {
     }
   };
 
-  const { logout } = useLogout();
-
   if (!isReady) return null;
 
   return (
-    <Box
-      display="grid"
-      gridTemplateColumns="20rem 1fr"
-      height="100vh"
-      maxH="100vh"
-    >
-      <Flex flexDir="column" bg="bg.subtle" px={6} py={8} maxH="100%" gap={6}>
-        <ChakraLink
-          as={Link}
-          href="/"
-          display="flex"
-          alignItems="center"
-          gap="2"
-          transition="opacity 0.24s ease"
-          _hover={{ opacity: 0.8, textDecor: "none" }}
-        >
-          <LclLogo width={16} avatarOnly />
-          <Heading m={0}>Global Nature Watch</Heading>
-        </ChakraLink>
-        <ButtonGroup
-          size="sm"
-          w="full"
-          gap={2}
-          variant="outline"
-          _hover={{ "& > :not(:hover)": { opacity: "0.5" } }}
-          css={{ "& > *": { justifyContent: "flex-start", width: "100%" } }}
-          colorPalette="gray"
-          orientation="vertical"
-          alignItems="stretch"
-        >
-          {/* <Button asChild>
-            <Link href="#">
-              <ChatsIcon />
-              Conversations
-            </Link>
-          </Button> */}
-          {/* <Button asChild>
-            <Link href="#">
-              <ShapesIcon />
-              Templates
-            </Link>
-          </Button> */}
-          <Button asChild bg="white">
-            <Link href="#">
-              {" "}
-              <GearIcon />
-              User Settings
-            </Link>
-          </Button>
-          <Button asChild>
-            <Link href="https://help.globalnaturewatch.org/" target="_blank">
-              <LifebuoyIcon />
-              Help
-            </Link>
-          </Button>
-          <Button asChild>
-            <Link href="/app">
-              <MapTrifoldIcon />
-              Back to Application
-            </Link>
-          </Button>
-        </ButtonGroup>
-        <Box p={4} mt="auto" bg="bg" rounded="lg">
-          <Heading size="xs" as="p" color="fg.muted">
-            Available Prompts
-          </Heading>
-          <Progress.Root
-            size="xs"
-            min={0}
-            max={promptUsage.quota}
-            value={promptUsage.used}
-            minW="6rem"
-            rounded="full"
-            colorPalette="primary"
-          >
-            <Progress.Label
-              mb={2}
-              fontSize="xs"
-              fontWeight="normal"
-              color="fg.subtle"
-            >
-              {promptUsage.used}/{promptUsage.quota}
-            </Progress.Label>
-            <Progress.Track>
-              <Progress.Range />
-            </Progress.Track>
-          </Progress.Root>
-        </Box>
-        <Button
-          size="sm"
-          w="full"
-          gap={2}
-          variant="outline"
-          justifyContent="flex-start"
-          onClick={logout}
-          title="Sign Out"
-        >
-          <UserIcon />
-          <Text mr="auto">{form.email || "User"}</Text>
-          <SignOutIcon />
-        </Button>
-      </Flex>
-      <Box maxH="100%" overflowY="auto">
-        <Container maxW="4xl" display="flex" flexDirection="column" py={16}>
+    <SettingsShell activePath="/dashboard">
+      <Container maxW="4xl" display="flex" flexDirection="column" py={16}>
           {/* Header Section */}
           <Flex
             justifyContent="space-between"
@@ -671,10 +533,7 @@ export default function UserSettingsPage() {
                   width="320px"
                   value={form.preferredLanguage ? [form.preferredLanguage] : []}
                   onValueChange={(d: ValueChangeDetails) =>
-                    setForm((p) => ({
-                      ...p,
-                      preferredLanguage: d.value[0] ?? "",
-                    }))
+                    setForm((p) => ({ ...p, preferredLanguage: d.value[0] ?? "" }))
                   }
                 >
                   <Select.HiddenSelect />
@@ -776,8 +635,7 @@ export default function UserSettingsPage() {
               </Flex>
             </GridItem>
           </Grid>
-        </Container>
-      </Box>
-    </Box>
+      </Container>
+    </SettingsShell>
   );
 }

--- a/app/hooks/useAdminUserTypeUpdate.ts
+++ b/app/hooks/useAdminUserTypeUpdate.ts
@@ -1,0 +1,54 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  PatchUserTypeRequestSchema,
+  type AssignableUserType,
+} from "@/app/schemas/api/admin/users/patch";
+import {
+  UserModelSchema,
+  type UserModel,
+} from "@/app/schemas/api/admin/users/get";
+import { apiFetch } from "@/app/lib/api-client";
+
+interface UpdateUserTypeArgs {
+  userId: string;
+  userType: AssignableUserType;
+}
+
+async function updateUserType({
+  userId,
+  userType,
+}: UpdateUserTypeArgs): Promise<UserModel> {
+  const payload = PatchUserTypeRequestSchema.parse({ user_type: userType });
+
+  const res = await apiFetch(`/api/admin/users/${userId}/user-type`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+
+  if (!res.ok) {
+    let detail: string | undefined;
+    try {
+      const body = await res.json();
+      detail = body?.detail ?? body?.error;
+    } catch {}
+    const errorWithStatus = new Error(
+      detail || `Request failed: ${res.statusText}`
+    );
+    (errorWithStatus as Error & { status?: number }).status = res.status;
+    throw errorWithStatus;
+  }
+
+  const data = await res.json();
+  return UserModelSchema.parse(data);
+}
+
+export function useAdminUserTypeUpdate() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: updateUserType,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["adminUsers"] });
+    },
+  });
+}

--- a/app/hooks/useAdminUsersExport.ts
+++ b/app/hooks/useAdminUsersExport.ts
@@ -1,0 +1,44 @@
+import { useMutation } from "@tanstack/react-query";
+import { apiFetch } from "@/app/lib/api-client";
+
+interface ExportResult {
+  blob: Blob;
+  filename: string;
+}
+
+function parseFilename(header: string | null): string | null {
+  if (!header) return null;
+  const match = header.match(/filename\*?=(?:UTF-8'')?"?([^";]+)"?/i);
+  return match ? match[1] : null;
+}
+
+async function exportUsersCsv(): Promise<ExportResult> {
+  const res = await apiFetch("/api/admin/users/export?format=csv");
+
+  if (!res.ok) {
+    let detail: string | undefined;
+    try {
+      const body = await res.json();
+      detail = body?.detail ?? body?.error;
+    } catch {}
+    const errorWithStatus = new Error(
+      detail || `Request failed: ${res.statusText}`
+    );
+    (errorWithStatus as Error & { status?: number }).status = res.status;
+    throw errorWithStatus;
+  }
+
+  const filename = parseFilename(res.headers.get("Content-Disposition"));
+  if (!filename) {
+    throw new Error(
+      "Server response was missing a filename. Please try again or contact support."
+    );
+  }
+
+  const blob = await res.blob();
+  return { blob, filename };
+}
+
+export function useAdminUsersExport() {
+  return useMutation({ mutationFn: exportUsersCsv });
+}

--- a/app/hooks/useAdminUsersList.ts
+++ b/app/hooks/useAdminUsersList.ts
@@ -1,0 +1,46 @@
+import { useQuery, keepPreviousData } from "@tanstack/react-query";
+import {
+  ListUsersResponseSchema,
+  type ListUsersResponse,
+} from "@/app/schemas/api/admin/users/get";
+import { apiFetch } from "@/app/lib/api-client";
+
+async function fetchAdminUsers(
+  emailQuery: string
+): Promise<ListUsersResponse> {
+  const params = new URLSearchParams();
+  if (emailQuery) params.set("email", emailQuery);
+  params.set("limit", "50");
+
+  const res = await apiFetch(`/api/admin/users?${params.toString()}`, {
+    method: "GET",
+    headers: { "Content-Type": "application/json" },
+  });
+
+  if (!res.ok) {
+    let detail: string | undefined;
+    try {
+      const body = await res.json();
+      detail = body?.detail ?? body?.error;
+    } catch {}
+    const errorWithStatus = new Error(
+      detail || `Request failed: ${res.statusText}`
+    );
+    (errorWithStatus as Error & { status?: number }).status = res.status;
+    throw errorWithStatus;
+  }
+
+  const data = await res.json();
+  return ListUsersResponseSchema.parse(data);
+}
+
+export function useAdminUsersList(emailQuery: string) {
+  const trimmed = emailQuery.trim();
+  return useQuery<ListUsersResponse>({
+    queryKey: ["adminUsers", trimmed],
+    queryFn: () => fetchAdminUsers(trimmed),
+    enabled: trimmed.length > 0,
+    placeholderData: keepPreviousData,
+    staleTime: 5_000,
+  });
+}

--- a/app/hooks/useAdminUsersList.ts
+++ b/app/hooks/useAdminUsersList.ts
@@ -5,9 +5,7 @@ import {
 } from "@/app/schemas/api/admin/users/get";
 import { apiFetch } from "@/app/lib/api-client";
 
-async function fetchAdminUsers(
-  emailQuery: string
-): Promise<ListUsersResponse> {
+async function fetchAdminUsers(emailQuery: string): Promise<ListUsersResponse> {
   const params = new URLSearchParams();
   if (emailQuery) params.set("email", emailQuery);
   params.set("limit", "50");

--- a/app/manage-users/page.tsx
+++ b/app/manage-users/page.tsx
@@ -1,0 +1,226 @@
+"use client";
+import { useEffect, useMemo, useState } from "react";
+import {
+  Container,
+  Field,
+  Flex,
+  Heading,
+  Input,
+  Portal,
+  Select,
+  Spinner,
+  Text,
+  createListCollection,
+} from "@chakra-ui/react";
+import { UsersThreeIcon } from "@phosphor-icons/react";
+import { useAuthGuard } from "@/app/hooks/useAuthGuard";
+import useAuthStore from "@/app/store/authStore";
+import SettingsShell from "@/app/components/SettingsShell";
+import { useAdminUsersList } from "@/app/hooks/useAdminUsersList";
+import { useAdminUserTypeUpdate } from "@/app/hooks/useAdminUserTypeUpdate";
+import { toaster } from "@/app/components/ui/toaster";
+import { type UserModel } from "@/app/schemas/api/admin/users/get";
+import { type AssignableUserType } from "@/app/schemas/api/admin/users/patch";
+
+const ASSIGNABLE_TYPES: AssignableUserType[] = [
+  "regular",
+  "pro",
+  "admin",
+  "superuser",
+];
+
+type ValueChangeDetails = { value: string[] };
+
+function UserTypeSelect({
+  user,
+  isSelf,
+  isPending,
+  onChange,
+}: {
+  user: UserModel;
+  isSelf: boolean;
+  isPending: boolean;
+  onChange: (newType: AssignableUserType) => void;
+}) {
+  const collection = useMemo(
+    () =>
+      createListCollection({
+        items: ASSIGNABLE_TYPES.map((t) => ({
+          label: t.charAt(0).toUpperCase() + t.slice(1),
+          value: t,
+        })),
+        // Self-demote guard: backend rejects, but disable here for clearer UX.
+        isItemDisabled: (item) => isSelf && item.value !== "superuser",
+      }),
+    [isSelf]
+  );
+
+  return (
+    <Select.Root
+      collection={collection}
+      size="sm"
+      width="180px"
+      value={[user.userType]}
+      disabled={isPending || user.userType === "machine"}
+      onValueChange={(d: ValueChangeDetails) => {
+        const newType = d.value[0] as AssignableUserType | undefined;
+        if (newType && newType !== user.userType) {
+          onChange(newType);
+        }
+      }}
+    >
+      <Select.HiddenSelect />
+      <Select.Control>
+        <Select.Trigger>
+          <Select.ValueText />
+        </Select.Trigger>
+        <Select.IndicatorGroup>
+          <Select.Indicator />
+        </Select.IndicatorGroup>
+      </Select.Control>
+      <Portal>
+        <Select.Positioner>
+          <Select.Content>
+            {collection.items.map((item) => (
+              <Select.Item item={item} key={item.value}>
+                {item.label}
+                <Select.ItemIndicator />
+              </Select.Item>
+            ))}
+          </Select.Content>
+        </Select.Positioner>
+      </Portal>
+    </Select.Root>
+  );
+}
+
+export default function ManageUsersPage() {
+  const isReady = useAuthGuard();
+  const { userId } = useAuthStore();
+  const [query, setQuery] = useState("");
+  const [debouncedQuery, setDebouncedQuery] = useState("");
+
+  useEffect(() => {
+    const t = setTimeout(() => setDebouncedQuery(query), 250);
+    return () => clearTimeout(t);
+  }, [query]);
+
+  const { data, isLoading, isError, error } = useAdminUsersList(debouncedQuery);
+  const mutation = useAdminUserTypeUpdate();
+
+  const handleChange = (user: UserModel, newType: AssignableUserType) => {
+    mutation.mutate(
+      { userId: user.id, userType: newType },
+      {
+        onSuccess: (updated) => {
+          toaster.create({
+            title: "User updated",
+            description: `${updated.email} is now ${updated.userType}.`,
+            type: "success",
+            duration: 3000,
+          });
+        },
+        onError: (err) => {
+          toaster.create({
+            title: "Update failed",
+            description:
+              (err as Error)?.message || "Could not update user type.",
+            type: "error",
+            duration: 5000,
+          });
+        },
+      }
+    );
+  };
+
+  if (!isReady) return null;
+
+  const trimmedQuery = debouncedQuery.trim();
+
+  return (
+    <SettingsShell activePath="/manage-users">
+      <Container
+        maxW="4xl"
+        display="flex"
+        flexDirection="column"
+        py={16}
+        gap={6}
+      >
+        <Flex alignItems="center" gap={2} color="fg.muted">
+          <UsersThreeIcon size={24} />
+          <Heading as="h1" size="2xl" fontWeight="normal">
+            Manage Users
+          </Heading>
+        </Flex>
+
+        <Field.Root id="search" maxW="md">
+          <Field.Label>Search by email</Field.Label>
+          <Input
+            type="search"
+            placeholder="Type an email…"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+          />
+        </Field.Root>
+
+        {trimmedQuery.length === 0 ? (
+          <Text color="fg.muted">Type an email to search for a user.</Text>
+        ) : isLoading ? (
+          <Flex alignItems="center" gap={2} color="fg.muted">
+            <Spinner size="sm" /> Loading users…
+          </Flex>
+        ) : isError ? (
+          <Text color="fg.error">
+            {(error as Error)?.message || "Failed to load users."}
+          </Text>
+        ) : !data || data.length === 0 ? (
+          <Text color="fg.muted">No users match that email.</Text>
+        ) : (
+          <Flex direction="column" gap={2}>
+            {data.map((user) => {
+              const isSelf = user.id === userId;
+              const isPending =
+                mutation.isPending &&
+                mutation.variables?.userId === user.id;
+              return (
+                <Flex
+                  key={user.id}
+                  alignItems="center"
+                  justifyContent="space-between"
+                  p={4}
+                  borderWidth="1px"
+                  borderColor="border"
+                  rounded="md"
+                  gap={4}
+                >
+                  <Flex direction="column" minW={0} flex="1">
+                    <Text fontWeight="medium" truncate>
+                      {user.email}
+                      {isSelf && (
+                        <Text as="span" color="fg.muted" fontWeight="normal">
+                          {" "}
+                          (you)
+                        </Text>
+                      )}
+                    </Text>
+                    {user.name && (
+                      <Text color="fg.muted" fontSize="sm" truncate>
+                        {user.name}
+                      </Text>
+                    )}
+                  </Flex>
+                  <UserTypeSelect
+                    user={user}
+                    isSelf={isSelf}
+                    isPending={isPending}
+                    onChange={(newType) => handleChange(user, newType)}
+                  />
+                </Flex>
+              );
+            })}
+          </Flex>
+        )}
+      </Container>
+    </SettingsShell>
+  );
+}

--- a/app/manage-users/page.tsx
+++ b/app/manage-users/page.tsx
@@ -22,14 +22,12 @@ import { useAdminUserTypeUpdate } from "@/app/hooks/useAdminUserTypeUpdate";
 import { useAdminUsersExport } from "@/app/hooks/useAdminUsersExport";
 import { toaster } from "@/app/components/ui/toaster";
 import { type UserModel } from "@/app/schemas/api/admin/users/get";
-import { type AssignableUserType } from "@/app/schemas/api/admin/users/patch";
+import {
+  AssignableUserTypeEnum,
+  type AssignableUserType,
+} from "@/app/schemas/api/admin/users/patch";
 
-const ASSIGNABLE_TYPES: AssignableUserType[] = [
-  "regular",
-  "pro",
-  "admin",
-  "superuser",
-];
+const ASSIGNABLE_TYPES = AssignableUserTypeEnum.options;
 
 type ValueChangeDetails = { value: string[] };
 

--- a/app/manage-users/page.tsx
+++ b/app/manage-users/page.tsx
@@ -180,8 +180,7 @@ export default function ManageUsersPage() {
             {data.map((user) => {
               const isSelf = user.id === userId;
               const isPending =
-                mutation.isPending &&
-                mutation.variables?.userId === user.id;
+                mutation.isPending && mutation.variables?.userId === user.id;
               return (
                 <Flex
                   key={user.id}

--- a/app/manage-users/page.tsx
+++ b/app/manage-users/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { useEffect, useMemo, useState } from "react";
 import {
+  Button,
   Container,
   Field,
   Flex,
@@ -12,12 +13,13 @@ import {
   Text,
   createListCollection,
 } from "@chakra-ui/react";
-import { UsersThreeIcon } from "@phosphor-icons/react";
+import { DownloadSimpleIcon, UsersThreeIcon } from "@phosphor-icons/react";
 import { useAuthGuard } from "@/app/hooks/useAuthGuard";
 import useAuthStore from "@/app/store/authStore";
 import SettingsShell from "@/app/components/SettingsShell";
 import { useAdminUsersList } from "@/app/hooks/useAdminUsersList";
 import { useAdminUserTypeUpdate } from "@/app/hooks/useAdminUserTypeUpdate";
+import { useAdminUsersExport } from "@/app/hooks/useAdminUsersExport";
 import { toaster } from "@/app/components/ui/toaster";
 import { type UserModel } from "@/app/schemas/api/admin/users/get";
 import { type AssignableUserType } from "@/app/schemas/api/admin/users/patch";
@@ -107,6 +109,37 @@ export default function ManageUsersPage() {
 
   const { data, isLoading, isError, error } = useAdminUsersList(debouncedQuery);
   const mutation = useAdminUserTypeUpdate();
+  const exportMutation = useAdminUsersExport();
+
+  const handleDownloadCsv = () => {
+    exportMutation.mutate(undefined, {
+      onSuccess: ({ blob, filename }) => {
+        const link = document.createElement("a");
+        const url = URL.createObjectURL(blob);
+        link.setAttribute("href", url);
+        link.setAttribute("download", filename);
+        link.style.visibility = "hidden";
+        document.body.appendChild(link);
+        link.click();
+        document.body.removeChild(link);
+        URL.revokeObjectURL(url);
+        toaster.create({
+          title: "Download started",
+          description: filename,
+          type: "success",
+          duration: 3000,
+        });
+      },
+      onError: (err) => {
+        toaster.create({
+          title: "Download failed",
+          description: (err as Error)?.message || "Could not download CSV.",
+          type: "error",
+          duration: 5000,
+        });
+      },
+    });
+  };
 
   const handleChange = (user: UserModel, newType: AssignableUserType) => {
     mutation.mutate(
@@ -146,11 +179,23 @@ export default function ManageUsersPage() {
         py={16}
         gap={6}
       >
-        <Flex alignItems="center" gap={2} color="fg.muted">
-          <UsersThreeIcon size={24} />
-          <Heading as="h1" size="2xl" fontWeight="normal">
-            Manage Users
-          </Heading>
+        <Flex alignItems="center" justifyContent="space-between" gap={4}>
+          <Flex alignItems="center" gap={2} color="fg.muted">
+            <UsersThreeIcon size={24} />
+            <Heading as="h1" size="2xl" fontWeight="normal">
+              Manage Users
+            </Heading>
+          </Flex>
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={handleDownloadCsv}
+            loading={exportMutation.isPending}
+            disabled={exportMutation.isPending}
+          >
+            <DownloadSimpleIcon />
+            Download CSV
+          </Button>
         </Flex>
 
         <Field.Root id="search" maxW="md">

--- a/app/schemas/api/admin/users/get.ts
+++ b/app/schemas/api/admin/users/get.ts
@@ -1,0 +1,26 @@
+import { z } from "zod";
+
+export const UserTypeEnum = z.enum([
+  "regular",
+  "admin",
+  "pro",
+  "superuser",
+  "machine",
+]);
+export type UserType = z.infer<typeof UserTypeEnum>;
+
+export const UserModelSchema = z
+  .object({
+    id: z.string(),
+    email: z.string(),
+    name: z.string().nullable().optional(),
+    userType: UserTypeEnum,
+    hasProfile: z.boolean().optional(),
+    createdAt: z.string().optional(),
+    updatedAt: z.string().optional(),
+  })
+  .passthrough();
+export type UserModel = z.infer<typeof UserModelSchema>;
+
+export const ListUsersResponseSchema = z.array(UserModelSchema);
+export type ListUsersResponse = z.infer<typeof ListUsersResponseSchema>;

--- a/app/schemas/api/admin/users/patch.ts
+++ b/app/schemas/api/admin/users/patch.ts
@@ -1,0 +1,14 @@
+import { z } from "zod";
+
+export const AssignableUserTypeEnum = z.enum([
+  "regular",
+  "admin",
+  "pro",
+  "superuser",
+]);
+export type AssignableUserType = z.infer<typeof AssignableUserTypeEnum>;
+
+export const PatchUserTypeRequestSchema = z.object({
+  user_type: AssignableUserTypeEnum,
+});
+export type PatchUserTypeRequest = z.infer<typeof PatchUserTypeRequestSchema>;

--- a/app/store/authStore.ts
+++ b/app/store/authStore.ts
@@ -1,7 +1,6 @@
 import { create } from "zustand";
 import { API_CONFIG } from "@/app/config/api";
-
-export type UserType = "regular" | "admin" | "pro" | "superuser" | "machine";
+import { type UserType } from "@/app/schemas/api/admin/users/get";
 
 interface AuthState {
   userId: string | null;

--- a/app/store/authStore.ts
+++ b/app/store/authStore.ts
@@ -1,9 +1,17 @@
 import { create } from "zustand";
 import { API_CONFIG } from "@/app/config/api";
 
+export type UserType =
+  | "regular"
+  | "admin"
+  | "pro"
+  | "superuser"
+  | "machine";
+
 interface AuthState {
   userId: string | null;
   userEmail: string | null;
+  userType: UserType | null;
   isAuthenticated: boolean;
   hasProfile: boolean;
   authLoaded: boolean;
@@ -13,7 +21,12 @@ interface AuthState {
   isLoadingMetadata: boolean;
   setPromptUsage: (used: number, total: number) => void;
   setUsageFromHeaders: (headers: Headers | Record<string, string>) => void;
-  setAuthStatus: (email: string, id: string, hasProfile: boolean) => void;
+  setAuthStatus: (args: {
+    email: string;
+    id: string;
+    hasProfile: boolean;
+    userType: UserType | null;
+  }) => void;
   setAuthLoaded: () => void;
   clearAuth: () => void;
   fetchMetadata: () => Promise<void>;
@@ -22,6 +35,7 @@ interface AuthState {
 const useAuthStore = create<AuthState>()((set) => ({
   userId: null,
   userEmail: null,
+  userType: null,
   isAuthenticated: false,
   hasProfile: false,
   authLoaded: false,
@@ -68,10 +82,11 @@ const useAuthStore = create<AuthState>()((set) => ({
       };
     });
   },
-  setAuthStatus: (email, id, hasProfile) => {
+  setAuthStatus: ({ email, id, hasProfile, userType }) => {
     set({
       userId: id,
       userEmail: email,
+      userType,
       isAuthenticated: true,
       hasProfile,
       authLoaded: true,
@@ -84,6 +99,7 @@ const useAuthStore = create<AuthState>()((set) => ({
     set({
       userId: null,
       userEmail: null,
+      userType: null,
       isAuthenticated: false,
       hasProfile: false,
       authLoaded: true,

--- a/app/store/authStore.ts
+++ b/app/store/authStore.ts
@@ -1,12 +1,7 @@
 import { create } from "zustand";
 import { API_CONFIG } from "@/app/config/api";
 
-export type UserType =
-  | "regular"
-  | "admin"
-  | "pro"
-  | "superuser"
-  | "machine";
+export type UserType = "regular" | "admin" | "pro" | "superuser" | "machine";
 
 interface AuthState {
   userId: string | null;


### PR DESCRIPTION
This:

 - Adds a new `/manage-users/` route where superusers can search for users and modify their "user type"
 - Adds a link to Manage Users on the `dashboard` page if a user is `superuser`
 - On the Manage Users page, presents a UI to search for a user, show results, and then modify the user type of a user in the result list.

This is a demo of what it looks like:

https://github.com/user-attachments/assets/73e76e6e-0dc7-4a16-82c1-2e5678acf1c2

@kamicut I think I'm mostly concerned about the refactoring that pulled out stuff from the dashboard to re-use on the Manage Users page. I tried to split up the steps into separate commits to make reviewing easier, but let me know if there's anything else I can do?

To test: You need to be a `superuser` on staging. @kamicut I have made your devseed email a superuser. If anyone else is testing this, let me know and I can bump you to superuser on staging.
