### PR TITLE
Add dataset card for IFL

### DIFF
--- a/app/constants/datasets.ts
+++ b/app/constants/datasets.ts
@@ -55,6 +55,26 @@ export const CONTEXT_LAYER_METADATA: Record<string, ContextLayerMetadata> = {
       note: "Extent of primary humid tropical forests in 2001. Pan-tropical coverage at 30m resolution (UMD/GLAD).",
     },
   },
+  ifl: {
+    dataset_id: 10,
+    dataset_name: "Intact Forest Landscapes",
+    context_layer: null as string | null,
+    description:
+      "The Intact Forest Landscapes (IFL) data set identifies unbroken expanses of natural ecosystems within the zone of forest extent that show no signs of significant human activity and are large enough that all native biodiversity, including viable populations of wide-ranging species, could be maintained.",
+    legend: {
+      title: "Intact Forest Landscapes (2000-2020)",
+      color: "#5C8C50",
+      items: [
+        { label: "Intact Forest Landscapes", color: "#5C8C50" },
+        { label: "Reduction in extent 2000-2013", color: "#91896F" },
+        { label: "Reduction in extent 2013-2016", color: "#969904" },
+        { label: "Reduction in extent 2016-2020", color: "#635731" },
+      ],
+      type: "symbol",
+      info: "Identifies the world's last remaining unfragmented forest landscapes, large enough to retain all native biodiversity and showing no signs of human alteration.",
+      note: "Extent of Intact Forest Landscapes (IFL) in 2000-2020. Global coverage, IFL Mapping Team.",
+    },
+  },
 };
 
 export const DATASET_CARDS: (DatasetCardConfig & { img?: string })[] = [


### PR DESCRIPTION
Adds IFL contextual layer item to datasets.ts so the dataset card can exposed to the user.