### PR TITLE
[PZB-840] Legend redesign

### DIFF
--- a/app/components/ContextMenu.tsx
+++ b/app/components/ContextMenu.tsx
@@ -242,7 +242,7 @@ function AreaCardList({
 function AreaMenu() {
   const { customAreas } = useCustomAreasListSuspense();
   const { addToRegistry, addLayer, flyToGeoJsonWithRetry } = useMapStore();
-  const { context, upsertContextByType } = useContextStore();
+  const { context, addContext } = useContextStore();
   const [query, setQuery] = useState("");
 
   const filtered = useMemo(() => {
@@ -276,7 +276,9 @@ function AreaMenu() {
   );
 
   const handleSelectArea = (area: { id: string; name: string }) => {
-    upsertContextByType({
+    // Areas stack — each selection is its own context item rendered as a chip.
+    // The existing `cards` lookup prevents re-selecting the same area twice.
+    addContext({
       contextType: "area",
       content: area.name,
       aoiData: {

--- a/app/components/DebugToastsPanel.tsx
+++ b/app/components/DebugToastsPanel.tsx
@@ -14,7 +14,7 @@ import useMapStore from "@/app/store/mapStore";
 import useChatStore from "@/app/store/chatStore";
 import { getToolErrorMessage } from "@/app/lib/tool-display";
 
-const GLOBAL_LAYER_ID = "global-layer";
+const GLOBAL_LAYER_ID = "Global Layer";
 
 const TOOL_ERROR_OPTIONS: Array<{ name: string; label: string }> = [
   { name: "generate_insights", label: "Insights" },

--- a/app/components/Map.tsx
+++ b/app/components/Map.tsx
@@ -140,7 +140,7 @@ function Map({ disableMapAreaControls }: { disableMapAreaControls?: boolean }) {
         >
           <Layer id="background-tiles" type="raster" />
         </Source>
-        {layers.length > 0 && (
+        {(layers.length > 0 || aois.length > 0) && (
           <Button
             variant="subtle"
             position="absolute"

--- a/app/components/Map.tsx
+++ b/app/components/Map.tsx
@@ -22,8 +22,9 @@ import {
 } from "@chakra-ui/react";
 import { ListDashesIcon, PlusIcon, XIcon } from "@phosphor-icons/react";
 import useMapStore from "@/app/store/mapStore";
-import MapAreaControls from "./MapAreaControls";
 import useContextStore from "@/app/store/contextStore";
+import { useShallow } from "zustand/react/shallow";
+import MapAreaControls from "./MapAreaControls";
 import DynamicTileLayers, {
   RASTER_TOP_SENTINEL_ID,
 } from "./map/layers/DynamicTileLayers";
@@ -47,9 +48,10 @@ function Map({ disableMapAreaControls }: { disableMapAreaControls?: boolean }) {
   useEffect(() => {
     registerPrimaryForestProtocol();
   }, []);
-  const { layers, handleLayerAction } = useLegendHook();
-  const { context } = useContextStore();
-  const areas = context.filter((c) => c.contextType === "area");
+  const { layers, handleLayerAction, aois, handleRemoveAoi } = useLegendHook();
+  const areas = useContextStore(
+    useShallow((s) => s.context.filter((c) => c.contextType === "area"))
+  );
   const onMapLoad = () => {
     if (mapRef.current) {
       const map = mapRef.current.getMap();
@@ -166,7 +168,12 @@ function Map({ disableMapAreaControls }: { disableMapAreaControls?: boolean }) {
           </Button>
         )}
         <Box display={{ base: showLegend ? "inherit" : "none", md: "inherit" }}>
-          <Legend layers={layers} onLayerAction={handleLayerAction} />
+          <Legend
+            layers={layers}
+            onLayerAction={handleLayerAction}
+            aois={aois}
+            onRemoveAoi={handleRemoveAoi}
+          />
         </Box>
 
         {/* Sentinel layer: caps raster layers below AOI/GeoJSON outlines.

--- a/app/components/legend/LayerEntry.tsx
+++ b/app/components/legend/LayerEntry.tsx
@@ -10,8 +10,6 @@ import {
 } from "@chakra-ui/react";
 import {
   InfoIcon,
-  EyeIcon,
-  EyeClosedIcon,
   XIcon,
   CircleHalfIcon,
   CaretDownIcon,
@@ -36,11 +34,9 @@ export function LayerEntry(
   const {
     id,
     title,
-    dateRange,
-    parametersText,
+    params,
     symbology,
     children,
-    visible,
     opacity,
     hideOpacityControl,
     hideRemoveControl,
@@ -49,7 +45,6 @@ export function LayerEntry(
     expanded = false,
     onToggleExpand,
   } = props;
-  const metadataText = [dateRange, parametersText].filter(Boolean).join(" · ");
 
   return (
     <Flex
@@ -85,16 +80,9 @@ export function LayerEntry(
           >
             <CaretDownIcon size={12} />
           </IconButton>
-          <Flex flexDir="column" minW={0}>
-            <Heading as="h3" size="sm" m={0} truncate>
-              {title}
-            </Heading>
-            {metadataText && (
-              <Text fontSize="xs" fontWeight="normal" color="fg.muted" truncate>
-                {metadataText}
-              </Text>
-            )}
-          </Flex>
+          <Heading as="h3" size="sm" m={0} truncate>
+            {title}
+          </Heading>
         </Flex>
         <ButtonGroup
           variant="ghost"
@@ -145,16 +133,6 @@ export function LayerEntry(
               </IconButton>
             </OpacityControl>
           )}
-          <IconButton
-            onClick={() =>
-              onLayerAction({
-                action: "visibility",
-                payload: { id: id, visible: !visible },
-              })
-            }
-          >
-            {visible ? <EyeIcon /> : <EyeClosedIcon />}
-          </IconButton>
           {!hideRemoveControl && (
             <IconButton
               onClick={() =>
@@ -167,10 +145,48 @@ export function LayerEntry(
         </ButtonGroup>
       </Flex>
 
-      {/* Collapsible body — symbology + notes */}
+      {/* Collapsible body — params, symbology + notes */}
       <Collapsible.Root open={expanded}>
         <Collapsible.Content css={{ transition: "height 0.15s ease" }}>
           <Flex flexDir="column" gap={2} pt={2} pr={4}>
+            {params && params.length > 0 && (
+              <Flex gap={1} flexWrap="wrap" alignItems="center">
+                {params.map((p) => (
+                  <Flex
+                    key={p.label}
+                    alignItems="center"
+                    gap="4px"
+                    h="20px"
+                    px="6px"
+                    borderRadius="sm"
+                    border="1px solid"
+                    borderColor="#E0E2E5"
+                    fontFamily="mono"
+                    fontSize="10px"
+                    flexShrink={0}
+                  >
+                    <Text
+                      as="span"
+                      fontWeight="normal"
+                      lineHeight="16px"
+                      letterSpacing="0.5px"
+                      color="#A51EC7"
+                    >
+                      {p.label}
+                    </Text>
+                    <Text
+                      as="span"
+                      fontWeight="500"
+                      lineHeight="16px"
+                      letterSpacing="0"
+                      textAlign="center"
+                    >
+                      {p.value}
+                    </Text>
+                  </Flex>
+                ))}
+              </Flex>
+            )}
             {symbology}
             {children}
           </Flex>

--- a/app/components/legend/LayerEntry.tsx
+++ b/app/components/legend/LayerEntry.tsx
@@ -2,6 +2,7 @@ import {
   Flex,
   Heading,
   Text,
+  Box,
   ButtonGroup,
   IconButton,
   Popover,
@@ -13,9 +14,14 @@ import {
   XIcon,
   CircleHalfIcon,
   CaretDownIcon,
+  ArrowBendDownRightIcon,
 } from "@phosphor-icons/react";
 import { OpacityControl } from "./OpacityControl";
-import type { LegendLayer, LayerActionHandler } from "./types";
+import type {
+  LegendLayer,
+  LegendContextLayer,
+  LayerActionHandler,
+} from "./types";
 
 /**
  * LayerEntry component displaying details, controls, and legend swatches for a
@@ -35,6 +41,7 @@ export function LayerEntry(
     id,
     title,
     params,
+    contextLayer,
     symbology,
     children,
     opacity,
@@ -145,10 +152,11 @@ export function LayerEntry(
         </ButtonGroup>
       </Flex>
 
-      {/* Collapsible body — params, symbology + notes */}
+      {/* Collapsible body — symbology → params → within → notes */}
       <Collapsible.Root open={expanded}>
         <Collapsible.Content css={{ transition: "height 0.15s ease" }}>
           <Flex flexDir="column" gap={2} pt={2} pr={4}>
+            {symbology}
             {params && params.length > 0 && (
               <Flex gap={1} flexWrap="wrap" alignItems="center">
                 {params.map((p) => (
@@ -187,11 +195,96 @@ export function LayerEntry(
                 ))}
               </Flex>
             )}
-            {symbology}
+            {contextLayer && (
+              <ContextLayerRow
+                contextLayer={contextLayer}
+                onLayerAction={onLayerAction}
+              />
+            )}
             {children}
           </Flex>
         </Collapsible.Content>
       </Collapsible.Root>
+    </Flex>
+  );
+}
+
+/**
+ * Indented "within" row shown inside an expanded layer card when a contextual
+ * sub-layer is active. e.g. "↳ within ■ Primary Forests (2001)"
+ */
+function ContextLayerRow(props: {
+  contextLayer: LegendContextLayer;
+  onLayerAction: LayerActionHandler;
+}) {
+  const { contextLayer, onLayerAction } = props;
+
+  return (
+    <Flex flexDir="column" gap={1}>
+      <Box h="1px" bg="border" mx={-4} />
+      <Flex alignItems="center" gap={1.5} pl={3}>
+        <ArrowBendDownRightIcon
+          size={12}
+          color="var(--chakra-colors-fg-muted)"
+        />
+        <Text fontSize="xs" color="fg.muted" fontStyle="italic" flexShrink={0}>
+          within
+        </Text>
+        {/* Colour swatch */}
+        <Box
+          w="10px"
+          h="10px"
+          borderRadius="2px"
+          bg={contextLayer.color}
+          flexShrink={0}
+        />
+        <Text fontSize="xs" truncate flex={1}>
+          {contextLayer.title}
+        </Text>
+        <ButtonGroup
+          variant="ghost"
+          size="xs"
+          gap={0}
+          flexShrink={0}
+          css={{ "& button": { h: 5, minW: 5 } }}
+        >
+          {contextLayer.info && (
+            <Popover.Root>
+              <Popover.Trigger asChild>
+                <IconButton>
+                  <InfoIcon />
+                </IconButton>
+              </Popover.Trigger>
+              <Portal>
+                <Popover.Positioner>
+                  <Popover.Content>
+                    <Popover.Arrow />
+                    <Popover.Body>
+                      <Popover.Title fontWeight="medium">
+                        Layer information
+                      </Popover.Title>
+                      <Text my="4">{contextLayer.info}</Text>
+                    </Popover.Body>
+                  </Popover.Content>
+                </Popover.Positioner>
+              </Portal>
+            </Popover.Root>
+          )}
+          <OpacityControl
+            value={contextLayer.opacity}
+            onValueChange={(value) =>
+              onLayerAction({
+                action: "opacity",
+                payload: { id: contextLayer.id, opacity: value },
+              })
+            }
+          >
+            <IconButton>
+              <CircleHalfIcon />
+            </IconButton>
+          </OpacityControl>
+        </ButtonGroup>
+      </Flex>
     </Flex>
   );
 }

--- a/app/components/legend/Legend.tsx
+++ b/app/components/legend/Legend.tsx
@@ -1,14 +1,23 @@
 import { useEffect, useState } from "react";
-import { Flex, Text, IconButton, chakra, Collapsible } from "@chakra-ui/react";
+import {
+  Flex,
+  Box,
+  Text,
+  IconButton,
+  chakra,
+  Collapsible,
+} from "@chakra-ui/react";
 import {
   DotsSixVerticalIcon,
   StackIcon,
   CaretDownIcon,
   CaretUpIcon,
+  XIcon,
 } from "@phosphor-icons/react";
 import { Reorder, useDragControls } from "motion/react";
 
 import { LayerActionHandler, LegendLayer } from "./types";
+import type { LegendAoi } from "./useLegendHook";
 import { LayerEntry } from "./LayerEntry";
 
 const ChReorderGroup = chakra(Reorder.Group);
@@ -20,6 +29,8 @@ const ChReorderItem = chakra(Reorder.Item);
 interface LegendProps {
   layers: LegendLayer[];
   onLayerAction?: LayerActionHandler;
+  aois?: LegendAoi[];
+  onRemoveAoi?: (contextId: string) => void;
 }
 
 /**
@@ -29,7 +40,7 @@ interface LegendProps {
  * @param props.layers - Array of LegendLayer objects to display.
  */
 export function Legend(props: LegendProps) {
-  const { layers, onLayerAction } = props;
+  const { layers, onLayerAction, aois, onRemoveAoi } = props;
 
   // Controls whether the whole legend body is collapsed to just the header.
   const [isCollapsed, setIsCollapsed] = useState(false);
@@ -177,6 +188,58 @@ export function Legend(props: LegendProps) {
               />
             ))}
           </ChReorderGroup>
+          {aois && aois.length > 0 && (
+            <>
+              <Box h="1px" bg="border" />
+              <Flex gap={1} flexWrap="wrap" p={2}>
+                {aois.map((aoi) => (
+                  <Flex
+                    key={`${aoi.contextId}-${aoi.name}`}
+                    alignItems="center"
+                    gap="4px"
+                    h="20px"
+                    pl="6px"
+                    pr="4px"
+                    borderRadius="sm"
+                    border="1px solid"
+                    borderColor="#E0E2E5"
+                    fontFamily="mono"
+                    fontSize="10px"
+                    flexShrink={0}
+                  >
+                    <Text
+                      as="span"
+                      fontWeight="normal"
+                      lineHeight="16px"
+                      letterSpacing="0.5px"
+                      color="#A51EC7"
+                    >
+                      AREA
+                    </Text>
+                    <Text
+                      as="span"
+                      fontWeight="500"
+                      lineHeight="16px"
+                      letterSpacing="0"
+                    >
+                      {aoi.name}
+                    </Text>
+                    <IconButton
+                      variant="ghost"
+                      size="xs"
+                      p={0}
+                      minW="12px"
+                      h="12px"
+                      aria-label={`Remove ${aoi.name}`}
+                      onClick={() => onRemoveAoi?.(aoi.contextId)}
+                    >
+                      <XIcon size={10} />
+                    </IconButton>
+                  </Flex>
+                ))}
+              </Flex>
+            </>
+          )}
         </Collapsible.Content>
       </Collapsible.Root>
     </Flex>

--- a/app/components/legend/Legend.tsx
+++ b/app/components/legend/Legend.tsx
@@ -1,12 +1,11 @@
 import { useEffect, useState } from "react";
+import { Flex, Text, IconButton, chakra, Collapsible } from "@chakra-ui/react";
 import {
-  Flex,
-  Heading,
-  VisuallyHidden,
-  IconButton,
-  chakra,
-} from "@chakra-ui/react";
-import { DotsSixVerticalIcon } from "@phosphor-icons/react";
+  DotsSixVerticalIcon,
+  StackIcon,
+  CaretDownIcon,
+  CaretUpIcon,
+} from "@phosphor-icons/react";
 import { Reorder, useDragControls } from "motion/react";
 
 import { LayerActionHandler, LegendLayer } from "./types";
@@ -31,6 +30,9 @@ interface LegendProps {
  */
 export function Legend(props: LegendProps) {
   const { layers, onLayerAction } = props;
+
+  // Controls whether the whole legend body is collapsed to just the header.
+  const [isCollapsed, setIsCollapsed] = useState(false);
 
   // Track which layers are expanded (multiple can be open).
   const [expandedIds, setExpandedIds] = useState<Set<string>>(new Set());
@@ -97,43 +99,86 @@ export function Legend(props: LegendProps) {
       flexDirection="column"
       overflow="hidden"
     >
-      <VisuallyHidden>
-        <Heading>Map Legend</Heading>
-      </VisuallyHidden>
-      <ChReorderGroup
-        axis="y"
-        values={layers}
-        onReorder={(layers: LegendLayer[]) =>
-          onLayerAction?.({ action: "reorder", payload: { layers } })
-        }
-        listStyleType="none"
-        fontSize="xs"
-        p={0}
-        m={0}
-        w="100%"
-        overflowY="auto"
-        flex={1}
+      {/* Always-visible header — click the caret to collapse/expand */}
+      <Flex
+        px={3}
+        py={2}
+        alignItems="center"
+        justifyContent="space-between"
+        borderBottom="1px solid"
+        borderColor="border"
+        flexShrink={0}
       >
-        {layers.map((item) => (
-          <Item
-            key={item.id}
-            item={item}
-            expanded={expandedIds.has(item.id)}
-            onToggleExpand={() =>
-              setExpandedIds((prev) => {
-                const next = new Set(prev);
-                if (next.has(item.id)) {
-                  next.delete(item.id);
-                } else {
-                  next.add(item.id);
-                }
-                return next;
-              })
+        {/* Icon + label group (matches Figma: width 83, height 16, gap 8px) */}
+        <Flex alignItems="center" gap={2}>
+          <StackIcon size={12} color="#0049AA" />
+          <Text
+            fontSize="10px"
+            fontWeight="400"
+            fontFamily="mono"
+            letterSpacing="wider"
+            textTransform="uppercase"
+            color="fg.muted"
+          >
+            Map layers
+          </Text>
+        </Flex>
+        <IconButton
+          variant="ghost"
+          size="xs"
+          p={0}
+          minW="16px"
+          h="16px"
+          aria-label={isCollapsed ? "Expand legend" : "Collapse legend"}
+          onClick={() => setIsCollapsed((prev) => !prev)}
+        >
+          {isCollapsed ? (
+            <CaretDownIcon size={12} />
+          ) : (
+            <CaretUpIcon size={12} />
+          )}
+        </IconButton>
+      </Flex>
+
+      {/* Collapsible body — animates height on open/close */}
+      <Collapsible.Root open={!isCollapsed}>
+        <Collapsible.Content>
+          <ChReorderGroup
+            axis="y"
+            values={layers}
+            onReorder={(layers: LegendLayer[]) =>
+              onLayerAction?.({ action: "reorder", payload: { layers } })
             }
-            onLayerAction={(details) => onLayerAction?.(details)}
-          />
-        ))}
-      </ChReorderGroup>
+            listStyleType="none"
+            fontSize="xs"
+            p={0}
+            m={0}
+            w="100%"
+            overflowY="auto"
+            maxH="200px"
+          >
+            {layers.map((item) => (
+              <Item
+                key={item.id}
+                item={item}
+                expanded={expandedIds.has(item.id)}
+                onToggleExpand={() =>
+                  setExpandedIds((prev) => {
+                    const next = new Set(prev);
+                    if (next.has(item.id)) {
+                      next.delete(item.id);
+                    } else {
+                      next.add(item.id);
+                    }
+                    return next;
+                  })
+                }
+                onLayerAction={(details) => onLayerAction?.(details)}
+              />
+            ))}
+          </ChReorderGroup>
+        </Collapsible.Content>
+      </Collapsible.Root>
     </Flex>
   );
 }

--- a/app/components/legend/Legend.tsx
+++ b/app/components/legend/Legend.tsx
@@ -94,7 +94,8 @@ export function Legend(props: LegendProps) {
     setPrevLayerIds(currentIds);
   }, [layers]);
 
-  if (!layers.length) return null;
+  const hasAois = !!aois && aois.length > 0;
+  if (!layers.length && !hasAois) return null;
 
   return (
     <Flex
@@ -154,43 +155,45 @@ export function Legend(props: LegendProps) {
       {/* Collapsible body — animates height on open/close */}
       <Collapsible.Root open={!isCollapsed}>
         <Collapsible.Content>
-          <ChReorderGroup
-            axis="y"
-            values={layers}
-            onReorder={(layers: LegendLayer[]) =>
-              onLayerAction?.({ action: "reorder", payload: { layers } })
-            }
-            listStyleType="none"
-            fontSize="xs"
-            p={0}
-            m={0}
-            w="100%"
-            overflowY="auto"
-            maxH="200px"
-          >
-            {layers.map((item) => (
-              <Item
-                key={item.id}
-                item={item}
-                expanded={expandedIds.has(item.id)}
-                onToggleExpand={() =>
-                  setExpandedIds((prev) => {
-                    const next = new Set(prev);
-                    if (next.has(item.id)) {
-                      next.delete(item.id);
-                    } else {
-                      next.add(item.id);
-                    }
-                    return next;
-                  })
-                }
-                onLayerAction={(details) => onLayerAction?.(details)}
-              />
-            ))}
-          </ChReorderGroup>
-          {aois && aois.length > 0 && (
+          {layers.length > 0 && (
+            <ChReorderGroup
+              axis="y"
+              values={layers}
+              onReorder={(layers: LegendLayer[]) =>
+                onLayerAction?.({ action: "reorder", payload: { layers } })
+              }
+              listStyleType="none"
+              fontSize="xs"
+              p={0}
+              m={0}
+              w="100%"
+              overflowY="auto"
+              maxH="200px"
+            >
+              {layers.map((item) => (
+                <Item
+                  key={item.id}
+                  item={item}
+                  expanded={expandedIds.has(item.id)}
+                  onToggleExpand={() =>
+                    setExpandedIds((prev) => {
+                      const next = new Set(prev);
+                      if (next.has(item.id)) {
+                        next.delete(item.id);
+                      } else {
+                        next.add(item.id);
+                      }
+                      return next;
+                    })
+                  }
+                  onLayerAction={(details) => onLayerAction?.(details)}
+                />
+              ))}
+            </ChReorderGroup>
+          )}
+          {hasAois && (
             <>
-              <Box h="1px" bg="border" />
+              {layers.length > 0 && <Box h="1px" bg="border" />}
               <Flex gap={1} flexWrap="wrap" p={2}>
                 {aois.map((aoi) => (
                   <Flex

--- a/app/components/legend/types.ts
+++ b/app/components/legend/types.ts
@@ -10,6 +10,18 @@ export interface LegendParam {
 }
 
 /**
+ * A contextual sub-layer shown indented under a parent layer card with a
+ * "within" prefix. e.g. "within ■ Primary Forests (2001)".
+ */
+export interface LegendContextLayer {
+  id: string;
+  title: string;
+  color: string;
+  opacity: number;
+  info?: string;
+}
+
+/**
  * Represents a single layer in the legend.
  */
 export interface LegendLayer {
@@ -17,6 +29,7 @@ export interface LegendLayer {
   title: string;
   opacity: number;
   params?: LegendParam[];
+  contextLayer?: LegendContextLayer;
   symbology: ReactNode;
   children?: ReactNode;
   info?: string;

--- a/app/components/legend/types.ts
+++ b/app/components/legend/types.ts
@@ -1,15 +1,22 @@
 import { ReactNode } from "react";
 
 /**
+ * A single read-only parameter chip shown beneath a layer title.
+ * e.g. { label: "YEAR", value: "2025" } or { label: "CANOPY", value: ">= 30%" }
+ */
+export interface LegendParam {
+  label: string;
+  value: string;
+}
+
+/**
  * Represents a single layer in the legend.
  */
 export interface LegendLayer {
   id: string;
   title: string;
-  visible: boolean;
   opacity: number;
-  dateRange?: string;
-  parametersText?: string;
+  params?: LegendParam[];
   symbology: ReactNode;
   children?: ReactNode;
   info?: string;
@@ -21,10 +28,6 @@ export type LayerActionArgs =
   | {
       action: "remove";
       payload: { id: string };
-    }
-  | {
-      action: "visibility";
-      payload: { id: string; visible: boolean };
     }
   | {
       action: "opacity";

--- a/app/components/legend/useLegendHook.tsx
+++ b/app/components/legend/useLegendHook.tsx
@@ -3,6 +3,7 @@ import { Text } from "@chakra-ui/react";
 
 import {
   LayerActionHandler,
+  LegendContextLayer,
   LegendLayer,
   LegendParam,
 } from "@/app/components/legend/types";
@@ -101,6 +102,27 @@ export function useLegendHook() {
 
   useEffect(() => {
     const buildEntries = (): LegendLayer[] => {
+      // First pass: build a map of parentLayerId → contextLayer data so we can
+      // attach sub-layers to their parent entries in the second pass.
+      const contextLayerByParentId = new Map<string, LegendContextLayer>();
+      for (const layer of managedLayers) {
+        if (!layer.parentLayerId) continue;
+        const metadata = CONTEXT_LAYER_METADATA[layer.name];
+        const legend = metadata?.legend;
+        // Use the first item's colour as the swatch, falling back to the
+        // legend's top-level color field.
+        const color = legend?.items?.[0]?.color ?? legend?.color ?? "#888";
+        contextLayerByParentId.set(layer.parentLayerId, {
+          id: layer.id,
+          title: legend?.title ?? layer.name,
+          color,
+          opacity: (layer.opacity ?? 1) * 100,
+          info: legend?.info,
+        });
+      }
+
+      // Second pass: build root-level legend entries, skipping sub-layers
+      // (they are now embedded via contextLayer on their parent).
       const entries: LegendLayer[] = [];
       for (const layer of managedLayers) {
         if (layer.type === "geojson" || layer.type === "vector") {
@@ -115,24 +137,8 @@ export function useLegendHook() {
           continue;
         }
 
-        // Sub-layer (e.g. primary_forest under TCL): rendered as a child row,
-        // no remove control (lifecycle owned by the parent dataset's context chip).
-        if (layer.parentLayerId) {
-          const metadata = CONTEXT_LAYER_METADATA[layer.name];
-          const legend = metadata?.legend;
-          entries.push({
-            id: layer.id,
-            title: legend?.title ?? layer.name,
-            opacity: (layer.opacity ?? 1) * 100,
-            info: legend?.info,
-            hideRemoveControl: true,
-            symbology: legend ? renderLegendSymbology(legend) : null,
-            children: legend?.note ? (
-              <Text fontSize="xs">{legend.note}</Text>
-            ) : undefined,
-          });
-          continue;
-        }
+        // Sub-layers are handled via their parent — skip them here.
+        if (layer.parentLayerId) continue;
 
         const relatedDataset = DATASET_CARDS.find(
           (d) => `dataset-${d.dataset_id}` === layer.id
@@ -149,42 +155,17 @@ export function useLegendHook() {
 
         entries.push({
           id: layer.id,
-          title: title,
+          title,
           opacity: (layer.opacity ?? 1) * 80,
           info,
           params: params.length > 0 ? params : undefined,
+          contextLayer: contextLayerByParentId.get(layer.id),
           symbology: renderLegendSymbology(relatedDataset.legend),
           children: note ? <Text fontSize="xs">{note}</Text> : undefined,
         });
       }
 
-      // Place each sub-layer directly after its parent so the legend reads top-down.
-      const byId = new Map(entries.map((e) => [e.id, e]));
-      const subsByParent = new Map<string, LegendLayer[]>();
-      const rootEntries: LegendLayer[] = [];
-      for (const layer of managedLayers) {
-        const e = byId.get(layer.id);
-        if (!e) continue;
-        if (layer.parentLayerId) {
-          if (!subsByParent.has(layer.parentLayerId)) {
-            subsByParent.set(layer.parentLayerId, []);
-          }
-          subsByParent.get(layer.parentLayerId)!.push(e);
-        } else {
-          rootEntries.push(e);
-        }
-      }
-      const ordered: LegendLayer[] = [];
-      for (const root of rootEntries) {
-        ordered.push(root);
-        const subs = subsByParent.get(root.id);
-        if (subs) ordered.push(...subs);
-      }
-      // Append any orphaned sub-layers (parent missing) at the end.
-      for (const [parentId, subs] of subsByParent) {
-        if (!rootEntries.some((r) => r.id === parentId)) ordered.push(...subs);
-      }
-      return ordered;
+      return entries;
     };
 
     setLayers(buildEntries());

--- a/app/components/legend/useLegendHook.tsx
+++ b/app/components/legend/useLegendHook.tsx
@@ -1,7 +1,11 @@
 import { useCallback, useEffect, useState } from "react";
 import { Text } from "@chakra-ui/react";
 
-import { LayerActionHandler, LegendLayer } from "@/app/components/legend/types";
+import {
+  LayerActionHandler,
+  LegendLayer,
+  LegendParam,
+} from "@/app/components/legend/types";
 import { LegendSequential } from "@/app/components/legend/LegendSequential";
 import { LegendSymbolList } from "@/app/components/legend/LegendSymbolList";
 import { LegendCategorical } from "@/app/components/legend/LegendCategorical";
@@ -14,23 +18,40 @@ import {
 import type { DatasetLegendConfig } from "@/app/constants/datasets";
 import useContextStore from "@/app/store/contextStore";
 
+// Maps internal parameter keys to the badge label shown in the legend.
 const PARAMETER_LABELS: Record<string, string> = {
-  canopy_cover: "Canopy ≥",
+  canopy_cover: "CANOPY",
 };
 
-const PARAMETER_UNITS: Record<string, string> = {
-  canopy_cover: "%",
+// Maps internal parameter keys to a formatting function that produces the value string.
+const PARAMETER_FORMATTERS: Record<string, (v: unknown) => string> = {
+  canopy_cover: (v) => `>= ${v}%`,
 };
 
-function formatParameters(params: Record<string, unknown>): string | undefined {
-  const parts = Object.entries(params)
-    .filter(([, v]) => v !== null && v !== undefined && v !== "")
-    .map(([k, v]) => {
-      const label = PARAMETER_LABELS[k] ?? k;
-      const unit = PARAMETER_UNITS[k] ?? "";
-      return `${label} ${v}${unit}`;
-    });
-  return parts.length > 0 ? parts.join(" · ") : undefined;
+/**
+ * Converts a layer's raw parameters object into structured LegendParam chips.
+ * Each entry becomes a { label, value } pair rendered as a badge in the card.
+ */
+function buildParams(
+  params: Record<string, unknown>,
+  dateRange?: string
+): LegendParam[] {
+  const result: LegendParam[] = [];
+
+  if (dateRange) {
+    // Use "YEARS" for a range, "YEAR" for a single year.
+    const label = dateRange.includes("–") ? "YEARS" : "YEAR";
+    result.push({ label, value: dateRange });
+  }
+
+  for (const [k, v] of Object.entries(params)) {
+    if (v === null || v === undefined || v === "") continue;
+    const label = PARAMETER_LABELS[k] ?? k.toUpperCase();
+    const format = PARAMETER_FORMATTERS[k];
+    result.push({ label, value: format ? format(v) : String(v) });
+  }
+
+  return result;
 }
 
 function renderLegendSymbology(legend: DatasetLegendConfig) {
@@ -72,7 +93,6 @@ export function useLegendHook() {
 
   const {
     layers: managedLayers,
-    setLayerVisibility,
     setLayerOpacity,
     removeLayer,
     reorderLayers,
@@ -87,7 +107,6 @@ export function useLegendHook() {
           entries.push({
             id: layer.id,
             title: layer.selectionName ?? layer.name,
-            visible: layer.visible,
             opacity: (layer.opacity ?? 1) * 100,
             hideOpacityControl: true,
             hideRemoveControl: true,
@@ -104,7 +123,6 @@ export function useLegendHook() {
           entries.push({
             id: layer.id,
             title: legend?.title ?? layer.name,
-            visible: layer.visible,
             opacity: (layer.opacity ?? 1) * 100,
             info: legend?.info,
             hideRemoveControl: true,
@@ -127,18 +145,14 @@ export function useLegendHook() {
           layer.startDate && layer.endDate
             ? `${layer.startDate.slice(0, 4)}–${layer.endDate.slice(0, 4)}`
             : undefined;
-        const parametersText = layer.parameters
-          ? formatParameters(layer.parameters)
-          : undefined;
+        const params = buildParams(layer.parameters ?? {}, dateRange);
 
         entries.push({
           id: layer.id,
           title: title,
-          visible: layer.visible,
           opacity: (layer.opacity ?? 1) * 80,
           info,
-          dateRange,
-          parametersText,
+          params: params.length > 0 ? params : undefined,
           symbology: renderLegendSymbology(relatedDataset.legend),
           children: note ? <Text fontSize="xs">{note}</Text> : undefined,
         });
@@ -195,23 +209,12 @@ export function useLegendHook() {
           }
           removeLayer(payload.id);
           break;
-        case "visibility":
-          // Go through the tile layers and update their visibility
-          setLayerVisibility(payload.id, payload.visible);
-          break;
         case "opacity":
           setLayerOpacity(payload.id, payload.opacity / 100);
           break;
       }
     },
-    [
-      context,
-      removeContext,
-      removeLayer,
-      setLayerVisibility,
-      setLayerOpacity,
-      reorderLayers,
-    ]
+    [context, removeContext, removeLayer, setLayerOpacity, reorderLayers]
   );
 
   return { layers, handleLayerAction };

--- a/app/components/legend/useLegendHook.tsx
+++ b/app/components/legend/useLegendHook.tsx
@@ -89,6 +89,12 @@ function renderLegendSymbology(legend: DatasetLegendConfig) {
   ) : null;
 }
 
+export interface LegendAoi {
+  /** Unique id of the context item this AOI belongs to — used to remove it. */
+  contextId: string;
+  name: string;
+}
+
 export function useLegendHook() {
   const [layers, setLayers] = useState<LegendLayer[]>([]);
 
@@ -102,6 +108,20 @@ export function useLegendHook() {
 
   useEffect(() => {
     const buildEntries = (): LegendLayer[] => {
+      // Context is the single source of truth for "is this layer an AOI?".
+      // We build two sets to cover both cases:
+      //   - aoiLayerNames: matches assistant-picked AOI layers (layer.id === selection name)
+      //   - aoiLayerIds:   matches custom-area layers (layer.id === aoiData.src_id, a DB id)
+      const areaItems = context.filter((c) => c.contextType === "area");
+      const aoiLayerNames = new Set(
+        areaItems.map(
+          (c) => c.aoiSelection?.name ?? c.aoiData?.name ?? String(c.content)
+        )
+      );
+      const aoiLayerIds = new Set(
+        areaItems.map((c) => c.aoiData?.src_id).filter(Boolean)
+      );
+
       // First pass: build a map of parentLayerId → contextLayer data so we can
       // attach sub-layers to their parent entries in the second pass.
       const contextLayerByParentId = new Map<string, LegendContextLayer>();
@@ -121,24 +141,26 @@ export function useLegendHook() {
         });
       }
 
-      // Second pass: build root-level legend entries, skipping sub-layers
-      // (they are now embedded via contextLayer on their parent).
+      // Second pass: build root-level legend entries.
+      // AOI layers are surfaced as chips separately — skip them.
+      // Sub-layers are embedded in their parent via contextLayer — skip them too.
       const entries: LegendLayer[] = [];
       for (const layer of managedLayers) {
+        if (aoiLayerNames.has(layer.name) || aoiLayerIds.has(layer.id))
+          continue;
+        if (layer.parentLayerId) continue;
+
+        // Non-dataset vector/geojson layers (e.g. boundary overlays) get a
+        // minimal card with no symbology — just title + opacity control.
         if (layer.type === "geojson" || layer.type === "vector") {
           entries.push({
             id: layer.id,
             title: layer.selectionName ?? layer.name,
             opacity: (layer.opacity ?? 1) * 100,
-            hideOpacityControl: true,
-            hideRemoveControl: true,
             symbology: null,
           });
           continue;
         }
-
-        // Sub-layers are handled via their parent — skip them here.
-        if (layer.parentLayerId) continue;
 
         const relatedDataset = DATASET_CARDS.find(
           (d) => `dataset-${d.dataset_id}` === layer.id
@@ -169,7 +191,21 @@ export function useLegendHook() {
     };
 
     setLayers(buildEntries());
-  }, [managedLayers]);
+  }, [managedLayers, context]);
+
+  // One chip per selection (context item), using the selection name as the label.
+  // Removing a chip removes the whole selection and its map layer.
+  const aois: LegendAoi[] = context
+    .filter((c) => c.contextType === "area")
+    .map((c) => ({
+      contextId: c.id,
+      name: c.aoiSelection?.name ?? c.aoiData?.name ?? String(c.content),
+    }));
+
+  const handleRemoveAoi = useCallback(
+    (contextId: string) => removeContext(contextId),
+    [removeContext]
+  );
 
   const handleLayerAction = useCallback<LayerActionHandler>(
     ({ action, payload }) => {
@@ -198,5 +234,5 @@ export function useLegendHook() {
     [context, removeContext, removeLayer, setLayerOpacity, reorderLayers]
   );
 
-  return { layers, handleLayerAction };
+  return { layers, handleLayerAction, aois, handleRemoveAoi };
 }

--- a/app/components/map/layers/GeoJsonLayers.tsx
+++ b/app/components/map/layers/GeoJsonLayers.tsx
@@ -143,7 +143,7 @@ export default function GeoJsonLayers({ areas }: GeoJsonLayersProps) {
 // If the group is a single area, render a single label and polygon
 // If the group is a multi-area selection, render a bbox polygon and a label for the selection name
 function GeoJsonLayerGroup({ layer, entries, areas }: GeoJsonLayerGroupProps) {
-  const { upsertContextByType, removeContext } = useContextStore();
+  const { addContext, removeContext } = useContextStore();
   const { isHovered, setHoverState } = useHoverState();
   // Context matching — use layer.selectionName for groups, or first entry name for singles
   const displayName = layer.selectionName ?? layer.name;
@@ -166,22 +166,24 @@ function GeoJsonLayerGroup({ layer, entries, areas }: GeoJsonLayerGroupProps) {
   };
   const handleSelectFromLabel = () => {
     if (!isInContext) {
+      // Areas stack — addContext keeps existing area chips and adds a new one.
+      // The `isInContext` guard above already prevents re-adding the same layer.
       if (layer.aoiSelection) {
-        upsertContextByType({
+        addContext({
           contextType: "area",
           content: displayName,
           aoiSelection: layer.aoiSelection,
         });
       } else {
         // For single-area layers, look up the registry entry to get the
-        // correct src_id, source, and subtype for the context upsert.
+        // correct src_id, source, and subtype for the context entry.
         const ref = layer.featureRefs?.[0];
         const entry = ref
           ? entries.find(
               (e) => e.ref.name === ref.name && e.ref.source === ref.source
             )
           : undefined;
-        upsertContextByType({
+        addContext({
           contextType: "area",
           content: displayName,
           aoiData: {

--- a/app/components/map/layers/select-area-layer/VectorAreasLayer.tsx
+++ b/app/components/map/layers/select-area-layer/VectorAreasLayer.tsx
@@ -34,7 +34,7 @@ interface Metadata {
 }
 
 function VectorAreasLayer({ layerId }: SourceLayerProps) {
-  const { upsertContextByType } = useContextStore();
+  const { context, addContext } = useContextStore();
   const { addToRegistry, addLayer, setSelectAreaLayer } = useMapStore();
   const { current: map } = useMap();
   const [hoverInfo, setHoverInfo] = useState<HoverInfo>();
@@ -175,17 +175,25 @@ function VectorAreasLayer({ layerId }: SourceLayerProps) {
 
             const idField = metadata?.layer_id_mapping?.[layerId.toLowerCase()];
 
-            upsertContextByType({
-              contextType: "area",
-              content: aoiName,
-              aoiData: {
-                name: aoiName,
-                ...(idField ? { [idField]: dynamicSrcId } : {}),
-                src_id: dynamicSrcId,
-                subtype: dynamicSubtype,
-                source: layerConfig?.id.toLowerCase(),
-              },
-            });
+            // Areas stack. Skip if this src_id is already in context to avoid
+            // duplicate chips when the user clicks the same region twice.
+            const alreadyInContext = context.some(
+              (c) =>
+                c.contextType === "area" && c.aoiData?.src_id === dynamicSrcId
+            );
+            if (!alreadyInContext) {
+              addContext({
+                contextType: "area",
+                content: aoiName,
+                aoiData: {
+                  name: aoiName,
+                  ...(idField ? { [idField]: dynamicSrcId } : {}),
+                  src_id: dynamicSrcId,
+                  subtype: dynamicSubtype,
+                  source: layerConfig?.id.toLowerCase(),
+                },
+              });
+            }
           }
         }
       };
@@ -216,7 +224,8 @@ function VectorAreasLayer({ layerId }: SourceLayerProps) {
     nameKeys,
     setSelectAreaLayer,
     metadata,
-    upsertContextByType,
+    addContext,
+    context,
     addToRegistry,
     addLayer,
     layerId,

--- a/app/store/chat-tools/pickAoi.ts
+++ b/app/store/chat-tools/pickAoi.ts
@@ -12,7 +12,7 @@ import { unionAoiBboxes } from "@/app/utils/bboxUtils";
 import { GeoJsonEntry } from "../layerManagerSlice";
 import { selectLayerOptions } from "@/app/types/map";
 
-const GLOBAL_LAYER_ID = "global-layer";
+const GLOBAL_LAYER_ID = "Global Layer";
 const GLOBAL_LAYER_NAME = "Global Layer";
 
 function isGlobalQuery(name: string): boolean {
@@ -66,7 +66,7 @@ export async function pickAoiTool(
   try {
     const { flyToGeoJsonWithRetry, flyToBounds, addToRegistry, addLayer } =
       useMapStore.getState();
-    const { upsertContextByType } = useContextStore.getState();
+    const { context, addContext } = useContextStore.getState();
 
     // Prefer the new multi-AOI aoi_selection, fall back to single aoi
     const aoiSelection: AOISelection | undefined = streamMessage.aoi_selection;
@@ -107,12 +107,19 @@ export async function pickAoiTool(
 
       flyToGeoJsonWithRetry(worldBbox);
 
-      upsertContextByType({
-        contextType: "area",
-        content: GLOBAL_LAYER_NAME,
-        isAiContext: true,
-        aoiSelection: aoiSelection ?? { name: GLOBAL_LAYER_NAME, aois },
-      });
+      // Areas stack — skip if the global layer is already in context.
+      const globalAlreadyInContext = context.some(
+        (c) =>
+          c.contextType === "area" && c.aoiSelection?.name === GLOBAL_LAYER_NAME
+      );
+      if (!globalAlreadyInContext) {
+        addContext({
+          contextType: "area",
+          content: GLOBAL_LAYER_NAME,
+          isAiContext: true,
+          aoiSelection: aoiSelection ?? { name: GLOBAL_LAYER_NAME, aois },
+        });
+      }
 
       return;
     }
@@ -197,13 +204,19 @@ export async function pickAoiTool(
       flyToGeoJsonWithRetry(allGeoData[0]);
     }
 
-    // Update area context with the selection name and full AOI selection data
-    upsertContextByType({
-      contextType: "area",
-      content: selectionName,
-      isAiContext: true,
-      aoiSelection: selectionForContext,
-    });
+    // Areas stack — add this AOI selection alongside any existing ones.
+    // Skip if a selection with this same name is already in context.
+    const selectionAlreadyInContext = context.some(
+      (c) => c.contextType === "area" && c.aoiSelection?.name === selectionName
+    );
+    if (!selectionAlreadyInContext) {
+      addContext({
+        contextType: "area",
+        content: selectionName,
+        isAiContext: true,
+        aoiSelection: selectionForContext,
+      });
+    }
 
     // If some AOIs failed, show a partial-failure message
     if (failures.length > 0 && failures.length < aois.length) {

--- a/app/store/contextStore.ts
+++ b/app/store/contextStore.ts
@@ -119,6 +119,19 @@ const useContextStore = create<ContextState & ContextActions>((set, get) => ({
     set((state) => {
       const itemToRemove = state.context.find((c) => c.id === id);
       if (itemToRemove) {
+        // TODO: sever the context-store ↔ layer-manager coupling.
+        // The block below (and the matching `addLayer` calls in `addContext`)
+        // exist because `addContext` was wired up as the entry point for
+        // adding/removing map layers. That coupling is the reason `ContextItem`
+        // carries layer-construction fields (`tileUrl`, `layerName`,
+        // `contextLayer`, etc.) and the reason this branch has to guess the
+        // map layer's id from up to four context fields below — each
+        // add-area call site picked its own convention for `layer.id`, and
+        // there's no single context field that always matches it.
+        //
+        // The fix is to make `addContext`/`removeContext` pure context
+        // operations and let each add-area / add-dataset call site manage its
+        // own layer lifecycle.
         const { removeLayer } = useMapStore.getState();
         if (typeof itemToRemove.datasetId === "number") {
           // Remove the dataset layer and its optional context sub-layer
@@ -129,14 +142,25 @@ const useContextStore = create<ContextState & ContextActions>((set, get) => ({
             );
           }
         } else if (itemToRemove.contextType === "area") {
-          // For custom areas, src_id is the map layer id (added via ContextMenu).
-          // For AOI selections from the assistant, the layer id equals the selection name.
-          const layerId =
-            itemToRemove.aoiData?.src_id ??
-            itemToRemove.aoiSelection?.name ??
-            itemToRemove.aoiData?.name ??
-            String(itemToRemove.content);
-          removeLayer(layerId);
+          // Different add-area paths register the map layer under different ids:
+          //   - ContextMenu.AreaMenu / CustomAreasLayer: layer.id === aoiData.src_id
+          //   - VectorAreasLayer (admin boundary click):  layer.id === aoiData.name
+          //   - pickAoiTool (assistant selection):        layer.id === aoiSelection.name
+          //   - Global vector layer:                      layer.id === "Global Layer"
+          // `??` would short-circuit on the wrong id (notably for admin clicks where
+          // src_id is set but isn't the layer id). Try every candidate — removeLayer
+          // is a no-op when the id doesn't match an existing layer.
+          const candidates = [
+            itemToRemove.aoiData?.src_id,
+            itemToRemove.aoiData?.name,
+            itemToRemove.aoiSelection?.name,
+            typeof itemToRemove.content === "string"
+              ? itemToRemove.content
+              : undefined,
+          ].filter((id): id is string => !!id);
+          for (const id of candidates) {
+            removeLayer(id);
+          }
         }
       }
       return {

--- a/app/store/contextStore.ts
+++ b/app/store/contextStore.ts
@@ -118,14 +118,25 @@ const useContextStore = create<ContextState & ContextActions>((set, get) => ({
   removeContext: (id) =>
     set((state) => {
       const itemToRemove = state.context.find((c) => c.id === id);
-      if (typeof itemToRemove?.datasetId === "number") {
+      if (itemToRemove) {
         const { removeLayer } = useMapStore.getState();
-        // Remove corresponding map layer if this context item represents a dataset layer
-        removeLayer(`dataset-${itemToRemove.datasetId}`);
-        if (itemToRemove.contextLayer) {
-          removeLayer(
-            `dataset-${itemToRemove.datasetId}-ctx-${itemToRemove.contextLayer.name}`
-          );
+        if (typeof itemToRemove.datasetId === "number") {
+          // Remove the dataset layer and its optional context sub-layer
+          removeLayer(`dataset-${itemToRemove.datasetId}`);
+          if (itemToRemove.contextLayer) {
+            removeLayer(
+              `dataset-${itemToRemove.datasetId}-ctx-${itemToRemove.contextLayer.name}`
+            );
+          }
+        } else if (itemToRemove.contextType === "area") {
+          // For custom areas, src_id is the map layer id (added via ContextMenu).
+          // For AOI selections from the assistant, the layer id equals the selection name.
+          const layerId =
+            itemToRemove.aoiData?.src_id ??
+            itemToRemove.aoiSelection?.name ??
+            itemToRemove.aoiData?.name ??
+            String(itemToRemove.content);
+          removeLayer(layerId);
         }
       }
       return {

--- a/app/utils/datasetLayerContext.ts
+++ b/app/utils/datasetLayerContext.ts
@@ -9,6 +9,20 @@ function patchPrimaryForestTileUrl(url: string): string {
   return wrapPrimaryForestTileUrl(url);
 }
 
+/**
+ * Derives the map layer props needed to add a dataset to the map and legend.
+ *
+ * Returns three things:
+ *  - `contextLayer` — optional sub-layer rendered beneath the main dataset
+ *    (e.g. Primary Forests mask under Tree Cover Loss). Resolved from
+ *    `dataset.context_layer` + `dataset.context_layers[]`.
+ *  - `parameters` — key/value record of display parameters shown as legend
+ *    chips (e.g. `{ canopy_cover: 30 }`). Backend-supplied values take
+ *    priority; falls back to `dataset.threshold` then the card default in
+ *    `DATASET_CARDS`. Will be `undefined` if the dataset has no threshold.
+ *  - `startDate` / `endDate` — ISO date strings forwarded from the backend,
+ *    shown as the YEAR/YEARS chip in the legend.
+ */
 export function getDatasetLayerContextProps(dataset: DatasetInfo) {
   // In the example of primary_forest, context_layer is "primary_forest" and context_layers is an array of context layers.
   // ctxMeta is the metadata for the context layer such as name, tile_url, description, legend, parameters, start_date, end_date.


### PR DESCRIPTION
This redesigns the legend to match the new Figma designs:

1. The legend is moved to a new collapsible component with a max-height
2. The layer cards now have Params chips
3. The context_layer is now nested within the parent layer
4. AOIs show up as chips instead of separate vector layers

I kept the possibility for having geojson / vector layers in the future, they have simple legend cards

@faustoperez there are some colors from your designs I used that were not in the saved variables in our theme, so I have to review this with you to see if these are supposed to be theme colors or not.

I also fixed what I think is a bug on staging: adding multiple administrative areas will not add them all in the context, it will add the last selection.

Please try out the preview and let me know if something is missing. I know this is a big PR so I can pair with whoever will review it.