### PR TITLE
PZB-788: Insight cards surface analysis parameters as read-only chips

### DIFF
--- a/app/components/WidgetMessage.tsx
+++ b/app/components/WidgetMessage.tsx
@@ -27,9 +27,10 @@ import InsightProvenanceDrawer from "./InsightProvenanceDrawer";
 import VisualizationDisclaimer from "./VisualizationDisclaimer";
 import WidgetErrorBoundary from "./widgets/WidgetErrorBoundary";
 import ScrollableTableWrapper from "./widgets/ScrollableTableWrapper";
-import AnalysisParameters, {
+import AnalysisParametersToggle, {
   AnalysisParamsChips,
 } from "./widgets/AnalysisParameters";
+import { buildChips } from "./widgets/analysis-params-utils";
 
 interface WidgetMessageProps {
   widget: InsightWidget;
@@ -38,6 +39,8 @@ interface WidgetMessageProps {
 export default function WidgetMessage({ widget }: WidgetMessageProps) {
   const [showAsTable, setShowAsTable] = useState(false);
   const [paramsExpanded, setParamsExpanded] = useState(false);
+  const chips = widget.analysisParams ? buildChips(widget.analysisParams) : [];
+  const hasChips = chips.length > 0;
   const { open, onOpen, onClose } = useDisclosure();
   const {
     open: expanded,
@@ -112,18 +115,15 @@ export default function WidgetMessage({ widget }: WidgetMessageProps) {
         >
           {widget.title}
         </Heading>
-        {widget.analysisParams && (
-          <AnalysisParameters
-            params={widget.analysisParams}
+        {hasChips && (
+          <AnalysisParametersToggle
             expanded={paramsExpanded}
             onToggle={() => setParamsExpanded((v) => !v)}
           />
         )}
       </Flex>
       <Flex gap={3} px={4} py={3} flexDir="column">
-        {widget.analysisParams && paramsExpanded && (
-          <AnalysisParamsChips params={widget.analysisParams} />
-        )}
+        {hasChips && paramsExpanded && <AnalysisParamsChips chips={chips} />}
         {hasData && <Separator />}
         {/* Toolbar row — segmented toggle + full-screen */}
         <Flex justify="flex-start" gap={2} flexWrap="wrap" align="center">

--- a/app/components/WidgetMessage.tsx
+++ b/app/components/WidgetMessage.tsx
@@ -27,6 +27,9 @@ import InsightProvenanceDrawer from "./InsightProvenanceDrawer";
 import VisualizationDisclaimer from "./VisualizationDisclaimer";
 import WidgetErrorBoundary from "./widgets/WidgetErrorBoundary";
 import ScrollableTableWrapper from "./widgets/ScrollableTableWrapper";
+import AnalysisParameters, {
+  AnalysisParamsChips,
+} from "./widgets/AnalysisParameters";
 
 interface WidgetMessageProps {
   widget: InsightWidget;
@@ -34,6 +37,7 @@ interface WidgetMessageProps {
 
 export default function WidgetMessage({ widget }: WidgetMessageProps) {
   const [showAsTable, setShowAsTable] = useState(false);
+  const [paramsExpanded, setParamsExpanded] = useState(false);
   const { open, onOpen, onClose } = useDisclosure();
   const {
     open: expanded,
@@ -97,13 +101,29 @@ export default function WidgetMessage({ widget }: WidgetMessageProps) {
       borderColor="blue.fg"
       overflow="hidden"
     >
-      <Flex px={4} py={3} gap={2} bgGradient="LCLGradientLight">
+      <Flex px={4} py={3} gap={2} bgGradient="LCLGradientLight" align="center">
         {WidgetIcons[widget.type]}
-        <Heading size="xs" fontWeight="medium" color="primary.fg" m={0}>
+        <Heading
+          size="xs"
+          fontWeight="medium"
+          color="primary.fg"
+          m={0}
+          flex={1}
+        >
           {widget.title}
         </Heading>
+        {widget.analysisParams && (
+          <AnalysisParameters
+            params={widget.analysisParams}
+            expanded={paramsExpanded}
+            onToggle={() => setParamsExpanded((v) => !v)}
+          />
+        )}
       </Flex>
       <Flex gap={3} px={4} py={3} flexDir="column">
+        {widget.analysisParams && paramsExpanded && (
+          <AnalysisParamsChips params={widget.analysisParams} />
+        )}
         {hasData && <Separator />}
         {/* Toolbar row — segmented toggle + full-screen */}
         <Flex justify="flex-start" gap={2} flexWrap="wrap" align="center">

--- a/app/components/widgets/AnalysisParameters.tsx
+++ b/app/components/widgets/AnalysisParameters.tsx
@@ -1,13 +1,6 @@
 "use client";
 import { Flex, Text } from "@chakra-ui/react";
-import { AnalysisParams } from "@/app/types/chat";
-import { buildChips, ParamChip } from "./analysis-params-utils";
-
-interface AnalysisParametersProps {
-  params: AnalysisParams;
-  expanded: boolean;
-  onToggle: () => void;
-}
+import { ParamChip } from "./analysis-params-utils";
 
 // Label text colors mapped from Figma spec to nearest theme tokens:
 // AREA #4A64CB → primary.400 (#3361C0)
@@ -20,15 +13,16 @@ const chipLabelColor: Record<ParamChip["colorScheme"], string> = {
   purple: "purple.500",
 };
 
+interface AnalysisParametersToggleProps {
+  expanded: boolean;
+  onToggle: () => void;
+}
+
 /** Toggle button rendered in the widget header row */
-export default function AnalysisParameters({
-  params,
+export default function AnalysisParametersToggle({
   expanded,
   onToggle,
-}: AnalysisParametersProps) {
-  const chips = buildChips(params);
-  if (chips.length === 0) return null;
-
+}: AnalysisParametersToggleProps) {
   return (
     <Text
       as="button"
@@ -51,10 +45,7 @@ export default function AnalysisParameters({
 }
 
 /** Chips panel rendered below the header row when expanded */
-export function AnalysisParamsChips({ params }: { params: AnalysisParams }) {
-  const chips = buildChips(params);
-  if (chips.length === 0) return null;
-
+export function AnalysisParamsChips({ chips }: { chips: ParamChip[] }) {
   return (
     <Flex gap={1.5} flexWrap="wrap">
       {chips.map((chip, idx) => (

--- a/app/components/widgets/AnalysisParameters.tsx
+++ b/app/components/widgets/AnalysisParameters.tsx
@@ -1,0 +1,98 @@
+"use client";
+import { Flex, Text } from "@chakra-ui/react";
+import { AnalysisParams } from "@/app/types/chat";
+import { buildChips, ParamChip } from "./analysis-params-utils";
+
+interface AnalysisParametersProps {
+  params: AnalysisParams;
+  expanded: boolean;
+  onToggle: () => void;
+}
+
+// Label text colors mapped from Figma spec to nearest theme tokens:
+// AREA #4A64CB → primary.400 (#3361C0)
+// DATA #1AA815 → green.500  (#00A651)
+// CANOPY #A51EC7 → purple.500 (#BA4AFF)
+// YEARS #A51EC7 → purple.500 (#BA4AFF)
+const chipLabelColor: Record<ParamChip["colorScheme"], string> = {
+  blue: "primary.400",
+  green: "green.500",
+  purple: "purple.500",
+};
+
+/** Toggle button rendered in the widget header row */
+export default function AnalysisParameters({
+  params,
+  expanded,
+  onToggle,
+}: AnalysisParametersProps) {
+  const chips = buildChips(params);
+  if (chips.length === 0) return null;
+
+  return (
+    <Text
+      as="button"
+      onClick={onToggle}
+      fontFamily="mono"
+      fontSize="10px"
+      fontWeight="400"
+      lineHeight="16px"
+      color="fg.muted"
+      textDecoration="underline"
+      textDecorationStyle="solid"
+      whiteSpace="nowrap"
+      flexShrink={0}
+      cursor="pointer"
+      _hover={{ color: "fg" }}
+    >
+      {expanded ? "Hide params" : "Show params"}
+    </Text>
+  );
+}
+
+/** Chips panel rendered below the header row when expanded */
+export function AnalysisParamsChips({ params }: { params: AnalysisParams }) {
+  const chips = buildChips(params);
+  if (chips.length === 0) return null;
+
+  return (
+    <Flex gap={1.5} flexWrap="wrap">
+      {chips.map((chip, idx) => (
+        <Flex
+          key={`${chip.label}-${idx}`}
+          align="center"
+          gap={1}
+          h="20px"
+          pt="2px"
+          pb="2px"
+          pr="6px"
+          pl={2}
+          rounded="sm"
+          border="1px solid"
+          borderColor="neutral.300"
+        >
+          <Text
+            fontFamily="mono"
+            fontSize="10px"
+            fontWeight="400"
+            lineHeight="16px"
+            letterSpacing="0.5px"
+            color={chipLabelColor[chip.colorScheme]}
+            textTransform="uppercase"
+          >
+            {chip.label}
+          </Text>
+          <Text
+            fontFamily="mono"
+            fontSize="10px"
+            fontWeight="500"
+            lineHeight="16px"
+            color="fg"
+          >
+            {chip.value}
+          </Text>
+        </Flex>
+      ))}
+    </Flex>
+  );
+}

--- a/app/components/widgets/AnalysisParameters.tsx
+++ b/app/components/widgets/AnalysisParameters.tsx
@@ -2,6 +2,7 @@
 import { Flex, Text } from "@chakra-ui/react";
 import { ParamChip } from "./analysis-params-utils";
 
+// TODO: Extract these colors to a shared util since they're used in DatasetCards too
 // Label text colors mapped from Figma spec to nearest theme tokens:
 // AREA #4A64CB → primary.400 (#3361C0)
 // DATA #1AA815 → green.500  (#00A651)

--- a/app/components/widgets/analysis-params-utils.ts
+++ b/app/components/widgets/analysis-params-utils.ts
@@ -1,0 +1,43 @@
+import { AnalysisParams } from "@/app/types/chat";
+
+export interface ParamChip {
+  label: string;
+  value: string;
+  colorScheme: "blue" | "green" | "purple";
+}
+
+export function buildChips(params: AnalysisParams): ParamChip[] {
+  const chips: ParamChip[] = [];
+
+  // Area chips — one per AOI
+  if (params.areas?.length) {
+    for (const area of params.areas) {
+      chips.push({ label: "AREA", value: area, colorScheme: "blue" });
+    }
+  }
+
+  // Dataset chip
+  if (params.dataset) {
+    chips.push({ label: "DATA", value: params.dataset, colorScheme: "green" });
+  }
+
+  // Canopy threshold chip (only if present — omit for non-tree-cover datasets)
+  if (params.canopyThreshold != null) {
+    chips.push({
+      label: "CANOPY",
+      value: `≥ ${params.canopyThreshold}%`,
+      colorScheme: "purple",
+    });
+  }
+
+  // Year range chip
+  if (params.startYear != null && params.endYear != null) {
+    chips.push({
+      label: "YEARS",
+      value: `${params.startYear}–${params.endYear}`,
+      colorScheme: "purple",
+    });
+  }
+
+  return chips;
+}

--- a/app/constants/datasets.ts
+++ b/app/constants/datasets.ts
@@ -59,7 +59,7 @@ export const CONTEXT_LAYER_METADATA: Record<string, ContextLayerMetadata> = {
       note: "Extent of primary humid tropical forests in 2001. Pan-tropical coverage at 30m resolution (UMD/GLAD).",
     },
   },
-  ifl: {
+  intact_forest: {
     dataset_id: 10,
     dataset_name: "Intact Forest Landscapes",
     context_layer: null as string | null,

--- a/app/store/chat-tools/generateInsights.ts
+++ b/app/store/chat-tools/generateInsights.ts
@@ -1,4 +1,10 @@
-import { ChatMessage, StreamMessage, InsightWidget } from "@/app/types/chat";
+import {
+  ChatMessage,
+  StreamMessage,
+  InsightWidget,
+  AnalysisParams,
+} from "@/app/types/chat";
+import useContextStore from "../contextStore";
 
 interface ChartData {
   id: string;
@@ -17,8 +23,42 @@ export function generateInsightsTool(
   try {
     // Handle charts_data from streamMessage
     if (streamMessage.charts_data && Array.isArray(streamMessage.charts_data)) {
-      const datasetName = (streamMessage.dataset as { dataset_name?: string })
-        ?.dataset_name;
+      // Build analysis params from contextStore — the earlier tools (pick_aoi,
+      // pick_dataset, pull_data) populate the store before generate_insights fires.
+      const context = useContextStore.getState().context;
+
+      const analysisParams: AnalysisParams = {};
+
+      // Areas from "area" context
+      const areaItem = context.find((c) => c.contextType === "area");
+      if (areaItem?.aoiSelection?.aois?.length) {
+        analysisParams.areas = areaItem.aoiSelection.aois.map((a) => a.name);
+      } else if (typeof areaItem?.content === "string" && areaItem.content) {
+        analysisParams.areas = [areaItem.content];
+      }
+
+      // Dataset name and canopy threshold from "layer" context
+      const layerItem = context.find((c) => c.contextType === "layer");
+      if (layerItem?.layerName) {
+        analysisParams.dataset = layerItem.layerName;
+      }
+      if (typeof layerItem?.parameters?.canopy_cover === "number") {
+        analysisParams.canopyThreshold = layerItem.parameters.canopy_cover;
+      }
+
+      // Year range from "date" context
+      const dateItem = context.find((c) => c.contextType === "date");
+      if (dateItem?.dateRange) {
+        analysisParams.startYear = dateItem.dateRange.start.getFullYear();
+        analysisParams.endYear = dateItem.dateRange.end.getFullYear();
+      }
+
+      const hasParams = Object.keys(analysisParams).length > 0;
+
+      // Dataset name for legacy datasetName field (used elsewhere)
+      const datasetName =
+        (streamMessage.dataset as { dataset_name?: string } | undefined)
+          ?.dataset_name ?? analysisParams.dataset;
 
       const widgets: InsightWidget[] = (
         streamMessage.charts_data as ChartData[]
@@ -34,6 +74,7 @@ export function generateInsightsTool(
           codeact_parts: streamMessage.codeact_parts,
           source_urls: streamMessage.source_urls,
         },
+        ...(hasParams ? { analysisParams } : {}),
       }));
 
       console.log("FRONTEND: Received charts_data message:", widgets);

--- a/app/store/chat-tools/generateInsights.ts
+++ b/app/store/chat-tools/generateInsights.ts
@@ -3,6 +3,7 @@ import {
   StreamMessage,
   InsightWidget,
   AnalysisParams,
+  DatasetInfo,
 } from "@/app/types/chat";
 import useContextStore from "../contextStore";
 
@@ -21,44 +22,57 @@ export function generateInsightsTool(
   addMessage: (message: Omit<ChatMessage, "id">) => void
 ) {
   try {
-    // Handle charts_data from streamMessage
     if (streamMessage.charts_data && Array.isArray(streamMessage.charts_data)) {
-      // Build analysis params from contextStore — the earlier tools (pick_aoi,
-      // pick_dataset, pull_data) populate the store before generate_insights fires.
+      // streamMessage carries the agent's authoritative selection for this
+      // analysis. Prefer it over contextStore, which is updated asynchronously
+      // by pickAoiTool/etc. and may not yet reflect this turn's choices.
       const context = useContextStore.getState().context;
-
+      const dataset = streamMessage.dataset as DatasetInfo | undefined;
       const analysisParams: AnalysisParams = {};
 
-      // Areas from "area" context
+      const aoiFromStream = streamMessage.aoi_selection?.aois;
       const areaItem = context.find((c) => c.contextType === "area");
-      if (areaItem?.aoiSelection?.aois?.length) {
+      if (aoiFromStream?.length) {
+        analysisParams.areas = aoiFromStream.map((a) => a.name);
+      } else if (areaItem?.aoiSelection?.aois?.length) {
         analysisParams.areas = areaItem.aoiSelection.aois.map((a) => a.name);
       } else if (typeof areaItem?.content === "string" && areaItem.content) {
         analysisParams.areas = [areaItem.content];
       }
 
-      // Dataset name and canopy threshold from "layer" context
       const layerItem = context.find((c) => c.contextType === "layer");
-      if (layerItem?.layerName) {
+      if (dataset?.dataset_name) {
+        analysisParams.dataset = dataset.dataset_name;
+      } else if (layerItem?.layerName) {
         analysisParams.dataset = layerItem.layerName;
       }
-      if (typeof layerItem?.parameters?.canopy_cover === "number") {
+
+      if (typeof dataset?.threshold === "number") {
+        analysisParams.canopyThreshold = dataset.threshold;
+      } else if (typeof layerItem?.parameters?.canopy_cover === "number") {
         analysisParams.canopyThreshold = layerItem.parameters.canopy_cover;
       }
 
-      // Year range from "date" context
-      const dateItem = context.find((c) => c.contextType === "date");
-      if (dateItem?.dateRange) {
-        analysisParams.startYear = dateItem.dateRange.start.getFullYear();
-        analysisParams.endYear = dateItem.dateRange.end.getFullYear();
+      const startStr = streamMessage.start_date ?? layerItem?.startDate;
+      const endStr = streamMessage.end_date ?? layerItem?.endDate;
+      if (startStr && endStr) {
+        const startYear = new Date(startStr).getUTCFullYear();
+        const endYear = new Date(endStr).getUTCFullYear();
+        if (!Number.isNaN(startYear) && !Number.isNaN(endYear)) {
+          analysisParams.startYear = startYear;
+          analysisParams.endYear = endYear;
+        }
+      } else {
+        const dateItem = context.find((c) => c.contextType === "date");
+        if (dateItem?.dateRange) {
+          analysisParams.startYear = dateItem.dateRange.start.getFullYear();
+          analysisParams.endYear = dateItem.dateRange.end.getFullYear();
+        }
       }
 
       const hasParams = Object.keys(analysisParams).length > 0;
 
-      // Dataset name for legacy datasetName field (used elsewhere)
-      const datasetName =
-        (streamMessage.dataset as { dataset_name?: string } | undefined)
-          ?.dataset_name ?? analysisParams.dataset;
+      const datasetName = dataset?.dataset_name ?? analysisParams.dataset;
 
       const widgets: InsightWidget[] = (
         streamMessage.charts_data as ChartData[]

--- a/app/types/chat.ts
+++ b/app/types/chat.ts
@@ -45,6 +45,16 @@ export interface InsightWidget {
   yAxis: string;
   datasetName?: string;
   generation?: InsightGeneration; // Optional provenance for how the widget was generated
+  analysisParams?: AnalysisParams; // Parameters used by the agent to produce this insight
+}
+
+// Parameters the agent used to produce an insight (read-only transparency)
+export interface AnalysisParams {
+  areas?: string[]; // e.g. ["Pará, Brazil", "KBAs"]
+  dataset?: string; // e.g. "Tree cover loss"
+  canopyThreshold?: number; // e.g. 30 (percentage)
+  startYear?: number;
+  endYear?: number;
 }
 
 // Raw insight data from API (before conversion to InsightWidget)


### PR DESCRIPTION
## Pull request checklist

## Pull request type

Please check the type of change your PR introduces:
- [x] Feature

## What is the current behavior?

Insight cards show no information about the parameters the agent used to produce the analysis (area, dataset, canopy threshold, year range). Users have no way to verify that the result reflects their question rather than a silent default.

## What is the new behavior?

- A **"Show params / Hide params"** toggle link (IBM Plex Mono, underlined) is rendered right-aligned in the insight card header, next to the chart title.
- Clicking the toggle expands a row of **read-only chips** in the card body, each labelled by type: `AREA`, `DATA`, `CANOPY`, `YEARS`.
- Multiple AOIs produce one `AREA` chip per area. Parameters that don't apply to a dataset (e.g. `CANOPY` for grasslands) are omitted entirely.
- Chip label colours follow the Figma spec mapped to the nearest theme tokens (`primary.400`, `green.500`, `purple.500`); borders use `neutral.300`.
- Parameters are sourced from `contextStore` at the time `generate_insights` fires, since the earlier tools (`pick_aoi`, `pick_dataset`) already populate the store before insights are generated.


## Does this introduce a breaking change?

- [ ] Yes
- [x] No


## Demo
<img width="555" height="573" alt="Screenshot 2026-05-21 at 00 17 16" src="https://github.com/user-attachments/assets/043d4815-f628-4c29-ba07-35bbe8b170bc" />
