### PR TITLE
Pzb 788 param source of truth

### DIFF
--- a/app/components/WidgetMessage.tsx
+++ b/app/components/WidgetMessage.tsx
@@ -27,9 +27,10 @@ import InsightProvenanceDrawer from "./InsightProvenanceDrawer";
 import VisualizationDisclaimer from "./VisualizationDisclaimer";
 import WidgetErrorBoundary from "./widgets/WidgetErrorBoundary";
 import ScrollableTableWrapper from "./widgets/ScrollableTableWrapper";
-import AnalysisParameters, {
+import AnalysisParametersToggle, {
   AnalysisParamsChips,
 } from "./widgets/AnalysisParameters";
+import { buildChips } from "./widgets/analysis-params-utils";
 
 interface WidgetMessageProps {
   widget: InsightWidget;
@@ -38,6 +39,8 @@ interface WidgetMessageProps {
 export default function WidgetMessage({ widget }: WidgetMessageProps) {
   const [showAsTable, setShowAsTable] = useState(false);
   const [paramsExpanded, setParamsExpanded] = useState(false);
+  const chips = widget.analysisParams ? buildChips(widget.analysisParams) : [];
+  const hasChips = chips.length > 0;
   const { open, onOpen, onClose } = useDisclosure();
   const {
     open: expanded,
@@ -112,18 +115,15 @@ export default function WidgetMessage({ widget }: WidgetMessageProps) {
         >
           {widget.title}
         </Heading>
-        {widget.analysisParams && (
-          <AnalysisParameters
-            params={widget.analysisParams}
+        {hasChips && (
+          <AnalysisParametersToggle
             expanded={paramsExpanded}
             onToggle={() => setParamsExpanded((v) => !v)}
           />
         )}
       </Flex>
       <Flex gap={3} px={4} py={3} flexDir="column">
-        {widget.analysisParams && paramsExpanded && (
-          <AnalysisParamsChips params={widget.analysisParams} />
-        )}
+        {hasChips && paramsExpanded && <AnalysisParamsChips chips={chips} />}
         {hasData && <Separator />}
         {/* Toolbar row — segmented toggle + full-screen */}
         <Flex justify="flex-start" gap={2} flexWrap="wrap" align="center">

--- a/app/components/widgets/AnalysisParameters.tsx
+++ b/app/components/widgets/AnalysisParameters.tsx
@@ -1,13 +1,6 @@
 "use client";
 import { Flex, Text } from "@chakra-ui/react";
-import { AnalysisParams } from "@/app/types/chat";
-import { buildChips, ParamChip } from "./analysis-params-utils";
-
-interface AnalysisParametersProps {
-  params: AnalysisParams;
-  expanded: boolean;
-  onToggle: () => void;
-}
+import { ParamChip } from "./analysis-params-utils";
 
 // Label text colors mapped from Figma spec to nearest theme tokens:
 // AREA #4A64CB → primary.400 (#3361C0)
@@ -20,15 +13,16 @@ const chipLabelColor: Record<ParamChip["colorScheme"], string> = {
   purple: "purple.500",
 };
 
+interface AnalysisParametersToggleProps {
+  expanded: boolean;
+  onToggle: () => void;
+}
+
 /** Toggle button rendered in the widget header row */
-export default function AnalysisParameters({
-  params,
+export default function AnalysisParametersToggle({
   expanded,
   onToggle,
-}: AnalysisParametersProps) {
-  const chips = buildChips(params);
-  if (chips.length === 0) return null;
-
+}: AnalysisParametersToggleProps) {
   return (
     <Text
       as="button"
@@ -51,10 +45,7 @@ export default function AnalysisParameters({
 }
 
 /** Chips panel rendered below the header row when expanded */
-export function AnalysisParamsChips({ params }: { params: AnalysisParams }) {
-  const chips = buildChips(params);
-  if (chips.length === 0) return null;
-
+export function AnalysisParamsChips({ chips }: { chips: ParamChip[] }) {
   return (
     <Flex gap={1.5} flexWrap="wrap">
       {chips.map((chip, idx) => (

--- a/app/components/widgets/AnalysisParameters.tsx
+++ b/app/components/widgets/AnalysisParameters.tsx
@@ -2,6 +2,7 @@
 import { Flex, Text } from "@chakra-ui/react";
 import { ParamChip } from "./analysis-params-utils";
 
+// TODO: Extract these colors to a shared util since they're used in DatasetCards too
 // Label text colors mapped from Figma spec to nearest theme tokens:
 // AREA #4A64CB → primary.400 (#3361C0)
 // DATA #1AA815 → green.500  (#00A651)

--- a/app/constants/datasets.ts
+++ b/app/constants/datasets.ts
@@ -59,7 +59,7 @@ export const CONTEXT_LAYER_METADATA: Record<string, ContextLayerMetadata> = {
       note: "Extent of primary humid tropical forests in 2001. Pan-tropical coverage at 30m resolution (UMD/GLAD).",
     },
   },
-  ifl: {
+  intact_forest: {
     dataset_id: 10,
     dataset_name: "Intact Forest Landscapes",
     context_layer: null as string | null,

--- a/app/store/chat-tools/generateInsights.ts
+++ b/app/store/chat-tools/generateInsights.ts
@@ -3,6 +3,7 @@ import {
   StreamMessage,
   InsightWidget,
   AnalysisParams,
+  DatasetInfo,
 } from "@/app/types/chat";
 import useContextStore from "../contextStore";
 
@@ -21,44 +22,57 @@ export function generateInsightsTool(
   addMessage: (message: Omit<ChatMessage, "id">) => void
 ) {
   try {
-    // Handle charts_data from streamMessage
     if (streamMessage.charts_data && Array.isArray(streamMessage.charts_data)) {
-      // Build analysis params from contextStore — the earlier tools (pick_aoi,
-      // pick_dataset, pull_data) populate the store before generate_insights fires.
+      // streamMessage carries the agent's authoritative selection for this
+      // analysis. Prefer it over contextStore, which is updated asynchronously
+      // by pickAoiTool/etc. and may not yet reflect this turn's choices.
       const context = useContextStore.getState().context;
-
+      const dataset = streamMessage.dataset as DatasetInfo | undefined;
       const analysisParams: AnalysisParams = {};
 
-      // Areas from "area" context
+      const aoiFromStream = streamMessage.aoi_selection?.aois;
       const areaItem = context.find((c) => c.contextType === "area");
-      if (areaItem?.aoiSelection?.aois?.length) {
+      if (aoiFromStream?.length) {
+        analysisParams.areas = aoiFromStream.map((a) => a.name);
+      } else if (areaItem?.aoiSelection?.aois?.length) {
         analysisParams.areas = areaItem.aoiSelection.aois.map((a) => a.name);
       } else if (typeof areaItem?.content === "string" && areaItem.content) {
         analysisParams.areas = [areaItem.content];
       }
 
-      // Dataset name and canopy threshold from "layer" context
       const layerItem = context.find((c) => c.contextType === "layer");
-      if (layerItem?.layerName) {
+      if (dataset?.dataset_name) {
+        analysisParams.dataset = dataset.dataset_name;
+      } else if (layerItem?.layerName) {
         analysisParams.dataset = layerItem.layerName;
       }
-      if (typeof layerItem?.parameters?.canopy_cover === "number") {
+
+      if (typeof dataset?.threshold === "number") {
+        analysisParams.canopyThreshold = dataset.threshold;
+      } else if (typeof layerItem?.parameters?.canopy_cover === "number") {
         analysisParams.canopyThreshold = layerItem.parameters.canopy_cover;
       }
 
-      // Year range from "date" context
-      const dateItem = context.find((c) => c.contextType === "date");
-      if (dateItem?.dateRange) {
-        analysisParams.startYear = dateItem.dateRange.start.getFullYear();
-        analysisParams.endYear = dateItem.dateRange.end.getFullYear();
+      const startStr = streamMessage.start_date ?? layerItem?.startDate;
+      const endStr = streamMessage.end_date ?? layerItem?.endDate;
+      if (startStr && endStr) {
+        const startYear = new Date(startStr).getUTCFullYear();
+        const endYear = new Date(endStr).getUTCFullYear();
+        if (!Number.isNaN(startYear) && !Number.isNaN(endYear)) {
+          analysisParams.startYear = startYear;
+          analysisParams.endYear = endYear;
+        }
+      } else {
+        const dateItem = context.find((c) => c.contextType === "date");
+        if (dateItem?.dateRange) {
+          analysisParams.startYear = dateItem.dateRange.start.getFullYear();
+          analysisParams.endYear = dateItem.dateRange.end.getFullYear();
+        }
       }
 
       const hasParams = Object.keys(analysisParams).length > 0;
 
-      // Dataset name for legacy datasetName field (used elsewhere)
-      const datasetName =
-        (streamMessage.dataset as { dataset_name?: string } | undefined)
-          ?.dataset_name ?? analysisParams.dataset;
+      const datasetName = dataset?.dataset_name ?? analysisParams.dataset;
 
       const widgets: InsightWidget[] = (
         streamMessage.charts_data as ChartData[]


### PR DESCRIPTION
Adds years and areas param chips by making `streamMessage` the primary source of truth for `analysisParams`. `contextStore` is a fallback.**

The handler reads in this priority order:

| Field    | Primary source                                | Fallback                                                                 |
| -------- | --------------------------------------------- | ------------------------------------------------------------------------ |
| `areas`  | `streamMessage.aoi_selection.aois`            | `contextStore` area item (`aoiSelection.aois` → `content` string)        |
| `dataset` | `streamMessage.dataset.dataset_name`          | `contextStore` layer item `layerName`                                    |
| `canopyThreshold` | `streamMessage.dataset.threshold`    | `contextStore` layer item `parameters.canopy_cover`                      |
| `startYear` / `endYear` | `streamMessage.start_date` / `end_date` | layer item `startDate` / `endDate`, then date context `dateRange`        |

Year values are parsed with `new Date(...).getUTCFullYear()` and guarded with `Number.isNaN` so a malformed date never produces a `"NaN–NaN"` chip.

- Adds a read-only chip strip under each insight card surfacing the AOI, dataset, canopy threshold, and year range the agent used to produce that analysis.
- Builds chip data from the streaming response so chips reliably reflect what the agent actually did this turn, not whatever happens to be in the UI's context store.
- Dedupes chip computation so it runs once per render rather than twice.
- Drops the manage-users admin feature (page, hooks, schemas, SettingsShell) and folds the dashboard layout inline.

<img width="565" height="168" alt="Screenshot 2026-05-21 at 11 54 13" src="https://github.com/user-attachments/assets/c3b2267b-8e4e-4b24-b865-6a79ad3cf7d5" />
