### PR TITLE
Map insights tweaks

### DIFF
--- a/app/components/AnalysisCard.tsx
+++ b/app/components/AnalysisCard.tsx
@@ -1,0 +1,59 @@
+"use client";
+import { InsightWidget } from "@/app/types/chat";
+import { WidgetIconComponent } from "@/app/utils/widgetIcons";
+import { InfoCard } from "./InfoCard";
+
+const CHART_TYPE_LABEL: Record<InsightWidget["type"], string> = {
+  line: "Line chart",
+  bar: "Bar chart",
+  "stacked-bar": "Stacked bar chart",
+  "grouped-bar": "Grouped bar chart",
+  pie: "Pie chart",
+  area: "Area chart",
+  scatter: "Scatter chart",
+  table: "Table",
+  "dataset-card": "Dataset",
+};
+
+const ROW_NOUN: Record<InsightWidget["type"], string> = {
+  table: "rows",
+  "dataset-card": "items",
+  line: "data points",
+  bar: "data points",
+  "stacked-bar": "data points",
+  "grouped-bar": "data points",
+  pie: "data points",
+  area: "data points",
+  scatter: "data points",
+};
+
+function buildSubtitle(widget: InsightWidget): string {
+  const chartLabel = CHART_TYPE_LABEL[widget.type] ?? widget.type;
+  if (!Array.isArray(widget.data)) return chartLabel;
+  const count = widget.data.length;
+  const noun = ROW_NOUN[widget.type] ?? "data points";
+  const label = count === 1 ? noun.replace(/s$/, "") : noun;
+  return `${chartLabel} · ${count} ${label}`;
+}
+
+interface AnalysisCardProps {
+  widget: InsightWidget;
+  onClick?: () => void;
+  selected?: boolean;
+}
+
+export function AnalysisCard({ widget, onClick, selected }: AnalysisCardProps) {
+  const Icon = WidgetIconComponent[widget.type];
+  return (
+    <InfoCard
+      thumbnail={<Icon size={32} color="#0049AA" />}
+      thumbnailBg="#F7F9FF"
+      typeLabel="ANALYSIS"
+      typeLabelColor="#8E9954"
+      title={widget.title}
+      description={buildSubtitle(widget)}
+      onClick={onClick}
+      selected={selected}
+    />
+  );
+}

--- a/app/components/ChatMessages.tsx
+++ b/app/components/ChatMessages.tsx
@@ -98,6 +98,7 @@ function ChatMessages() {
         const previousMessage = index > 0 ? messages[index - 1] : null;
         const isConsecutive = previousMessage?.type === message.type;
         const isFirst = index === 0;
+        const isLast = index === messages.length - 1;
         const isLastUserMessage =
           index === lastUserMessageIndex && message.type === "user";
         return (
@@ -157,6 +158,7 @@ function ChatMessages() {
               message={message}
               isConsecutive={isConsecutive}
               isFirst={isFirst}
+              isLast={isLast}
             />
             {message.type === "user" && (
               <>

--- a/app/components/InfoCard.tsx
+++ b/app/components/InfoCard.tsx
@@ -1,0 +1,123 @@
+"use client";
+import { Box, Flex, Text } from "@chakra-ui/react";
+import * as React from "react";
+
+export interface InfoCardProps {
+  /** Element rendered inside the left 80x80 thumbnail slot — image or icon. */
+  thumbnail: React.ReactNode;
+  /** Background applied to the thumbnail slot. Defaults to white. */
+  thumbnailBg?: string;
+  /** Small uppercase mono label above the title (e.g. "ANALYSIS", "DATA"). */
+  typeLabel?: string;
+  /** Hex color for the type label. */
+  typeLabelColor?: string;
+  /** Bold sans-serif title text. */
+  title: string;
+  /** Mono caption shown under the title. */
+  description?: string;
+  onClick?: () => void;
+  /** When true, swaps the gray border for a primary highlight border. */
+  selected?: boolean;
+  /** Optional action node (e.g. info icon) anchored to the right of the title row. */
+  titleActions?: React.ReactNode;
+}
+
+export function InfoCard({
+  thumbnail,
+  thumbnailBg = "#FFFFFF",
+  typeLabel,
+  typeLabelColor = "#656E7B",
+  title,
+  description,
+  onClick,
+  selected = false,
+  titleActions,
+}: InfoCardProps) {
+  return (
+    <Flex
+      flexDirection="row"
+      alignItems="center"
+      w="100%"
+      h="80px"
+      bg="#FFFFFF"
+      border={selected ? "2px solid" : "1px solid"}
+      borderColor={selected ? "primary.solid" : "rgba(19, 22, 25, 0.3)"}
+      borderRadius="4px"
+      overflow="hidden"
+      cursor={onClick ? "pointer" : "default"}
+      onClick={onClick}
+      _hover={onClick ? { borderColor: "primary.300" } : undefined}
+      transition="border-color 0.16s ease"
+    >
+      <Flex
+        w="80px"
+        h="80px"
+        minH="80px"
+        flexShrink={0}
+        bg={thumbnailBg}
+        borderRight="1px solid rgba(19, 22, 25, 0.1)"
+        alignItems="center"
+        justifyContent="center"
+      >
+        {thumbnail}
+      </Flex>
+      <Box
+        flex="1"
+        display="flex"
+        flexDirection="column"
+        gap="2px"
+        px="16px"
+        py={0}
+        minW={0}
+      >
+        {typeLabel && (
+          <Text
+            fontFamily="mono"
+            fontSize="10px"
+            fontWeight="normal"
+            lineHeight="16px"
+            letterSpacing="0.5px"
+            color={typeLabelColor}
+            textTransform="uppercase"
+            whiteSpace="nowrap"
+            overflow="hidden"
+            textOverflow="ellipsis"
+          >
+            {typeLabel}
+          </Text>
+        )}
+        <Flex align="center" gap="8px" minW={0}>
+          <Text
+            fontFamily="body"
+            fontSize="12px"
+            fontWeight="medium"
+            lineHeight="150%"
+            color="#3A4048"
+            flex="1"
+            minW={0}
+            whiteSpace="nowrap"
+            overflow="hidden"
+            textOverflow="ellipsis"
+          >
+            {title}
+          </Text>
+          {titleActions}
+        </Flex>
+        {description && (
+          <Text
+            fontFamily="mono"
+            fontSize="10px"
+            fontWeight="normal"
+            lineHeight="16px"
+            color="#656E7B"
+            whiteSpace="nowrap"
+            overflow="hidden"
+            textOverflow="ellipsis"
+          >
+            {description}
+          </Text>
+        )}
+      </Box>
+    </Flex>
+  );
+}

--- a/app/components/InsightWorkspace.tsx
+++ b/app/components/InsightWorkspace.tsx
@@ -1,6 +1,6 @@
 "use client";
 import { useState, useEffect } from "react";
-import { Box, Flex, Text, Heading, IconButton, Link } from "@chakra-ui/react";
+import { Box, Flex, Text, Heading, IconButton } from "@chakra-ui/react";
 import {
   CaretDownIcon,
   CaretUpIcon,
@@ -9,11 +9,38 @@ import {
 } from "@phosphor-icons/react";
 import useInsightStore from "@/app/store/insightStore";
 import WidgetMessage from "./WidgetMessage";
-import { WidgetIcons } from "@/app/ChatPanelHeader";
+import { Tooltip } from "./ui/tooltip";
+import { WidgetIconComponent } from "@/app/utils/widgetIcons";
 import AnalysisParametersToggle, {
   AnalysisParamsChips,
 } from "./widgets/AnalysisParameters";
 import { buildChips } from "./widgets/analysis-params-utils";
+
+const AI_DISCLAIMER =
+  "This visualization includes AI-generated charts and data summaries. AI models may produce incomplete or incorrect information. Please verify all outputs before using them in your work.";
+
+const aiDisclaimerTooltip = (
+  <Box display="flex" flexDirection="column" gap="2px" maxW="296px">
+    <Text
+      fontFamily="body"
+      fontSize="12px"
+      lineHeight="150%"
+      fontWeight="medium"
+      color="#FFFFFF"
+    >
+      AI-Assisted Analysis
+    </Text>
+    <Text
+      fontFamily="body"
+      fontSize="12px"
+      lineHeight="150%"
+      fontWeight="normal"
+      color="#B2B6BD"
+    >
+      {AI_DISCLAIMER}
+    </Text>
+  </Box>
+);
 
 export default function InsightWorkspace() {
   const { insights } = useInsightStore();
@@ -34,6 +61,7 @@ export default function InsightWorkspace() {
   const hasChips = chips.length > 0;
   const canGoPrev = currentIndex < total - 1;
   const canGoNext = currentIndex > 0;
+  const HeaderIcon = WidgetIconComponent[widget.type];
 
   return (
     <Box
@@ -51,53 +79,77 @@ export default function InsightWorkspace() {
         bg="primary.25"
         border="1px solid"
         borderColor="#DDE2F5"
-        borderRadius="md"
-        boxShadow="0 4px 20px -4px {colors.primary.solid/40}"
+        rounded="4px"
         pointerEvents="all"
+        display="flex"
+        flexDirection="column"
       >
-        {/* Header row */}
+        {/* Header row — 28px section header */}
         <Flex
-          px={4}
+          h="28px"
+          px="16px"
+          py="6px"
+          gap="8px"
           justify="space-between"
           align="center"
           borderBottom="1px solid"
           borderColor="#DDE2F5"
         >
-          <Flex align="center" gap={1.5} flexWrap="nowrap" overflow="hidden">
-            {WidgetIcons[widget.type]}
+          <Flex
+            align="center"
+            gap="8px"
+            h="16px"
+            flexWrap="nowrap"
+            overflow="hidden"
+          >
+            <HeaderIcon size={12} color="#0049AA" />
             <Text
               fontSize="10px"
               fontFamily="mono"
-              textTransform="uppercase"
-              letterSpacing="wider"
+              fontWeight="normal"
+              lineHeight="16px"
+              letterSpacing="0.03em"
               color="fg.muted"
               whiteSpace="nowrap"
             >
-              AI-Assisted Analysis{" · "}
-              <Link
-                href="https://help.globalnaturewatch.org"
-                target="_blank"
-                rel="noopener noreferrer"
-                fontSize="10px"
-                fontFamily="mono"
-                textDecoration="underline"
-                textTransform="none"
+              AI-Assisted Analysis
+              {" · "}
+              <Tooltip
+                variant="dark"
+                content={aiDisclaimerTooltip}
+                showArrow
+                positioning={{ placement: "bottom" }}
+                openDelay={100}
+                closeDelay={100}
               >
-                learn more
-              </Link>
+                <Box
+                  as="span"
+                  color="#4A64CB"
+                  textDecoration="underline"
+                  cursor="help"
+                  tabIndex={0}
+                  aria-label="Learn more about AI-Assisted Analysis"
+                >
+                  learn more
+                </Box>
+              </Tooltip>
             </Text>
           </Flex>
           <IconButton
-            size="xs"
+            size="2xs"
             variant="ghost"
+            h="16px"
+            minW="16px"
+            w="16px"
+            color="#656E7B"
             aria-label={isCollapsed ? "Expand insight" : "Collapse insight"}
             flexShrink={0}
             onClick={() => setIsCollapsed((v) => !v)}
           >
             {isCollapsed ? (
-              <CaretDownIcon size={14} />
+              <CaretDownIcon size={12} weight="bold" />
             ) : (
-              <CaretUpIcon size={14} />
+              <CaretUpIcon size={12} weight="bold" />
             )}
           </IconButton>
         </Flex>

--- a/app/components/InsightWorkspace.tsx
+++ b/app/components/InsightWorkspace.tsx
@@ -59,8 +59,10 @@ export default function InsightWorkspace() {
   const widget = insights[total - 1 - currentIndex];
   const chips = widget.analysisParams ? buildChips(widget.analysisParams) : [];
   const hasChips = chips.length > 0;
-  const canGoPrev = currentIndex < total - 1;
-  const canGoNext = currentIndex > 0;
+  // currentIndex 0 = newest (shown as "1 of N"). The Left/Prev arrow
+  // disables at 1/N; Right/Next advances through the stack to older entries.
+  const canGoPrev = currentIndex > 0;
+  const canGoNext = currentIndex < total - 1;
   const HeaderIcon = WidgetIconComponent[widget.type];
 
   return (
@@ -212,7 +214,7 @@ export default function InsightWorkspace() {
                   borderColor="border.emphasized"
                   aria-label="Previous insight"
                   disabled={!canGoPrev}
-                  onClick={() => setCurrentIndex((i) => i + 1)}
+                  onClick={() => setCurrentIndex((i) => i - 1)}
                 >
                   <ArrowArcLeftIcon size={14} />
                 </IconButton>
@@ -226,7 +228,7 @@ export default function InsightWorkspace() {
                   borderColor="border.emphasized"
                   aria-label="Next insight"
                   disabled={!canGoNext}
-                  onClick={() => setCurrentIndex((i) => i - 1)}
+                  onClick={() => setCurrentIndex((i) => i + 1)}
                 >
                   <ArrowArcRightIcon size={14} />
                 </IconButton>

--- a/app/components/MessageBubble.tsx
+++ b/app/components/MessageBubble.tsx
@@ -38,12 +38,14 @@ interface MessageBubbleProps {
   message: ChatMessage;
   isConsecutive?: boolean; // Whether this message is consecutive to the previous one of the same type
   isFirst?: boolean;
+  isLast?: boolean;
 }
 
 function MessageBubble({
   message,
   isConsecutive = false,
   isFirst = false,
+  isLast = false,
 }: MessageBubbleProps) {
   const [formattedTimestamp, setFormattedTimestamp] = useState("");
   const clipboard = useClipboard({ value: message.message });
@@ -149,7 +151,11 @@ function MessageBubble({
     : [];
   const hasContext = isUser && message.context && message.context.length > 0;
   const showFooter =
-    !isUser && !isConsecutive && !isError && !isWarning && !isFirst;
+    !isUser &&
+    !isError &&
+    !isWarning &&
+    !isFirst &&
+    (!isConsecutive || analysisWidgets.length > 0 || isLast);
   // For widget messages, render them in a full-width container
   if (isWidget && message.widgets) {
     return message.widgets.map((widget, idx) => (

--- a/app/components/MessageBubble.tsx
+++ b/app/components/MessageBubble.tsx
@@ -13,6 +13,7 @@ import {
 import { Tooltip } from "./ui/tooltip";
 import { ChatMessage } from "@/app/types/chat";
 import WidgetMessage from "./WidgetMessage";
+import { AnalysisCard } from "./AnalysisCard";
 import Markdown from "react-markdown";
 import {
   ArrowBendDownRightIcon,
@@ -142,6 +143,10 @@ function MessageBubble({
   const isWidget = message.type === "widget";
   const isError = message.type === "error";
   const isWarning = message.type === "warning";
+  const isAssistant = message.type === "assistant";
+  const analysisWidgets = isAssistant
+    ? (message.widgets ?? []).filter((w) => w.type !== "dataset-card")
+    : [];
   const hasContext = isUser && message.context && message.context.length > 0;
   const showFooter =
     !isUser && !isConsecutive && !isError && !isWarning && !isFirst;
@@ -260,6 +265,16 @@ function MessageBubble({
               </Markdown>
             </CopySelectionTooltip>
           </Box>
+        )}
+        {analysisWidgets.length > 0 && (
+          <Flex direction="column" gap="2" mt="2" w="100%">
+            {analysisWidgets.map((widget, idx) => (
+              <AnalysisCard
+                key={`${message.id}-analysis-${idx}`}
+                widget={widget}
+              />
+            ))}
+          </Flex>
         )}
         {showFooter && (
           <Flex

--- a/app/components/legend/Legend.tsx
+++ b/app/components/legend/Legend.tsx
@@ -103,51 +103,57 @@ export function Legend(props: LegendProps) {
       right={3}
       bottom={{ base: "4.5rem", md: 12 }}
       zIndex={100}
-      width={320}
+      width={420}
       maxH={{ base: "50vh", md: "60vh" }}
-      bg="bg"
-      rounded="sm"
-      shadow="sm"
+      bg="#F7F9FF"
+      border="1px solid"
+      borderColor="#D7D3D0"
+      rounded="4px"
       flexDirection="column"
       overflow="hidden"
     >
-      {/* Always-visible header — click the caret to collapse/expand */}
+      {/* Always-visible header — 28px section header per Figma */}
       <Flex
-        px={3}
-        py={2}
+        h="28px"
+        px="16px"
+        py="6px"
+        gap="8px"
         alignItems="center"
         justifyContent="space-between"
         borderBottom="1px solid"
-        borderColor="border"
+        borderColor="#DDE2F5"
         flexShrink={0}
       >
         {/* Icon + label group (matches Figma: width 83, height 16, gap 8px) */}
-        <Flex alignItems="center" gap={2}>
+        <Flex alignItems="center" gap="8px" h="16px">
           <StackIcon size={12} color="#0049AA" />
           <Text
             fontSize="10px"
             fontWeight="400"
             fontFamily="mono"
-            letterSpacing="wider"
+            lineHeight="16px"
+            letterSpacing="0.03em"
             textTransform="uppercase"
-            color="fg.muted"
+            color="#656E7B"
           >
             Map layers
           </Text>
         </Flex>
         <IconButton
           variant="ghost"
-          size="xs"
+          size="2xs"
           p={0}
           minW="16px"
           h="16px"
+          w="16px"
+          color="#656E7B"
           aria-label={isCollapsed ? "Expand legend" : "Collapse legend"}
           onClick={() => setIsCollapsed((prev) => !prev)}
         >
           {isCollapsed ? (
-            <CaretDownIcon size={12} />
+            <CaretDownIcon size={12} weight="bold" />
           ) : (
-            <CaretUpIcon size={12} />
+            <CaretUpIcon size={12} weight="bold" />
           )}
         </IconButton>
       </Flex>
@@ -193,19 +199,28 @@ export function Legend(props: LegendProps) {
           )}
           {hasAois && (
             <>
-              {layers.length > 0 && <Box h="1px" bg="border" />}
-              <Flex gap={1} flexWrap="wrap" p={2}>
+              {layers.length > 0 && <Box h="1px" bg="#DDE2F5" />}
+              <Flex
+                bg="#F7F9FF"
+                flexWrap="wrap"
+                gap="8px"
+                pt="8px"
+                pr={0}
+                pb="8px"
+                pl="24px"
+              >
                 {aois.map((aoi) => (
                   <Flex
                     key={`${aoi.contextId}-${aoi.name}`}
                     alignItems="center"
                     gap="4px"
                     h="20px"
-                    pl="6px"
-                    pr="4px"
-                    borderRadius="sm"
+                    px="6px"
+                    py="2px"
+                    borderRadius="6px"
                     border="1px solid"
                     borderColor="#E0E2E5"
+                    bg="#FFFFFF"
                     fontFamily="mono"
                     fontSize="10px"
                     flexShrink={0}
@@ -215,7 +230,7 @@ export function Legend(props: LegendProps) {
                       fontWeight="normal"
                       lineHeight="16px"
                       letterSpacing="0.5px"
-                      color="#A51EC7"
+                      color="#4A64CB"
                     >
                       AREA
                     </Text>

--- a/app/components/widgets/AnalysisParameters.tsx
+++ b/app/components/widgets/AnalysisParameters.tsx
@@ -59,6 +59,8 @@ export function AnalysisParamsChips({ chips }: { chips: ParamChip[] }) {
           pr="6px"
           pl={2}
           rounded="sm"
+          border="1px solid"
+          borderColor="neutral.300"
         >
           <Text
             fontFamily="mono"

--- a/app/components/widgets/AnalysisParameters.tsx
+++ b/app/components/widgets/AnalysisParameters.tsx
@@ -59,8 +59,6 @@ export function AnalysisParamsChips({ chips }: { chips: ParamChip[] }) {
           pr="6px"
           pl={2}
           rounded="sm"
-          border="1px solid"
-          borderColor="neutral.300"
         >
           <Text
             fontFamily="mono"

--- a/app/components/widgets/AnalysisParameters.tsx
+++ b/app/components/widgets/AnalysisParameters.tsx
@@ -32,13 +32,12 @@ export default function AnalysisParametersToggle({
       fontSize="10px"
       fontWeight="400"
       lineHeight="16px"
-      color="fg.muted"
+      color="#4A64CB"
       textDecoration="underline"
       textDecorationStyle="solid"
       whiteSpace="nowrap"
       flexShrink={0}
       cursor="pointer"
-      _hover={{ color: "fg" }}
     >
       {expanded ? "Hide params" : "Show params"}
     </Text>

--- a/app/components/widgets/AnalysisParameters.tsx
+++ b/app/components/widgets/AnalysisParameters.tsx
@@ -76,7 +76,9 @@ export function AnalysisParamsChips({ chips }: { chips: ParamChip[] }) {
             fontSize="10px"
             fontWeight="500"
             lineHeight="16px"
-            color="fg"
+            color={
+              chip.label === "AREA" ? chipLabelColor[chip.colorScheme] : "fg"
+            }
           >
             {chip.value}
           </Text>

--- a/app/sidebar.tsx
+++ b/app/sidebar.tsx
@@ -253,10 +253,7 @@ export function Sidebar() {
           },
         }}
       >
-        <Accordion.Root
-          multiple
-          defaultValue={["today", "previousWeek", "older"]}
-        >
+        <Accordion.Root multiple defaultValue={["today", "previousWeek"]}>
           {hasTodayThreads && (
             <ThreadSection
               threads={threadGroups.today}

--- a/app/store/chat-tools/generateInsights.ts
+++ b/app/store/chat-tools/generateInsights.ts
@@ -100,6 +100,7 @@ export function generateInsightsTool(
         type: "assistant",
         message: "I've created an insight you can view on the map.",
         timestamp: streamMessage.timestamp,
+        widgets,
       });
     }
   } catch (error) {

--- a/app/store/chat-tools/generateInsights.ts
+++ b/app/store/chat-tools/generateInsights.ts
@@ -32,8 +32,17 @@ export function generateInsightsTool(
       const analysisParams: AnalysisParams = {};
 
       const aoiFromStream = streamMessage.aoi_selection?.aois;
+      const selectionFromStream = streamMessage.aoi_selection?.name;
       const areaItem = context.find((c) => c.contextType === "area");
-      if (aoiFromStream?.length) {
+      const selectionFromContext = areaItem?.aoiSelection?.name;
+      // Prefer the selection name (one chip) over the per-AOI list so the
+      // chip matches the legend, which always shows one chip per selection.
+      // Falls back to the AOI list / content string when no name is given.
+      if (selectionFromStream) {
+        analysisParams.areas = [selectionFromStream];
+      } else if (selectionFromContext) {
+        analysisParams.areas = [selectionFromContext];
+      } else if (aoiFromStream?.length) {
         analysisParams.areas = aoiFromStream.map((a) => a.name);
       } else if (areaItem?.aoiSelection?.aois?.length) {
         analysisParams.areas = areaItem.aoiSelection.aois.map((a) => a.name);

--- a/app/utils/widgetIcons.ts
+++ b/app/utils/widgetIcons.ts
@@ -1,0 +1,30 @@
+import {
+  ChartBarIcon,
+  ChartLineIcon,
+  ChartPieSliceIcon,
+  ChartPolarIcon,
+  ChartScatterIcon,
+  ListNumbersIcon,
+  StackIcon,
+} from "@phosphor-icons/react";
+import type { Icon } from "@phosphor-icons/react";
+import type { InsightWidget } from "@/app/types/chat";
+
+/**
+ * Maps an InsightWidget type to the Phosphor icon *component* (not an
+ * instance), so callers can pass their own size/color/weight props.
+ *
+ * Mirrors the `WidgetIcons` element map in ChatPanelHeader.tsx — kept in
+ * sync manually for now since the two have different ergonomics.
+ */
+export const WidgetIconComponent: Record<InsightWidget["type"], Icon> = {
+  line: ChartLineIcon,
+  bar: ChartBarIcon,
+  "stacked-bar": ChartBarIcon,
+  "grouped-bar": ChartBarIcon,
+  pie: ChartPieSliceIcon,
+  area: ChartPolarIcon,
+  scatter: ChartScatterIcon,
+  table: ListNumbersIcon,
+  "dataset-card": StackIcon,
+};


### PR DESCRIPTION
Insight workspace + legend Figma alignment, chat-side analysis cards

- Visual alignment: InsightWorkspace and Legend share a 420px panel
with the same 28px Figma section header (dark "AI-Assisted Analysis ·
learn more" tooltip, type-aware icon, #DDE2F5 dividers, #F7F9FF bg).
AREA chips collapsed to one per selection (matches the legend) and the
AREA value text now reads in the same blue as its label.
- Chat-side analysis cards: Each insight reference message in chat
renders one AnalysisCard per chart widget (clickable surface for
future workspace navigation). The thumbs-up/down/copy/timestamp footer
is now forced on for insight references and the final message in any
conversation (previously hidden by the isConsecutive rule).
- Workspace UX nits: Prev/Next direction flipped so 1/N disables the
left arrow and the right arrow steps through to older entries. "Show
params" toggle uses the same #4A64CB blue as the header "learn more"
link, and the older-conversations sidebar section is collapsed by
default.