### PR TITLE
PZB-834: TCL from Fires available as a map layer

### DIFF
--- a/app/components/ContextMenu.tsx
+++ b/app/components/ContextMenu.tsx
@@ -88,12 +88,23 @@ function LayerCardList({
     if (existing) {
       removeContext(existing.id);
     } else {
+      const year = card.defaultYear;
+      const tileUrl =
+        year && card.tile_url
+          ? `${card.tile_url}&start_year=${year}&end_year=${year}`
+          : card.tile_url;
       upsertContextByType({
         contextType: "layer",
         content: card.dataset_name,
         datasetId: card.dataset_id,
-        tileUrl: card.tile_url,
+        tileUrl,
         layerName: card.dataset_name,
+        ...(year
+          ? {
+              startDate: `${year}-01-01`,
+              endDate: `${year}-12-31`,
+            }
+          : {}),
         isAiContext: false,
       });
     }
@@ -112,6 +123,9 @@ function LayerCardList({
             img={card.img ?? "/globe.svg"}
             selected={isSelected}
             onClick={() => handleToggle(card)}
+            {...(card.viewOnly
+              ? { label: "VIEW ONLY", labelColor: "#656E7B" }
+              : {})}
           />
         );
       })}

--- a/app/components/legend/useLegendHook.tsx
+++ b/app/components/legend/useLegendHook.tsx
@@ -169,10 +169,14 @@ export function useLegendHook() {
 
         const { title, info, note } = relatedDataset.legend;
 
-        const dateRange =
-          layer.startDate && layer.endDate
-            ? `${layer.startDate.slice(0, 4)}–${layer.endDate.slice(0, 4)}`
-            : undefined;
+        const dateRange = (() => {
+          if (!layer.startDate || !layer.endDate) return undefined;
+          const startYear = layer.startDate.slice(0, 4);
+          const endYear = layer.endDate.slice(0, 4);
+          return startYear === endYear
+            ? startYear
+            : `${startYear}\u2013${endYear}`;
+        })();
         const params = buildParams(layer.parameters ?? {}, dateRange);
 
         entries.push({

--- a/app/constants/datasets.ts
+++ b/app/constants/datasets.ts
@@ -32,6 +32,10 @@ export type DatasetCardConfig = {
   resolution?: string;
   geographic_coverage?: string;
   provider?: string;
+  methodology?: string;
+  citation?: string;
+  viewOnly?: boolean;
+  defaultYear?: number;
 };
 
 export type ContextLayerMetadata = {
@@ -295,6 +299,37 @@ export const DATASET_CARDS: (DatasetCardConfig & { img?: string })[] = [
       type: "symbol",
       info: "Tree cover gain dataset can detect natural forest regrowth and tree plantation cycles. It is useful for tracking large-scale forest recovery trends.",
       note: "Baseline percent tree canopy cover showing density of woody vegetation at the selected canopy density.",
+      unit: "ha",
+    },
+  },
+  {
+    dataset_id: 11,
+    dataset_name: "Tree cover loss from fires",
+    data_layer: "Tree cover loss from fires",
+    context_layer: null,
+    threshold: 30,
+    img: "/dataset_card_tree_cover_loss.webp",
+    cadence: "annual",
+    resolution: "30 m",
+    geographic_coverage: "global",
+    provider: "UMD",
+    viewOnly: true,
+    defaultYear: 2025,
+    description:
+      "Tree Cover Loss from Fires (Hansen/UMD/GLAD) maps annual global tree cover loss attributed to fire from 2001 to 2025 at 30-meter resolution. This subset of the broader Tree Cover Loss dataset isolates fire-driven stand-replacement disturbances in vegetation over 5 meters tall, helping users understand where fire is a dominant driver of forest loss.",
+    tile_url:
+      "https://tiles.globalforestwatch.org/umd_tree_cover_loss_from_fires/latest/dynamic/{z}/{x}/{y}.png?tree_cover_density_threshold=30&render_type=true_color",
+    methodology:
+      "Tree cover loss from fires is derived by overlaying the Hansen/UMD/GLAD global annual tree cover loss dataset with the MCD64A1 burned area product (MODIS). A tree cover loss pixel (30 m) is attributed to fire when a MODIS burned area detection occurs within the same 500 m grid cell and calendar year. Only stand-replacement disturbances in woody vegetation taller than 5 m are included, at the selected canopy density threshold.",
+    citation:
+      'Hansen, M. C., P. V. Potapov, R. Moore, M. Hancher, S. A. Turubanova, A. Tyukavina, D. Thau, S. V. Stehman, S. J. Goetz, T. R. Loveland, A. Kommareddy, A. Egorov, L. Chini, C. O. Justice, and J. R. G. Townshend. 2013. "High-Resolution Global Maps of 21st-Century Forest Cover Change." *Science* 342 (6160): 850–53. https://doi.org/10.1126/science.1244693',
+    legend: {
+      title: "Tree cover loss from fires (2001-2025)",
+      color: "#DC6C9A",
+      items: [{ label: "Tree cover loss from fires", color: "#DC6C9A" }],
+      type: "symbol",
+      info: "This dataset isolates fire as a cause of tree cover loss, showing annual locations where fire-driven stand-replacement disturbances have occurred in forests. Useful for understanding the spatial extent and temporal trends of fire impact on forests.",
+      note: "Annual locations of fire-driven tree cover removal at the selected canopy density threshold.",
       unit: "ha",
     },
   },

--- a/app/constants/datasets.ts
+++ b/app/constants/datasets.ts
@@ -304,8 +304,8 @@ export const DATASET_CARDS: (DatasetCardConfig & { img?: string })[] = [
   },
   {
     dataset_id: 11,
-    dataset_name: "Tree cover loss from fires",
-    data_layer: "Tree cover loss from fires",
+    dataset_name: "Tree cover loss due to fires",
+    data_layer: "Tree cover loss due to fires",
     context_layer: null,
     threshold: 30,
     img: "/dataset_card_tree_cover_loss.webp",
@@ -316,17 +316,17 @@ export const DATASET_CARDS: (DatasetCardConfig & { img?: string })[] = [
     viewOnly: true,
     defaultYear: 2025,
     description:
-      "Tree Cover Loss from Fires (Hansen/UMD/GLAD) maps annual global tree cover loss attributed to fire from 2001 to 2025 at 30-meter resolution. This subset of the broader Tree Cover Loss dataset isolates fire-driven stand-replacement disturbances in vegetation over 5 meters tall, helping users understand where fire is a dominant driver of forest loss.",
+      "Tree Cover Loss due to Fires (Hansen/UMD/GLAD) maps annual global tree cover loss attributed to fire from 2001 to 2025 at 30-meter resolution. This subset of the broader Tree Cover Loss dataset isolates fire-driven stand-replacement disturbances in vegetation over 5 meters tall, helping users understand where fire is a dominant driver of forest loss.",
     tile_url:
       "https://tiles.globalforestwatch.org/umd_tree_cover_loss_from_fires/latest/dynamic/{z}/{x}/{y}.png?tree_cover_density_threshold=30&render_type=true_color",
     methodology:
-      "Tree cover loss from fires is derived by overlaying the Hansen/UMD/GLAD global annual tree cover loss dataset with the MCD64A1 burned area product (MODIS). A tree cover loss pixel (30 m) is attributed to fire when a MODIS burned area detection occurs within the same 500 m grid cell and calendar year. Only stand-replacement disturbances in woody vegetation taller than 5 m are included, at the selected canopy density threshold.",
+      "Tree cover loss due to fires is derived by overlaying the Hansen/UMD/GLAD global annual tree cover loss dataset with the MCD64A1 burned area product (MODIS). A tree cover loss pixel (30 m) is attributed to fire when a MODIS burned area detection occurs within the same 500 m grid cell and calendar year. Only stand-replacement disturbances in woody vegetation taller than 5 m are included, at the selected canopy density threshold.",
     citation:
       'Hansen, M. C., P. V. Potapov, R. Moore, M. Hancher, S. A. Turubanova, A. Tyukavina, D. Thau, S. V. Stehman, S. J. Goetz, T. R. Loveland, A. Kommareddy, A. Egorov, L. Chini, C. O. Justice, and J. R. G. Townshend. 2013. "High-Resolution Global Maps of 21st-Century Forest Cover Change." *Science* 342 (6160): 850–53. https://doi.org/10.1126/science.1244693',
     legend: {
-      title: "Tree cover loss from fires (2001-2025)",
-      color: "#DC6C9A",
-      items: [{ label: "Tree cover loss from fires", color: "#DC6C9A" }],
+      title: "Tree cover loss due to fires (2001-2025)",
+      color: "#9A5B50 ",
+      items: [{ label: "Tree cover loss due to fire", color: "#9A5B50" }],
       type: "symbol",
       info: "This dataset isolates fire as a cause of tree cover loss, showing annual locations where fire-driven stand-replacement disturbances have occurred in forests. Useful for understanding the spatial extent and temporal trends of fire impact on forests.",
       note: "Annual locations of fire-driven tree cover removal at the selected canopy density threshold.",


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:
- [x] Feature

## What is the current behavior?

The non-chat (classic) UI layer browser does not include Tree Cover Loss from Fires as a selectable map layer.

Issue Number: PZB-834


## What is the new behavior?

- **Tree cover loss from fires** is available in the layer browser as a view-only dataset, listed alongside other TCL variants with a **"VIEW ONLY"** badge
- Toggling the layer on renders GFW tiles (`umd_tree_cover_loss_from_fires`, 30 m, true-colour) on the map with the correct pink (`#DC6C9A`) legend colour
- The legend displays a **"YEAR 2025"** chip (most recent year) by default, consistent with the PZB-720 year-control pattern; the tile URL is also filtered to that year via `start_year`/`end_year` query params
- The dataset info modal exposes **description, source (UMD), methodology, and citation**
- Fixed a minor display bug in `useLegendHook` where a single-year range was incorrectly labelled "YEARS X–X" instead of "YEAR X"

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Demo
<img width="1235" height="274" alt="Screenshot 2026-05-26 at 12 49 51" src="https://github.com/user-attachments/assets/0316312b-2d75-41e7-aaf0-ec3dc7276e65" />
___________________________________
<img width="804" height="612" alt="Screenshot 2026-05-26 at 12 46 58" src="https://github.com/user-attachments/assets/4a134e75-fb7e-470d-811e-6937f561a801" />
