### PR TITLE
Tidy insight workspace, legend layout, and Insight Card chat injection

### DIFF
--- a/app/components/InsightWorkspace.tsx
+++ b/app/components/InsightWorkspace.tsx
@@ -66,37 +66,35 @@ export default function InsightWorkspace() {
   const HeaderIcon = WidgetIconComponent[widget.type];
 
   return (
+    /* Card is the scroll container: grows to content, scrolls when flex-shrunk */
     <Box
-      position="absolute"
-      top={4}
-      right={3}
-      zIndex={400}
-      pointerEvents="none"
+      flex="0 1 auto"
+      minH="0"
+      overflowY="auto"
+      w="100%"
+      bg="primary.25"
+      border="1px solid"
+      borderColor="#DDE2F5"
+      rounded="4px"
+      pointerEvents="all"
+      display="flex"
+      flexDirection="column"
     >
-      {/* Panel */}
-      <Box
-        w="420px"
-        maxH="calc(100vh - 6rem)"
-        overflowY="auto"
+      {/* Header — sticky so it never scrolls away */}
+      <Flex
+        position="sticky"
+        top={0}
+        zIndex={1}
         bg="primary.25"
-        border="1px solid"
+        h="28px"
+        px="16px"
+        py="6px"
+        gap="8px"
+        justify="space-between"
+        align="center"
+        borderBottom="1px solid"
         borderColor="#DDE2F5"
-        rounded="4px"
-        pointerEvents="all"
-        display="flex"
-        flexDirection="column"
       >
-        {/* Header row — 28px section header */}
-        <Flex
-          h="28px"
-          px="16px"
-          py="6px"
-          gap="8px"
-          justify="space-between"
-          align="center"
-          borderBottom="1px solid"
-          borderColor="#DDE2F5"
-        >
           <Flex
             align="center"
             gap="8px"
@@ -156,87 +154,90 @@ export default function InsightWorkspace() {
           </IconButton>
         </Flex>
 
-        {!isCollapsed && (
-          <>
-            {/* Title row */}
-            <Flex
-              px={4}
-              py={1}
-              justify="space-between"
-              align="flex-start"
-              borderBottom="1px solid"
-              borderColor="#DDE2F5"
+      {!isCollapsed && (
+        <>
+          {/* Title row */}
+          <Flex
+            px={4}
+            py={1}
+            justify="space-between"
+            align="flex-start"
+            borderBottom="1px solid"
+            borderColor="#DDE2F5"
+          >
+            <Heading
+              size="sm"
+              fontWeight="semibold"
+              color="primary.fg"
+              flex={1}
+              mr={2}
+              mb={0}
             >
-              <Heading
-                size="sm"
-                fontWeight="semibold"
-                color="primary.fg"
-                flex={1}
-                mr={2}
-                mb={0}
-              >
-                {widget.title}
-              </Heading>
-              {hasChips && (
-                <AnalysisParametersToggle
-                  expanded={paramsExpanded}
-                  onToggle={() => setParamsExpanded((v) => !v)}
-                />
-              )}
-            </Flex>
-
-            {/* Params chips section */}
-            {hasChips && paramsExpanded && (
-              <Box px={4} py={2} borderBottom="1px solid" borderColor="#DDE2F5">
-                <AnalysisParamsChips chips={chips} />
-              </Box>
+              {widget.title}
+            </Heading>
+            {hasChips && (
+              <AnalysisParametersToggle
+                expanded={paramsExpanded}
+                onToggle={() => setParamsExpanded((v) => !v)}
+              />
             )}
+          </Flex>
 
-            {/* Inner chart card */}
-            <Box px={2} py={2}>
-              <WidgetMessage widget={widget} inWorkspace />
+          {/* Params chips section */}
+          {hasChips && paramsExpanded && (
+            <Box px={4} py={2} borderBottom="1px solid" borderColor="#DDE2F5">
+              <AnalysisParamsChips chips={chips} />
             </Box>
+          )}
 
-            {/* Navigation footer */}
-            {total > 1 && (
-              <Flex
-                px={4}
-                py={2}
-                borderTop="1px solid"
-                borderColor="#DDE2F5"
-                justify="space-between"
-                align="center"
+          {/* Inner chart card */}
+          <Box px={2} py={2}>
+            <WidgetMessage widget={widget} inWorkspace />
+          </Box>
+
+          {/* Navigation footer — sticky so it never scrolls away */}
+          {total > 1 && (
+            <Flex
+              position="sticky"
+              bottom={0}
+              zIndex={1}
+              bg="primary.25"
+              px={4}
+              py={2}
+              borderTop="1px solid"
+              borderColor="#DDE2F5"
+              justify="space-between"
+              align="center"
+            >
+              <IconButton
+                size="xs"
+                variant="ghost"
+                border="1px solid"
+                borderColor="border.emphasized"
+                aria-label="Previous insight"
+                disabled={!canGoPrev}
+                onClick={() => setCurrentIndex((i) => i - 1)}
               >
-                <IconButton
-                  size="xs"
-                  variant="ghost"
-                  border="1px solid"
-                  borderColor="border.emphasized"
-                  aria-label="Previous insight"
-                  disabled={!canGoPrev}
-                  onClick={() => setCurrentIndex((i) => i - 1)}
-                >
-                  <ArrowArcLeftIcon size={14} />
-                </IconButton>
-                <Text fontSize="xs" color="neutral.500">
-                  {currentIndex + 1} of {total} available analyses
-                </Text>
-                <IconButton
-                  size="xs"
-                  variant="ghost"
-                  border="1px solid"
-                  borderColor="border.emphasized"
-                  aria-label="Next insight"
-                  disabled={!canGoNext}
-                  onClick={() => setCurrentIndex((i) => i + 1)}
-                >
-                  <ArrowArcRightIcon size={14} />
-                </IconButton>
-              </Flex>
-            )}
-          </>
-        )}
-      </Box>
+                <ArrowArcLeftIcon size={14} />
+              </IconButton>
+              <Text fontSize="xs" color="neutral.500">
+                {currentIndex + 1} of {total} available analyses
+              </Text>
+              <IconButton
+                size="xs"
+                variant="ghost"
+                border="1px solid"
+                borderColor="border.emphasized"
+                aria-label="Next insight"
+                disabled={!canGoNext}
+                onClick={() => setCurrentIndex((i) => i + 1)}
+              >
+                <ArrowArcRightIcon size={14} />
+              </IconButton>
+            </Flex>
+          )}
+        </>
+      )}
     </Box>
   );
 }

--- a/app/components/InsightWorkspace.tsx
+++ b/app/components/InsightWorkspace.tsx
@@ -95,64 +95,64 @@ export default function InsightWorkspace() {
         borderBottom="1px solid"
         borderColor="#DDE2F5"
       >
-          <Flex
-            align="center"
-            gap="8px"
-            h="16px"
-            flexWrap="nowrap"
-            overflow="hidden"
+        <Flex
+          align="center"
+          gap="8px"
+          h="16px"
+          flexWrap="nowrap"
+          overflow="hidden"
+        >
+          <HeaderIcon size={12} color="#0049AA" />
+          <Text
+            fontSize="10px"
+            fontFamily="mono"
+            fontWeight="normal"
+            lineHeight="16px"
+            letterSpacing="0.03em"
+            color="fg.muted"
+            whiteSpace="nowrap"
           >
-            <HeaderIcon size={12} color="#0049AA" />
-            <Text
-              fontSize="10px"
-              fontFamily="mono"
-              fontWeight="normal"
-              lineHeight="16px"
-              letterSpacing="0.03em"
-              color="fg.muted"
-              whiteSpace="nowrap"
+            AI-ASSISTED ANALYSIS
+            {" · "}
+            <Tooltip
+              variant="dark"
+              content={aiDisclaimerTooltip}
+              showArrow
+              positioning={{ placement: "bottom" }}
+              openDelay={100}
+              closeDelay={100}
             >
-              AI-ASSISTED ANALYSIS
-              {" · "}
-              <Tooltip
-                variant="dark"
-                content={aiDisclaimerTooltip}
-                showArrow
-                positioning={{ placement: "bottom" }}
-                openDelay={100}
-                closeDelay={100}
+              <Box
+                as="span"
+                color="#4A64CB"
+                textDecoration="underline"
+                cursor="help"
+                tabIndex={0}
+                aria-label="Learn more about AI-Assisted Analysis"
               >
-                <Box
-                  as="span"
-                  color="#4A64CB"
-                  textDecoration="underline"
-                  cursor="help"
-                  tabIndex={0}
-                  aria-label="Learn more about AI-Assisted Analysis"
-                >
-                  learn more
-                </Box>
-              </Tooltip>
-            </Text>
-          </Flex>
-          <IconButton
-            size="2xs"
-            variant="ghost"
-            h="16px"
-            minW="16px"
-            w="16px"
-            color="#656E7B"
-            aria-label={isCollapsed ? "Expand insight" : "Collapse insight"}
-            flexShrink={0}
-            onClick={() => setIsCollapsed((v) => !v)}
-          >
-            {isCollapsed ? (
-              <CaretDownIcon size={12} weight="bold" />
-            ) : (
-              <CaretUpIcon size={12} weight="bold" />
-            )}
-          </IconButton>
+                learn more
+              </Box>
+            </Tooltip>
+          </Text>
         </Flex>
+        <IconButton
+          size="2xs"
+          variant="ghost"
+          h="16px"
+          minW="16px"
+          w="16px"
+          color="#656E7B"
+          aria-label={isCollapsed ? "Expand insight" : "Collapse insight"}
+          flexShrink={0}
+          onClick={() => setIsCollapsed((v) => !v)}
+        >
+          {isCollapsed ? (
+            <CaretDownIcon size={12} weight="bold" />
+          ) : (
+            <CaretUpIcon size={12} weight="bold" />
+          )}
+        </IconButton>
+      </Flex>
 
       {!isCollapsed && (
         <>

--- a/app/components/Map.tsx
+++ b/app/components/Map.tsx
@@ -34,6 +34,7 @@ import { useLegendHook } from "@/app/components/legend/useLegendHook";
 import GeoJsonLayers from "./map/layers/GeoJsonLayers";
 import { Legend } from "@/app/components/legend/Legend";
 import InsightWorkspace from "./InsightWorkspace";
+import useInsightStore from "@/app/store/insightStore";
 
 const MAPBOX_ACCESS_TOKEN = process.env.NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN;
 
@@ -50,6 +51,7 @@ function Map({ disableMapAreaControls }: { disableMapAreaControls?: boolean }) {
     registerPrimaryForestProtocol();
   }, []);
   const { layers, handleLayerAction, aois, handleRemoveAoi } = useLegendHook();
+  const hasInsights = useInsightStore((s) => s.insights.length > 0);
   const areas = useContextStore(
     useShallow((s) => s.context.filter((c) => c.contextType === "area"))
   );
@@ -168,14 +170,33 @@ function Map({ disableMapAreaControls }: { disableMapAreaControls?: boolean }) {
             Legend
           </Button>
         )}
-        <Box display={{ base: showLegend ? "inherit" : "none", md: "inherit" }}>
-          <Legend
-            layers={layers}
-            onLayerAction={handleLayerAction}
-            aois={aois}
-            onRemoveAoi={handleRemoveAoi}
-          />
-        </Box>
+        {/* Right overlay column: insight panel (top, scrollable) + legend (bottom) */}
+        <Flex
+          position="absolute"
+          top={4}
+          right={3}
+          bottom={{ base: "4.5rem", md: 12 }}
+          zIndex={400}
+          w="420px"
+          flexDirection="column"
+          gap={2}
+          pointerEvents="none"
+        >
+          {hasInsights && <InsightWorkspace />}
+          {/* Spacer: pushes legend to the bottom */}
+          <Box flex="1 1 0" minH="0" />
+          <Box
+            flexShrink={0}
+            display={{ base: showLegend ? "block" : "none", md: "block" }}
+          >
+            <Legend
+              layers={layers}
+              onLayerAction={handleLayerAction}
+              aois={aois}
+              onRemoveAoi={handleRemoveAoi}
+            />
+          </Box>
+        </Flex>
 
         {/* Sentinel layer: caps raster layers below AOI/GeoJSON outlines.
             Must be added before DynamicTileLayers so the sentinel exists
@@ -218,7 +239,6 @@ function Map({ disableMapAreaControls }: { disableMapAreaControls?: boolean }) {
             <NavigationControl showCompass={false} position="bottom-left" />
           </>
         )}
-        <InsightWorkspace />
         <Flex
           pos="absolute"
           bottom="4"

--- a/app/components/MapAreaControls.tsx
+++ b/app/components/MapAreaControls.tsx
@@ -41,13 +41,13 @@ function Wrapper({
       position="absolute"
       pt={2}
       pb={{ base: 4, md: 0 }}
-      pl={{ base: 2, md: 0 }}
+      pl={{ base: 2, md: 3 }}
       gap={2}
       width="100%"
       height="100%"
       pointerEvents="none"
       justifyContent={{ base: "flex-end", md: "flex-start" }}
-      alignItems={{ base: "flex-start", md: "center" }}
+      alignItems="flex-start"
       zIndex={100}
       borderWidth="4px"
       {...props}

--- a/app/components/MessageBubble.tsx
+++ b/app/components/MessageBubble.tsx
@@ -155,6 +155,7 @@ function MessageBubble({
     !isError &&
     !isWarning &&
     !isFirst &&
+    !message.suppressFooter &&
     (!isConsecutive || analysisWidgets.length > 0 || isLast);
   // For widget messages, render them in a full-width container
   if (isWidget && message.widgets) {
@@ -174,7 +175,7 @@ function MessageBubble({
     <Box
       display="flex"
       justifyContent={isUser ? "flex-end" : "flex-start"}
-      mb={isConsecutive ? 1 : 4} // Reduced margin for consecutive messages
+      mb={isConsecutive || message.suppressFooter ? 1 : 4}
       _first={{ base: { mt: 3 }, md: { mt: 6 } }}
     >
       <Box

--- a/app/components/legend/Legend.tsx
+++ b/app/components/legend/Legend.tsx
@@ -99,11 +99,7 @@ export function Legend(props: LegendProps) {
 
   return (
     <Flex
-      position="absolute"
-      right={3}
-      bottom={{ base: "4.5rem", md: 12 }}
-      zIndex={100}
-      width={420}
+      w="100%"
       maxH={{ base: "50vh", md: "60vh" }}
       bg="#F7F9FF"
       border="1px solid"
@@ -111,6 +107,8 @@ export function Legend(props: LegendProps) {
       rounded="4px"
       flexDirection="column"
       overflow="hidden"
+      pointerEvents="all"
+      flexShrink={0}
     >
       {/* Always-visible header — 28px section header per Figma */}
       <Flex

--- a/app/store/chat-tools/__tests__/generateInsights.test.ts
+++ b/app/store/chat-tools/__tests__/generateInsights.test.ts
@@ -49,17 +49,22 @@ describe("generateInsightsTool", () => {
     expect(insights[0].title).toBe("Forest Loss");
   });
 
-  it("adds the static reference message to chat as assistant type", () => {
+  it("does not call addMessage in the happy path", () => {
     generateInsightsTool(
       baseMessage({ charts_data: [chartData()] }),
       addMessage
     );
-    expect(addMessage).toHaveBeenCalledOnce();
-    const msg = addMessage.mock.calls[0][0] as Omit<ChatMessage, "id">;
-    expect(msg.type).toBe("assistant");
-    expect(msg.message).toBe(
-      "I've created an insight you can view on the map."
+    expect(addMessage).not.toHaveBeenCalled();
+  });
+
+  it("sets pendingBatch to the newly added widgets", () => {
+    generateInsightsTool(
+      baseMessage({ charts_data: [chartData("Tree Cover"), chartData("Fires")] }),
+      addMessage
     );
+    const { pendingBatch } = useInsightStore.getState();
+    expect(pendingBatch).toHaveLength(2);
+    expect(pendingBatch[0].title).toBe("Tree Cover");
   });
 
   it("does nothing when charts_data is absent", () => {

--- a/app/store/chat-tools/__tests__/generateInsights.test.ts
+++ b/app/store/chat-tools/__tests__/generateInsights.test.ts
@@ -59,7 +59,9 @@ describe("generateInsightsTool", () => {
 
   it("sets pendingBatch to the newly added widgets", () => {
     generateInsightsTool(
-      baseMessage({ charts_data: [chartData("Tree Cover"), chartData("Fires")] }),
+      baseMessage({
+        charts_data: [chartData("Tree Cover"), chartData("Fires")],
+      }),
       addMessage
     );
     const { pendingBatch } = useInsightStore.getState();

--- a/app/store/chat-tools/generateInsights.ts
+++ b/app/store/chat-tools/generateInsights.ts
@@ -87,6 +87,7 @@ export function generateInsightsTool(
       const widgets: InsightWidget[] = (
         streamMessage.charts_data as ChartData[]
       ).map((chart: ChartData) => ({
+        id: chart.id,
         type: chart.type,
         title: chart.title,
         description: chart.insight,
@@ -104,13 +105,6 @@ export function generateInsightsTool(
       console.log("FRONTEND: Received charts_data message:", widgets);
 
       useInsightStore.getState().addInsights(widgets);
-
-      addMessage({
-        type: "assistant",
-        message: "I've created an insight you can view on the map.",
-        timestamp: streamMessage.timestamp,
-        widgets,
-      });
     }
   } catch (error) {
     console.error("Error processing generate_insights:", error);

--- a/app/store/chatStore.ts
+++ b/app/store/chatStore.ts
@@ -173,12 +173,59 @@ async function processStreamMessage(
   } else if (streamMessage.type === "text" && streamMessage.text) {
     const pending = getPendingTraceId();
     const traceToUse = streamMessage.trace_id || pending || undefined;
-    addMessage({
-      type: "assistant",
-      message: streamMessage.text,
-      timestamp: streamMessage.timestamp,
-      traceId: traceToUse,
-    });
+
+    const chartRefRe = /\[Chart\s+[a-f0-9-]+\]/gi;
+    if (chartRefRe.test(streamMessage.text)) {
+      // Split the text on [Chart <uuid>] markers and inject insight cards positionally
+      const re = /\[Chart\s+[a-f0-9-]+\]/gi;
+      const pendingWidgets = useInsightStore.getState().consumePendingBatch();
+      let lastIndex = 0;
+      let match: RegExpExecArray | null;
+      let widgetIdx = 0;
+      const segments: Array<{ text?: string; widgetIdx?: number }> = [];
+      while ((match = re.exec(streamMessage.text)) !== null) {
+        const textBefore = streamMessage.text.slice(lastIndex, match.index);
+        if (textBefore.trim()) {
+          segments.push({ text: textBefore });
+        }
+        segments.push({ widgetIdx: widgetIdx++ });
+        lastIndex = re.lastIndex;
+      }
+      const textAfter = streamMessage.text.slice(lastIndex);
+      if (textAfter.trim()) {
+        segments.push({ text: textAfter });
+      }
+      segments.forEach((seg, i) => {
+        const isLast = i === segments.length - 1;
+        if (seg.text !== undefined) {
+          addMessage({
+            type: "assistant",
+            message: seg.text,
+            timestamp: streamMessage.timestamp,
+            ...(!isLast ? { suppressFooter: true } : {}),
+            ...(isLast && traceToUse ? { traceId: traceToUse } : {}),
+          });
+        } else if (seg.widgetIdx !== undefined) {
+          const widget = pendingWidgets[seg.widgetIdx];
+          if (widget) {
+            addMessage({
+              type: "assistant",
+              message: "",
+              timestamp: streamMessage.timestamp,
+              widgets: [widget],
+              ...(isLast && traceToUse ? { traceId: traceToUse } : {}),
+            });
+          }
+        }
+      });
+    } else {
+      addMessage({
+        type: "assistant",
+        message: streamMessage.text,
+        timestamp: streamMessage.timestamp,
+        traceId: traceToUse,
+      });
+    }
     // Clear pending trace id once used
     if (pending && pending === traceToUse) {
       setPendingTraceId(null);

--- a/app/store/insightStore.ts
+++ b/app/store/insightStore.ts
@@ -3,15 +3,26 @@ import { InsightWidget } from "@/app/types/chat";
 
 interface InsightState {
   insights: InsightWidget[];
+  pendingBatch: InsightWidget[]; // widgets from the most recent generate_insights call
   addInsights: (widgets: InsightWidget[]) => void;
+  consumePendingBatch: () => InsightWidget[];
   clearInsights: () => void;
 }
 
-const useInsightStore = create<InsightState>((set) => ({
+const useInsightStore = create<InsightState>((set, get) => ({
   insights: [],
+  pendingBatch: [],
   addInsights: (widgets) =>
-    set((state) => ({ insights: [...state.insights, ...widgets] })),
-  clearInsights: () => set({ insights: [] }),
+    set((state) => ({
+      insights: [...state.insights, ...widgets],
+      pendingBatch: widgets,
+    })),
+  consumePendingBatch: () => {
+    const batch = get().pendingBatch;
+    set({ pendingBatch: [] });
+    return batch;
+  },
+  clearInsights: () => set({ insights: [], pendingBatch: [] }),
 }));
 
 export default useInsightStore;

--- a/app/types/chat.ts
+++ b/app/types/chat.ts
@@ -24,10 +24,12 @@ export interface ChatMessage {
   traceId?: string;
   toolSteps?: ToolStepData[]; // For user messages - reasoning steps taken to respond
   reasoningDuration?: number; // Duration in seconds for reasoning to complete
+  suppressFooter?: boolean; // Non-terminal segment of a [Chart uuid] split — no footer, tight spacing
 }
 
 // Widget types for insights
 export interface InsightWidget {
+  id?: string; // backend chart UUID, used to resolve [Chart <id>] references in text
   type:
     | "line"
     | "bar"


### PR DESCRIPTION
### Summary
Worked with Fausto on friday to review the behaviour of the Insight+Legends. A couple of things tidied up in this PR:

- Insight workspace + legend no longer overlap. A single shared right-column flex container owns the 420 px right edge of the map. InsightWorkspace sits at the top (content-sized, can shrink), a spacer pushes the legend to the bottom, and the two panels always maintain a gap — regardless of chart height.
- InsightWorkspace scrolls correctly. The card is its own scroll container (overflowY="auto"). The "AI-ASSISTED ANALYSIS" header and the "N of M available analyses" navigation footer are position="sticky" so they never scroll out of view. Only the chart body scrolls.
- Map tools anchored to the chat panel (left). MapAreaControls was centred horizontally across the map, making it vulnerable to being obscured by the insight panel. Changed to alignItems="flex-start" so tools always sit top-left, clear of the right-column stack.
- Insight cards injected inline in chat. The previous behaviour added a static "I've created an insight you can view on the map." message when the tool call completed, then the LLM text referenced the chart again as [Chart <uuid>]. The static message is gone. Instead, when the assistant's text message arrives in the stream, any [Chart <uuid>] markers are split out and replaced with the corresponding AnalysisCard widget, injected positionally from insightStore.pendingBatch. Text segments preceding a card get tight spacing and no footer controls since they flow directly into the chart.

Test plan
Generate chart e.g. "Trends in Natural Grassland extent in Mongolia"
- Confirm the chart card appears inline in the assistant message at the point the LLM references it — no preceding "I've created an insight" message.
- Ask a question that generates multiple insights (e.g. TCL in BRA). Confirm each [Chart …] reference is replaced by the correct chart in order.
- With an insight visible, confirm InsightWorkspace (top-right) and Legend (bottom-right) are separated by a gap and do not overlap.
- Resize the browser to make the insight panel tall enough to need scrolling. Confirm the header and "N of M" footer stay fixed while the chart body scrolls.
- Collapse the insight panel using the caret. Confirm only the header remains and the legend moves up to fill available space.
- Use the upload / select / draw tools. Confirm they appear at the top-left of the map and are not obscured by the insight or legend panels.
- Load a historical thread that contains insights e.g. `http://localhost:3000/app/threads/c10551f5-c183-448c-af89-cb8f7d10ff75` Confirm inline cards render correctly on replay.