### PR TITLE
implement infinite scroll pagination for conversations / threads listing

### DIFF
--- a/app/components/PageHeader.tsx
+++ b/app/components/PageHeader.tsx
@@ -34,6 +34,7 @@ import useSidebarStore from "../store/sidebarStore";
 import ThreadActionsMenu from "./ThreadActionsMenu";
 import Link from "next/link";
 import { useLogout } from "@/app/hooks/useLogout";
+import { useThreadsInfinite } from "@/app/hooks/useThreadsInfinite";
 
 const isPrototype = process.env.NEXT_PUBLIC_PROTOTYPE_MODE === "true";
 const DISCLAIMER_STORAGE_KEY = "gnw_disclaimer_dismissed_v2";
@@ -41,12 +42,13 @@ const DISCLAIMER_STORAGE_KEY = "gnw_disclaimer_dismissed_v2";
 function PageHeader() {
   const { userEmail, usedPrompts, totalPrompts, isAuthenticated } =
     useAuthStore();
-  const { toggleSidebar, getThreadById } = useSidebarStore();
+  const { toggleSidebar } = useSidebarStore();
   const { currentThreadId } = useChatStore();
   const { logout } = useLogout();
+  const { threads } = useThreadsInfinite();
 
   const currentThread = currentThreadId
-    ? getThreadById(currentThreadId)
+    ? threads.find((t) => t.id === currentThreadId)
     : undefined;
   const currentThreadName = currentThread
     ? currentThread.name

--- a/app/components/providers/index.tsx
+++ b/app/components/providers/index.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect } from "react";
 import { ChakraProvider } from "@chakra-ui/react";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { QueryClientProvider } from "@tanstack/react-query";
 import { jwtDecode } from "jwt-decode";
 
 import theme from "@/app/theme";
@@ -11,12 +11,11 @@ import DebugToastsPanel from "@/app/components/DebugToastsPanel";
 import useAuthStore from "@/app/store/authStore";
 import { UserTypeEnum, type UserType } from "@/app/schemas/api/admin/users/get";
 import { getToken, clearToken, apiFetch } from "@/app/lib/api-client";
+import { queryClient } from "@/app/lib/query-client";
 
 function coerceUserType(value: unknown): UserType | null {
   return UserTypeEnum.safeParse(value).data ?? null;
 }
-
-const queryClient = new QueryClient();
 
 function AuthBootstrapper() {
   const { setAuthStatus, setAuthLoaded, clearAuth, setPromptUsage } =

--- a/app/constants/preview-content.ts
+++ b/app/constants/preview-content.ts
@@ -12,8 +12,14 @@ export const PREVIEW_LINKS = [
     label: "FAQs",
     href: "https://help.globalnaturewatch.org/support/faqs",
   },
-  { label: "Capabilities", href: "https://help.globalnaturewatch.org/get-started/capabilities-and-datasets" },
-  { label: "Accuracy", href: "https://help.globalnaturewatch.org/get-started/accuracy-and-performance" },
+  {
+    label: "Capabilities",
+    href: "https://help.globalnaturewatch.org/get-started/capabilities-and-datasets",
+  },
+  {
+    label: "Accuracy",
+    href: "https://help.globalnaturewatch.org/get-started/accuracy-and-performance",
+  },
   {
     label: "Known Issues",
     href: "https://help.globalnaturewatch.org/resources/known-issues",

--- a/app/hooks/useIntersectionObserver.ts
+++ b/app/hooks/useIntersectionObserver.ts
@@ -1,0 +1,21 @@
+import { useEffect, type RefObject } from "react";
+
+export function useIntersectionObserver(
+  ref: RefObject<HTMLElement | null>,
+  callback: () => void,
+  options?: { enabled?: boolean; rootMargin?: string }
+) {
+  useEffect(() => {
+    if (!options?.enabled || !ref.current) return;
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) callback();
+      },
+      { rootMargin: options.rootMargin ?? "200px" }
+    );
+
+    observer.observe(ref.current);
+    return () => observer.disconnect();
+  }, [ref, callback, options?.enabled, options?.rootMargin]);
+}

--- a/app/hooks/useThreadsInfinite.ts
+++ b/app/hooks/useThreadsInfinite.ts
@@ -1,0 +1,96 @@
+import { useMemo } from "react";
+import { useInfiniteQuery } from "@tanstack/react-query";
+import { apiFetch } from "@/app/lib/api-client";
+import useAuthStore from "@/app/store/authStore";
+
+const PAGE_SIZE = 30;
+
+export interface ThreadEntry {
+  agent_id: "UniGuana";
+  created_at: string;
+  id: string;
+  name: string;
+  updated_at: string;
+  user_id: string;
+  is_public: boolean;
+}
+
+export interface ThreadGroups {
+  today: ThreadEntry[];
+  previousWeek: ThreadEntry[];
+  older: ThreadEntry[];
+}
+
+interface ThreadsPage {
+  threads: ThreadEntry[];
+  nextCursor: string | null;
+}
+
+export function computeThreadGroups(data: ThreadEntry[]): ThreadGroups {
+  const threads = [...data].sort(
+    (a, b) =>
+      new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
+  );
+
+  const now = new Date();
+  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  const weekAgo = new Date(today);
+  weekAgo.setDate(weekAgo.getDate() - 7);
+
+  return {
+    today: threads.filter((thread) => new Date(thread.created_at) >= today),
+    previousWeek: threads.filter((thread) => {
+      const date = new Date(thread.created_at);
+      return date >= weekAgo && date < today;
+    }),
+    older: threads.filter((thread) => new Date(thread.created_at) < weekAgo),
+  };
+}
+
+async function fetchThreadsPage(cursor?: string): Promise<ThreadsPage> {
+  const params = new URLSearchParams({ limit: String(PAGE_SIZE) });
+  if (cursor) params.set("cursor", cursor);
+
+  const response = await apiFetch(`/api/threads?${params.toString()}`);
+
+  if (!response.ok) {
+    throw new Error(`Failed to load threads (${response.status})`);
+  }
+
+  const raw: ThreadEntry[] = await response.json();
+  const threads = raw.map((t) => ({ ...t, is_public: t.is_public ?? false }));
+
+  const nextCursor = response.headers.get("X-Next-Cursor") || null;
+
+  return { threads, nextCursor };
+}
+
+export function useThreadsInfinite() {
+  const isAuthenticated = useAuthStore((s) => s.isAuthenticated);
+
+  const query = useInfiniteQuery<ThreadsPage>({
+    queryKey: ["threads"],
+    queryFn: ({ pageParam }) => fetchThreadsPage(pageParam as string),
+    initialPageParam: undefined as string | undefined,
+    getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
+    enabled: isAuthenticated,
+  });
+
+  const threads = useMemo(
+    () => query.data?.pages.flatMap((p) => p.threads) ?? [],
+    [query.data]
+  );
+
+  const threadGroups = useMemo(() => computeThreadGroups(threads), [threads]);
+
+  return {
+    threads,
+    threadGroups,
+    fetchNextPage: query.fetchNextPage,
+    hasNextPage: query.hasNextPage,
+    isFetchingNextPage: query.isFetchingNextPage,
+    isLoading: query.isLoading,
+    isError: query.isError,
+    error: query.error,
+  };
+}

--- a/app/hooks/useThreadsInfinite.ts
+++ b/app/hooks/useThreadsInfinite.ts
@@ -3,7 +3,7 @@ import { useInfiniteQuery } from "@tanstack/react-query";
 import { apiFetch } from "@/app/lib/api-client";
 import useAuthStore from "@/app/store/authStore";
 
-const PAGE_SIZE = 30;
+const PAGE_SIZE = 100;
 
 export interface ThreadEntry {
   agent_id: "UniGuana";

--- a/app/lib/query-client.ts
+++ b/app/lib/query-client.ts
@@ -1,0 +1,3 @@
+import { QueryClient } from "@tanstack/react-query";
+
+export const queryClient = new QueryClient();

--- a/app/lib/query-client.ts
+++ b/app/lib/query-client.ts
@@ -1,3 +1,11 @@
-import { QueryClient } from "@tanstack/react-query";
+import { QueryCache, QueryClient } from "@tanstack/react-query";
+import { showApiError } from "@/app/hooks/useErrorHandler";
 
-export const queryClient = new QueryClient();
+export const queryClient = new QueryClient({
+  queryCache: new QueryCache({
+    onError: (error, query) => {
+      if (query.queryKey[0] !== "threads") return;
+      showApiError(error as Error, { title: "Failed to load data." });
+    },
+  }),
+});

--- a/app/sidebar.tsx
+++ b/app/sidebar.tsx
@@ -67,6 +67,7 @@ function ThreadSection({
   label,
   value,
   currentThreadId,
+  footer,
 }: {
   threads: {
     id: string;
@@ -77,9 +78,10 @@ function ThreadSection({
   label: string;
   value: string;
   currentThreadId: string | null;
+  footer?: React.ReactNode;
 }) {
   const { toggleSidebar } = useSidebarStore();
-  if (!threads.length) return null;
+  if (!threads.length && !footer) return null;
   return (
     <Accordion.Item value={value} border="none">
       <Accordion.ItemTrigger px="3" py="1" cursor="pointer">
@@ -134,6 +136,7 @@ function ThreadSection({
             );
           })}
         </Stack>
+        {footer}
       </Accordion.ItemContent>
     </Accordion.Item>
   );
@@ -282,21 +285,25 @@ export function Sidebar() {
               currentThreadId={currentThreadId}
             />
           )}
-          {hasOlderThreads && (
+          {(hasOlderThreads || hasNextPage) && (
             <ThreadSection
               threads={threadGroups.older}
               label="Older Conversations"
               value="older"
               currentThreadId={currentThreadId}
+              footer={
+                <>
+                  <div ref={sentinelRef} />
+                  {isFetchingNextPage && (
+                    <Flex justify="center" py="2">
+                      <Spinner size="sm" color="fg.subtle" />
+                    </Flex>
+                  )}
+                </>
+              }
             />
           )}
         </Accordion.Root>
-        <div ref={sentinelRef} />
-        {isFetchingNextPage && (
-          <Flex justify="center" py="2">
-            <Spinner size="sm" color="fg.subtle" />
-          </Flex>
-        )}
         <Status.Root
           colorPalette={apiStatus === "OK" ? "green" : "red"}
           m="3"

--- a/app/sidebar.tsx
+++ b/app/sidebar.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import {
   Button,
   Flex,
@@ -13,6 +13,7 @@ import {
   Box,
   Badge,
   Progress,
+  Spinner,
 } from "@chakra-ui/react";
 import Link from "next/link";
 
@@ -30,6 +31,8 @@ import useChatStore from "./store/chatStore";
 import { useLogout } from "./hooks/useLogout";
 import ThreadActionsMenu from "./components/ThreadActionsMenu";
 import LclLogo from "./components/LclLogo";
+import { useThreadsInfinite } from "./hooks/useThreadsInfinite";
+import { useIntersectionObserver } from "./hooks/useIntersectionObserver";
 
 function ThreadLink(props: LinkProps & { isActive?: boolean; href: string }) {
   const { href, children, isActive, ...rest } = props;
@@ -137,21 +140,27 @@ function ThreadSection({
 }
 
 export function Sidebar() {
-  const {
-    sideBarVisible,
-    toggleSidebar,
-    threadGroups,
-    fetchThreads,
-    apiStatus,
-    fetchApiStatus,
-  } = useSidebarStore();
+  const { sideBarVisible, toggleSidebar, apiStatus, fetchApiStatus } =
+    useSidebarStore();
   const { currentThreadId } = useChatStore();
   const { userEmail, usedPrompts, totalPrompts } = useAuthStore();
+  const { threadGroups, fetchNextPage, hasNextPage, isFetchingNextPage } =
+    useThreadsInfinite();
+
+  const sentinelRef = useRef<HTMLDivElement>(null);
+
+  const handleLoadMore = useCallback(() => {
+    fetchNextPage();
+  }, [fetchNextPage]);
+
+  useIntersectionObserver(sentinelRef, handleLoadMore, {
+    enabled: hasNextPage && !isFetchingNextPage,
+    rootMargin: "200px",
+  });
 
   useEffect(() => {
-    fetchThreads();
     fetchApiStatus();
-  }, [fetchThreads, fetchApiStatus]);
+  }, [fetchApiStatus]);
 
   const { logout, isLoggingOut } = useLogout();
 
@@ -282,6 +291,12 @@ export function Sidebar() {
             />
           )}
         </Accordion.Root>
+        <div ref={sentinelRef} />
+        {isFetchingNextPage && (
+          <Flex justify="center" py="2">
+            <Spinner size="sm" color="fg.subtle" />
+          </Flex>
+        )}
         <Status.Root
           colorPalette={apiStatus === "OK" ? "green" : "red"}
           m="3"

--- a/app/store/chatStore.ts
+++ b/app/store/chatStore.ts
@@ -25,7 +25,7 @@ import { generateInsightsTool } from "./chat-tools/generateInsights";
 import { pickAoiTool } from "./chat-tools/pickAoi";
 import { pickDatasetTool } from "./chat-tools/pickDataset";
 import { pullDataTool } from "./chat-tools/pullData";
-import useSidebarStore from "./sidebarStore";
+import { queryClient } from "@/app/lib/query-client";
 import {
   showApiError,
   showError,
@@ -526,7 +526,7 @@ const useChatStore = create<ChatState & ChatActions>((set, get) => ({
 
       setLoading(false);
 
-      useSidebarStore.getState().fetchThreads(); // Refresh threads in sidebar
+      queryClient.invalidateQueries({ queryKey: ["threads"] });
       return { isNew: !currentThreadId, id: threadId };
     }
   },

--- a/app/store/sidebarStore.ts
+++ b/app/store/sidebarStore.ts
@@ -25,19 +25,16 @@ interface SidebarState {
 function updateThreadInCache(
   updater: (threads: ThreadEntry[]) => ThreadEntry[]
 ) {
-  queryClient.setQueryData<InfiniteData<ThreadsPage>>(
-    ["threads"],
-    (old) => {
-      if (!old) return old;
-      return {
-        ...old,
-        pages: old.pages.map((page) => ({
-          ...page,
-          threads: updater(page.threads),
-        })),
-      };
-    }
-  );
+  queryClient.setQueryData<InfiniteData<ThreadsPage>>(["threads"], (old) => {
+    if (!old) return old;
+    return {
+      ...old,
+      pages: old.pages.map((page) => ({
+        ...page,
+        threads: updater(page.threads),
+      })),
+    };
+  });
 }
 
 const useSidebarStore = create<SidebarState>(() => ({

--- a/app/store/sidebarStore.ts
+++ b/app/store/sidebarStore.ts
@@ -1,127 +1,68 @@
 import { create } from "zustand";
 import { API_CONFIG } from "@/app/config/api";
-import { showApiError } from "@/app/hooks/useErrorHandler";
 import { apiFetch } from "@/app/lib/api-client";
+import { queryClient } from "@/app/lib/query-client";
+import type { InfiniteData } from "@tanstack/react-query";
+import type { ThreadEntry } from "@/app/hooks/useThreadsInfinite";
 
-interface ThreadEntry {
-  agent_id: "UniGuana";
-  created_at: string;
-  id: string;
-  name: string;
-  updated_at: string;
-  user_id: string;
-  is_public: boolean;
-}
-
-interface ThreadGroups {
-  today: ThreadEntry[];
-  previousWeek: ThreadEntry[];
-  older: ThreadEntry[];
+interface ThreadsPage {
+  threads: ThreadEntry[];
+  nextCursor: string | null;
 }
 
 interface SidebarState {
   sideBarVisible: boolean;
-  threads: ThreadEntry[];
-  threadGroups: ThreadGroups;
-  fetchThreads: () => Promise<void>;
+  toggleSidebar: () => void;
   renameThread: (threadId: string, newName: string) => Promise<void>;
   shareThread: (threadId: string, isPublic: boolean) => Promise<void>;
   deleteThread: (threadId: string) => Promise<void>;
-  getThreadById: (
-    threadId: string | null | undefined
-  ) => ThreadEntry | undefined;
-  // Function to toggle the sidebar visibility
-  toggleSidebar: () => void;
   fetchApiStatus: () => Promise<void>;
   apiStatus: "Idle" | "OK" | "Error";
   isChatFullSize: boolean;
   setChatFullSize: (value: boolean) => void;
 }
 
-const computeThreadGroups = (data: ThreadEntry[]): ThreadGroups => {
-  const threads = data.sort(
-    (a, b) =>
-      new Date(b.created_at).getTime() - new Date(a.created_at).getTime()
+function updateThreadInCache(
+  updater: (threads: ThreadEntry[]) => ThreadEntry[]
+) {
+  queryClient.setQueryData<InfiniteData<ThreadsPage>>(
+    ["threads"],
+    (old) => {
+      if (!old) return old;
+      return {
+        ...old,
+        pages: old.pages.map((page) => ({
+          ...page,
+          threads: updater(page.threads),
+        })),
+      };
+    }
   );
-  // Group threads by date
-  const now = new Date();
-  const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
-  const weekAgo = new Date(today);
-  weekAgo.setDate(weekAgo.getDate() - 7);
+}
 
-  const groupedThreads = {
-    today: threads.filter((thread) => new Date(thread.created_at) >= today),
-    previousWeek: threads.filter((thread) => {
-      const date = new Date(thread.created_at);
-      return date >= weekAgo && date < today;
-    }),
-    older: threads.filter((thread) => new Date(thread.created_at) < weekAgo),
-  };
-
-  return groupedThreads;
-};
-
-const useSidebarStore = create<SidebarState>((set, get) => ({
+const useSidebarStore = create<SidebarState>(() => ({
   sideBarVisible: false,
-  threads: [],
-  threadGroups: {
-    today: [],
-    previousWeek: [],
-    older: [],
-  },
   apiStatus: "Idle",
   isChatFullSize: false,
-  setChatFullSize: (value) => set({ isChatFullSize: value }),
+  setChatFullSize: (value) =>
+    useSidebarStore.setState({ isChatFullSize: value }),
+
   toggleSidebar: () =>
-    set((state) => ({ sideBarVisible: !state.sideBarVisible })),
-
-  getThreadById: (threadId: string | null | undefined) => {
-    const { threads } = get();
-    return threads.find((thread) => thread.id === threadId);
-  },
-
-  fetchThreads: async () => {
-    try {
-      const response = await apiFetch("/api/threads");
-
-      if (response.ok) {
-        const raw: ThreadEntry[] = await response.json();
-        const data = raw.map((t) => ({
-          ...t,
-          is_public: t.is_public ?? false,
-        }));
-        const groupedThreads = computeThreadGroups(data);
-        set({ threadGroups: groupedThreads, threads: data });
-      } else {
-        showApiError("Failed to load threads.", {
-          title: response.status >= 500 ? "Server Error" : "Request Error",
-        });
-      }
-    } catch (error) {
-      console.error("Error loading threads:", error);
-      showApiError("Network error while loading threads.", {
-        title: "Network Error",
-      });
-    }
-  },
+    useSidebarStore.setState((state) => ({
+      sideBarVisible: !state.sideBarVisible,
+    })),
 
   renameThread: async (threadId: string, newName: string) => {
     const response = await apiFetch(`/api/threads/${threadId}`, {
       method: "PATCH",
-      headers: {
-        "Content-Type": "application/json",
-      },
+      headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ name: newName }),
     });
 
     if (response.ok) {
-      // Update the thread in the store
-      set((state) => {
-        const threads = state.threads.map((thread) =>
-          thread.id === threadId ? { ...thread, name: newName } : thread
-        );
-        return { threads, threadGroups: computeThreadGroups(threads) };
-      });
+      updateThreadInCache((threads) =>
+        threads.map((t) => (t.id === threadId ? { ...t, name: newName } : t))
+      );
     } else {
       throw new Error("Failed to rename thread");
     }
@@ -130,20 +71,16 @@ const useSidebarStore = create<SidebarState>((set, get) => ({
   shareThread: async (threadId: string, isPublic: boolean) => {
     const response = await apiFetch(`/api/threads/${threadId}`, {
       method: "PATCH",
-      headers: {
-        "Content-Type": "application/json",
-      },
+      headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ is_public: isPublic }),
     });
 
     if (response.ok) {
-      // Update the thread in the store
-      set((state) => {
-        const threads = state.threads.map((thread) =>
-          thread.id === threadId ? { ...thread, is_public: isPublic } : thread
-        );
-        return { threads, threadGroups: computeThreadGroups(threads) };
-      });
+      updateThreadInCache((threads) =>
+        threads.map((t) =>
+          t.id === threadId ? { ...t, is_public: isPublic } : t
+        )
+      );
     } else {
       throw new Error("Failed to share thread");
     }
@@ -155,16 +92,9 @@ const useSidebarStore = create<SidebarState>((set, get) => ({
     });
 
     if (response.ok) {
-      // Remove the thread from the store
-      set((state) => {
-        const threads = state.threads.filter(
-          (thread) => thread.id !== threadId
-        );
-        return {
-          threads,
-          threadGroups: computeThreadGroups(threads),
-        };
-      });
+      updateThreadInCache((threads) =>
+        threads.filter((t) => t.id !== threadId)
+      );
     } else {
       throw new Error("Failed to delete thread");
     }
@@ -174,12 +104,12 @@ const useSidebarStore = create<SidebarState>((set, get) => ({
     try {
       const response = await fetch(`${API_CONFIG.API_HOST}/docs`);
       if (response.status === 200) {
-        set({ apiStatus: "OK" });
+        useSidebarStore.setState({ apiStatus: "OK" });
       } else {
-        set({ apiStatus: "Error" });
+        useSidebarStore.setState({ apiStatus: "Error" });
       }
     } catch {
-      set({ apiStatus: "Error" });
+      useSidebarStore.setState({ apiStatus: "Error" });
     }
   },
 }));


### PR DESCRIPTION
Refs #440 

Depends on https://github.com/wri/project-zeno/pull/685 backend PR, although nothing should break if deployed without the backend change.

Implements "Infinite scrolling" for threads - fetching upto , and then fetching more if the user scrolls down.

Am not fully sure what's going on with this infinite scroll plugin - this was definitely quite vibe-coded, so would appreciate any feedback.

To test:

 - Needs to point to new version of backend with https://github.com/wri/project-zeno-next/issues/440 merged
 - If you have less than 100 threads, adjust PAGE_SIZE in `app/hooks/useThreadsInfinite.ts` to make it smaller
 - Should fetch more threads as you scroll down, and not all threads in a single request

This will probably be easier to test once the backend is merged to staging.

