### PR TITLE
PZB-859: Move disclaimer component outside chat

### DIFF
--- a/app/components/ChatMessages.tsx
+++ b/app/components/ChatMessages.tsx
@@ -1,11 +1,10 @@
 "use client";
-import { Fragment, useState, useEffect, useRef } from "react";
-import { Box, Text, Link } from "@chakra-ui/react";
+import { Fragment, useEffect, useRef } from "react";
+import { Box } from "@chakra-ui/react";
 import useChatStore from "@/app/store/chatStore";
 import MessageBubble from "./MessageBubble";
 import Reasoning from "./Reasoning";
 import SamplePrompts from "./SamplePrompts";
-import ChatDisclaimer from "./ChatDisclaimer";
 import WhatsNewModal from "./WhatsNewModal";
 
 function ChatMessages() {
@@ -13,7 +12,6 @@ function ChatMessages() {
   const lastUserMessageRef = useRef<HTMLDivElement>(null);
   const spacerRef = useRef<HTMLDivElement>(null);
   const { messages, isLoading, toolSteps: currentToolSteps } = useChatStore();
-  const [displayDisclaimer, setDisplayDisclaimer] = useState(true);
   const shouldAutoScroll = useRef(true);
 
   // Scroll to the bottom of real content, ignoring the blank spacer.
@@ -104,55 +102,6 @@ function ChatMessages() {
         return (
           <Fragment key={message.id}>
             {isLastUserMessage && <Box ref={lastUserMessageRef} />}
-            {isFirst && displayDisclaimer && (
-              <ChatDisclaimer
-                type="info"
-                setDisplayDisclaimer={setDisplayDisclaimer}
-              >
-                <Box>
-                  <Text mb={{ base: 1, md: 2 }}>
-                    <strong>Global Nature Watch preview</strong>
-                  </Text>
-                  <Text mb={{ base: 1, md: 2 }}>
-                    You&apos;re using a preview version that&apos;s still under
-                    active development. You may encounter errors or incomplete
-                    results, so verify results with primary sources. Features,
-                    datasets, and assistant behavior may change or be removed as
-                    we iterate.
-                  </Text>
-                  <Text>
-                    By using this preview, you&apos;re helping shape the future
-                    of Global Nature Watch. Share feedback via{" "}
-                    <Link
-                      color="primary.solid"
-                      textDecor="underline"
-                      href="https://surveys.hotjar.com/860def81-d4f2-4f8c-abee-339ebc3129f3"
-                    >
-                      this survey
-                    </Link>{" "}
-                    or by emailing{" "}
-                    <Link
-                      color="primary.solid"
-                      textDecor="underline"
-                      href="mailto:landcarbonlab@wri.org"
-                    >
-                      landcarbonlab@wri.org
-                    </Link>{" "}
-                    Visit the{" "}
-                    <Link
-                      color="primary.solid"
-                      textDecor="underline"
-                      href="https://help.globalnaturewatch.org/"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                    >
-                      Help Center
-                    </Link>{" "}
-                    to learn more about the preview.
-                  </Text>
-                </Box>
-              </ChatDisclaimer>
-            )}
             {isFirst && <WhatsNewModal />}
             <MessageBubble
               message={message}

--- a/app/components/DisclaimerPanel.tsx
+++ b/app/components/DisclaimerPanel.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { Box, CloseButton, Flex, Link, Text } from "@chakra-ui/react";
+import { InfoIcon } from "@phosphor-icons/react";
+
+const STORAGE_KEY = "gnw_disclaimer_dismissed";
+
+export default function DisclaimerPanel() {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const dismissed = localStorage.getItem(STORAGE_KEY);
+    if (!dismissed) {
+      setVisible(true);
+    }
+  }, []);
+
+  if (!visible) return null;
+
+  const dismiss = () => {
+    localStorage.setItem(STORAGE_KEY, "true");
+    setVisible(false);
+  };
+
+  return (
+    <Box
+      p={3}
+      bg="lime.100"
+      border="1px solid"
+      borderColor="lime.400"
+      rounded="sm"
+      fontSize="xs"
+      fontFamily="body"
+    >
+      <Flex gap={2} align="flex-start">
+        <InfoIcon
+          weight="fill"
+          size={16}
+          style={{ flexShrink: 0, marginTop: 2 }}
+        />
+        <Box flex="1" pr={5}>
+          <Text mb={1}>
+            You&apos;re using an{" "}
+            <Text as="span" fontWeight="medium">
+              experimental preview
+            </Text>{" "}
+            that&apos;s still under active development. You may encounter errors
+            or incomplete results, so verify results with primary sources.
+            Features, datasets, and assistant behavior may change or be removed
+            as we iterate.
+          </Text>
+          <Text>
+            Share feedback via{" "}
+            <Link
+              color="#0049aa"
+              textDecoration="underline"
+              href="mailto:landcarbonlab@wri.org"
+            >
+              landcarbonlab@wri.org
+            </Link>{" "}
+            or visit the{" "}
+            <Link
+              color="#0049aa"
+              textDecoration="underline"
+              href="https://help.globalnaturewatch.org/"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Help Center
+            </Link>{" "}
+            to learn more.
+          </Text>
+        </Box>
+        <CloseButton
+          size="2xs"
+          position="absolute"
+          top={2}
+          right={2}
+          onClick={dismiss}
+          aria-label="Dismiss disclaimer"
+        />
+      </Flex>
+      <Flex mt={2} gap={3} flexWrap="wrap" fontSize="xs" fontFamily="heading">
+        <Link
+          color="#0049aa"
+          textDecoration="underline"
+          href="https://help.globalnaturewatch.org/methodology"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Methodology
+        </Link>
+        <Link
+          color="#0049aa"
+          textDecoration="underline"
+          href="https://help.globalnaturewatch.org/datasets"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Datasets
+        </Link>
+        <Link
+          color="#0049aa"
+          textDecoration="underline"
+          href="https://help.globalnaturewatch.org/accuracy"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Accuracy
+        </Link>
+        <Link
+          color="#0049aa"
+          textDecoration="underline"
+          href="https://help.globalnaturewatch.org/known-issues"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Known Issues
+        </Link>
+      </Flex>
+    </Box>
+  );
+}

--- a/app/components/Map.tsx
+++ b/app/components/Map.tsx
@@ -34,6 +34,7 @@ import { useLegendHook } from "@/app/components/legend/useLegendHook";
 import GeoJsonLayers from "./map/layers/GeoJsonLayers";
 import { Legend } from "@/app/components/legend/Legend";
 import InsightWorkspace from "./InsightWorkspace";
+import DisclaimerPanel from "./DisclaimerPanel";
 import useInsightStore from "@/app/store/insightStore";
 
 const MAPBOX_ACCESS_TOKEN = process.env.NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN;
@@ -170,6 +171,19 @@ function Map({ disableMapAreaControls }: { disableMapAreaControls?: boolean }) {
             Legend
           </Button>
         )}
+        {/* Top-left overlay: disclaimer panel */}
+        <Box
+          position="absolute"
+          top={4}
+          left={4}
+          zIndex={400}
+          maxW="380px"
+          w="calc(100% - 2rem)"
+          pointerEvents="all"
+          hideBelow="md"
+        >
+          <DisclaimerPanel />
+        </Box>
         {/* Right overlay column: insight panel (top, scrollable) + legend (bottom) */}
         <Flex
           position="absolute"


### PR DESCRIPTION
## Pull request type

- [x] Feature

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The experimental preview disclaimer is rendered inline inside the chat message thread (ChatMessages.tsx), anchored to the first message. It scrolls away as the conversation grows and relies on ephemeral React state — dismissal is lost on page reload.

Issue Number: PZB-859


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

The disclaimer is now a floating panel overlaid on the top-left of the map, outside the chat thread entirely — it does not scroll or disappear as messages accumulate.
Dismissal is persisted in localStorage so the panel stays closed across reloads and sessions.
A new DisclaimerPanel component encapsulates the panel UI: lime background (#F7FBD9), lime border (#E3F37F), info icon, body copy with feedback email and Help Center link, and four footer links (Methodology, Datasets, Accuracy, Known Issues).

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Demo
<img width="1691" height="957" alt="Screenshot 2026-05-27 at 14 39 29" src="https://github.com/user-attachments/assets/39912e17-5610-4604-8173-929f28d238ef" />
