### PR TITLE
Fix rendering error when context layer is null

### DIFF
--- a/app/types/chat.ts
+++ b/app/types/chat.ts
@@ -149,7 +149,7 @@ export interface AOISelection {
 
 export interface DatasetContextLayer {
   name: string;
-  tile_url: string;
+  tile_url: string | null;
 }
 
 export interface DatasetParameter {

--- a/app/utils/datasetLayerContext.ts
+++ b/app/utils/datasetLayerContext.ts
@@ -52,7 +52,7 @@ export function getDatasetLayerContextProps(dataset: DatasetInfo) {
         : undefined;
 
   return {
-    contextLayer: ctxMeta
+    contextLayer: ctxMeta?.tile_url
       ? {
           name: ctxMeta.name,
           tileUrl: patchPrimaryForestTileUrl(ctxMeta.tile_url),


### PR DESCRIPTION
Currently the rendering of thread breaks when contextlayer is `null`

example: https://staging.globalnaturewatch.org/app/threads/bed3d549-103e-4bb9-8d61-689efc2fd4f9