### PR TITLE
PZB-859: Design tweaks to the DisclaimerPanel

### DIFF
--- a/app/components/DisclaimerPanel.tsx
+++ b/app/components/DisclaimerPanel.tsx
@@ -1,10 +1,10 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { Box, CloseButton, Flex, Link, Text } from "@chakra-ui/react";
+import { Box, CloseButton, Flex, Icon, Link, Text } from "@chakra-ui/react";
 import { InfoIcon } from "@phosphor-icons/react";
 
-const STORAGE_KEY = "gnw_disclaimer_dismissed";
+const STORAGE_KEY = "gnw_disclaimer_dismissed_v2";
 
 export default function DisclaimerPanel() {
   const [visible, setVisible] = useState(false);
@@ -25,7 +25,9 @@ export default function DisclaimerPanel() {
 
   return (
     <Box
-      p={3}
+      px={2}
+      pt={2}
+      pb={3}
       bg="lime.100"
       border="1px solid"
       borderColor="lime.400"
@@ -34,34 +36,32 @@ export default function DisclaimerPanel() {
       fontFamily="body"
     >
       <Flex gap={2} align="flex-start">
-        <InfoIcon
-          weight="fill"
-          size={16}
-          style={{ flexShrink: 0, marginTop: 2 }}
-        />
+        <Icon color="lime.700" flexShrink={0} mt="2px" asChild>
+          <InfoIcon weight="fill" size={16} />
+        </Icon>
         <Box flex="1" pr={5}>
           <Text mb={1}>
-            You&apos;re using an{" "}
+            This is an{" "}
             <Text as="span" fontWeight="medium">
               experimental preview
             </Text>{" "}
-            that&apos;s still under active development. You may encounter errors
-            or incomplete results, so verify results with primary sources.
-            Features, datasets, and assistant behavior may change or be removed
-            as we iterate.
+            of Global Nature Watch. Results are grounded in trusted datasets,
+            but AI summaries can be incomplete or incorrect. Verify important
+            findings with source data.
           </Text>
           <Text>
-            Share feedback via{" "}
+            Feedback is welcome at{" "}
             <Link
-              color="#0049aa"
+              color="fg.link"
               textDecoration="underline"
               href="mailto:landcarbonlab@wri.org"
             >
-              landcarbonlab@wri.org
+              landcarbonlab@wri.org.
             </Link>{" "}
-            or visit the{" "}
+            <br />
+            Visit the{" "}
             <Link
-              color="#0049aa"
+              color="fg.link"
               textDecoration="underline"
               href="https://help.globalnaturewatch.org/"
               target="_blank"
@@ -69,8 +69,53 @@ export default function DisclaimerPanel() {
             >
               Help Center
             </Link>{" "}
-            to learn more.
+            to learn more about the preview.
           </Text>
+
+          <Flex
+            mt={4}
+            gap={3}
+            flexWrap="wrap"
+            fontSize="xs"
+            fontFamily="heading"
+          >
+            <Link
+              color="fg.link"
+              textDecoration="underline"
+              href="https://help.globalnaturewatch.org/methodology"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Methodology
+            </Link>
+            <Link
+              color="fg.link"
+              textDecoration="underline"
+              href="https://help.globalnaturewatch.org/datasets"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Datasets
+            </Link>
+            <Link
+              color="fg.link"
+              textDecoration="underline"
+              href="https://help.globalnaturewatch.org/accuracy"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Accuracy
+            </Link>
+            <Link
+              color="fg.link"
+              textDecoration="underline"
+              href="https://help.globalnaturewatch.org/known-issues"
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              Known Issues
+            </Link>
+          </Flex>
         </Box>
         <CloseButton
           size="2xs"
@@ -80,44 +125,6 @@ export default function DisclaimerPanel() {
           onClick={dismiss}
           aria-label="Dismiss disclaimer"
         />
-      </Flex>
-      <Flex mt={2} gap={3} flexWrap="wrap" fontSize="xs" fontFamily="heading">
-        <Link
-          color="#0049aa"
-          textDecoration="underline"
-          href="https://help.globalnaturewatch.org/methodology"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Methodology
-        </Link>
-        <Link
-          color="#0049aa"
-          textDecoration="underline"
-          href="https://help.globalnaturewatch.org/datasets"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Datasets
-        </Link>
-        <Link
-          color="#0049aa"
-          textDecoration="underline"
-          href="https://help.globalnaturewatch.org/accuracy"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Accuracy
-        </Link>
-        <Link
-          color="#0049aa"
-          textDecoration="underline"
-          href="https://help.globalnaturewatch.org/known-issues"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Known Issues
-        </Link>
       </Flex>
     </Box>
   );

--- a/app/components/Map.tsx
+++ b/app/components/Map.tsx
@@ -174,10 +174,10 @@ function Map({ disableMapAreaControls }: { disableMapAreaControls?: boolean }) {
         {/* Top-left overlay: disclaimer panel */}
         <Box
           position="absolute"
-          top={4}
-          left={4}
+          top={2}
+          left={3}
           zIndex={400}
-          maxW="380px"
+          maxW="400px"
           w="calc(100% - 2rem)"
           pointerEvents="all"
           hideBelow="md"

--- a/app/theme/index.tsx
+++ b/app/theme/index.tsx
@@ -100,6 +100,7 @@ export const config = defineConfig({
         lime: {
           100: { value: "#F7FBD9" },
           400: { value: "#E3F37F" },
+          700: { value: "#8E9954" },
         },
         mint: {
           50: { value: "#e2fff8" },
@@ -230,6 +231,9 @@ export const config = defineConfig({
               _light: "{colors.primary.600}",
               _dark: "{colors.primary.300}",
             },
+          },
+          link: {
+            value: { _light: "#0049aa", _dark: "#0049aa" },
           },
         },
         border: {


### PR DESCRIPTION
## What is the new behavior?

- `DisclaimerPanel` is now positioned at the top-left of the map (fixed width 400px) instead of inside the chat panel
- Panel layout updated to match Figma spec: padding top/left/right 8px, bottom 12px, gap 8px
- All hardcoded hex colors replaced with theme tokens (`lime.100`, `lime.400`, `lime.700`, `fg.link`); `lime.700` (#8E9954) and `fg.link` (#0049aa) are newly defined in the theme
- Bumped localStorage key to `gnw_disclaimer_dismissed_v2` so existing users see the updated panel again
## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Demo
<img width="1822" height="918" alt="Screenshot 2026-05-28 at 11 02 59" src="https://github.com/user-attachments/assets/57ab4159-4fc1-413c-8d80-467baaf9f4b0" />
