### PR TITLE
PZB-913: Implement the fires dataset nudge

### DIFF
--- a/app/components/ChatInput.tsx
+++ b/app/components/ChatInput.tsx
@@ -40,8 +40,7 @@ export default function ChatInput({
 
   const [focusEl, setFocusEl] = useState<HTMLTextAreaElement | null>(null);
 
-  const { sendMessage, isLoading, simulateDatasetNudge } = useChatStore();
-  const isDebug = process.env.NEXT_PUBLIC_ENABLE_DEBUG_TOOLS === "true";
+  const { sendMessage, isLoading } = useChatStore();
   const { context, removeContext } = useContextStore();
 
   const openContextMenu = (type: ChatContextType) => {
@@ -162,17 +161,6 @@ export default function ChatInput({
             onClick={() => openContextMenu("date")}
             disabled={disabled}
           />
-          {isDebug && (
-            <Button
-              size="xs"
-              variant="outline"
-              colorPalette="gray"
-              onClick={simulateDatasetNudge}
-              title="[Debug] Simulate dataset nudge"
-            >
-              nudge
-            </Button>
-          )}
         </Flex>
         <Button
           p="0"

--- a/app/components/ChatInput.tsx
+++ b/app/components/ChatInput.tsx
@@ -40,7 +40,7 @@ export default function ChatInput({
 
   const [focusEl, setFocusEl] = useState<HTMLTextAreaElement | null>(null);
 
-  const { sendMessage, isLoading } = useChatStore();
+  const { sendMessage, isLoading, messages } = useChatStore();
   const { context, removeContext } = useContextStore();
 
   const openContextMenu = (type: ChatContextType) => {
@@ -83,7 +83,12 @@ export default function ChatInput({
   };
 
   const disabled = isLoading || isChatDisabled;
-  const message = isLoading ? "Sending..." : "Ask a question...";
+  const hasNudge = messages.at(-1)?.type === "dataset-nudge";
+  const message = isLoading
+    ? "Sending..."
+    : hasNudge
+      ? "Or ask a different question..."
+      : "Ask a question...";
 
   const isButtonDisabled = disabled || !inputValue?.trim();
   const hasContext = context.length > 0;

--- a/app/components/ChatInput.tsx
+++ b/app/components/ChatInput.tsx
@@ -40,7 +40,8 @@ export default function ChatInput({
 
   const [focusEl, setFocusEl] = useState<HTMLTextAreaElement | null>(null);
 
-  const { sendMessage, isLoading } = useChatStore();
+  const { sendMessage, isLoading, simulateDatasetNudge } = useChatStore();
+  const isDebug = process.env.NEXT_PUBLIC_ENABLE_DEBUG_TOOLS === "true";
   const { context, removeContext } = useContextStore();
 
   const openContextMenu = (type: ChatContextType) => {
@@ -161,6 +162,17 @@ export default function ChatInput({
             onClick={() => openContextMenu("date")}
             disabled={disabled}
           />
+          {isDebug && (
+            <Button
+              size="xs"
+              variant="outline"
+              colorPalette="gray"
+              onClick={simulateDatasetNudge}
+              title="[Debug] Simulate dataset nudge"
+            >
+              nudge
+            </Button>
+          )}
         </Flex>
         <Button
           p="0"

--- a/app/components/DatasetNudge.tsx
+++ b/app/components/DatasetNudge.tsx
@@ -8,7 +8,7 @@ import useContextStore from "@/app/store/contextStore";
 import { DATASET_BY_ID } from "@/app/constants/datasets";
 import { getDatasetLayerContextProps } from "@/app/utils/datasetLayerContext";
 
-export default function DatasetNudgeWidget({
+export default function DatasetNudge({
   datasets,
 }: {
   datasets: SuggestedDataset[];

--- a/app/components/DatasetNudge.tsx
+++ b/app/components/DatasetNudge.tsx
@@ -19,10 +19,10 @@ export default function DatasetNudge({
     if (pickedId !== null) return;
     setPickedId(selected.dataset_id);
 
-    const localDataset = DATASET_BY_ID[selected.dataset_id];
-    if (localDataset) {
+    const datasetMetadata = DATASET_BY_ID[selected.dataset_id];
+    if (datasetMetadata) {
       const merged = {
-        ...localDataset,
+        ...datasetMetadata,
         ...(selected.context_layer !== undefined && {
           context_layer: selected.context_layer,
         }),

--- a/app/components/DatasetNudgeWidget.tsx
+++ b/app/components/DatasetNudgeWidget.tsx
@@ -1,0 +1,84 @@
+"use client";
+import { useState } from "react";
+import { Flex, Button, Text, Badge } from "@chakra-ui/react";
+import { SuggestedDataset } from "@/app/types/chat";
+import useChatStore from "@/app/store/chatStore";
+import useContextStore from "@/app/store/contextStore";
+import { DATASET_BY_ID } from "@/app/constants/datasets";
+import { getDatasetLayerContextProps } from "@/app/utils/datasetLayerContext";
+
+export default function DatasetNudgeWidget({
+  datasets,
+}: {
+  datasets: SuggestedDataset[];
+}) {
+  const [pickedId, setPickedId] = useState<number | null>(null);
+
+  const handlePick = (selected: SuggestedDataset) => {
+    if (pickedId !== null) return;
+    setPickedId(selected.dataset_id);
+
+    // Merge backend-supplied fields (context_layer, dates) over local registry entry
+    const localDataset = DATASET_BY_ID[selected.dataset_id];
+    if (localDataset) {
+      const merged = {
+        ...localDataset,
+        ...(selected.context_layer !== undefined && {
+          context_layer: selected.context_layer,
+        }),
+        ...(selected.start_date && { start_date: selected.start_date }),
+        ...(selected.end_date && { end_date: selected.end_date }),
+        ...(selected.parameters && { parameters: selected.parameters }),
+      };
+
+      const layerContextProps = getDatasetLayerContextProps(merged);
+      useContextStore.getState().upsertContextByType({
+        contextType: "layer",
+        content: merged.dataset_name,
+        datasetId: merged.dataset_id,
+        tileUrl: merged.tile_url,
+        layerName: merged.dataset_name,
+        ...layerContextProps,
+        isAiContext: true,
+      });
+    }
+
+    useChatStore.getState().sendMessage(selected.dataset_name, "human_input");
+  };
+
+  return (
+    <Flex direction="column" gap={2} mt={1}>
+      <Text
+        fontSize="xs"
+        fontWeight="semibold"
+        color="fg.muted"
+        letterSpacing="wider"
+      >
+        SUGGESTED
+      </Text>
+      <Flex gap={2} flexWrap="wrap">
+        {datasets.map((d) => {
+          const isPicked = pickedId === d.dataset_id;
+          const isDisabled = pickedId !== null && !isPicked;
+          return (
+            <Button
+              key={d.dataset_id}
+              size="sm"
+              variant={isPicked ? "solid" : "outline"}
+              colorPalette={isPicked ? "primary" : "gray"}
+              disabled={isDisabled}
+              onClick={() => handlePick(d)}
+            >
+              {d.dataset_name}
+              {d.recommended && (
+                <Badge ml={1} size="xs" colorPalette="teal" variant="solid">
+                  REC
+                </Badge>
+              )}
+            </Button>
+          );
+        })}
+      </Flex>
+    </Flex>
+  );
+}

--- a/app/components/DatasetNudgeWidget.tsx
+++ b/app/components/DatasetNudgeWidget.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { useState } from "react";
-import { Flex, Button, Text, Badge } from "@chakra-ui/react";
+import { Flex, Text } from "@chakra-ui/react";
+import { CheckIcon } from "@phosphor-icons/react";
 import { SuggestedDataset } from "@/app/types/chat";
 import useChatStore from "@/app/store/chatStore";
 import useContextStore from "@/app/store/contextStore";
@@ -18,7 +19,6 @@ export default function DatasetNudgeWidget({
     if (pickedId !== null) return;
     setPickedId(selected.dataset_id);
 
-    // Merge backend-supplied fields (context_layer, dates) over local registry entry
     const localDataset = DATASET_BY_ID[selected.dataset_id];
     if (localDataset) {
       const merged = {
@@ -47,35 +47,71 @@ export default function DatasetNudgeWidget({
   };
 
   return (
-    <Flex direction="column" gap={2} mt={1}>
-      <Text
-        fontSize="xs"
-        fontWeight="semibold"
-        color="fg.muted"
-        letterSpacing="wider"
-      >
-        SUGGESTED
+    <Flex direction="column" gap={3} w="full">
+      <Text fontSize="xs" color="fg.muted" lineHeight="18px">
+        Pick one to continue and I&apos;ll run the analysis:
       </Text>
-      <Flex gap={2} flexWrap="wrap">
+      <Flex direction="column" gap={3}>
         {datasets.map((d) => {
           const isPicked = pickedId === d.dataset_id;
           const isDisabled = pickedId !== null && !isPicked;
           return (
-            <Button
+            <Flex
               key={d.dataset_id}
-              size="sm"
-              variant={isPicked ? "solid" : "outline"}
-              colorPalette={isPicked ? "primary" : "gray"}
-              disabled={isDisabled}
+              align="center"
+              gap={2}
+              w="full"
+              px={3}
+              py={2}
+              bg={isPicked ? "primary.500" : "bg.panel"}
+              border="1px solid"
+              borderColor={
+                isPicked
+                  ? "primary.500"
+                  : d.recommended
+                    ? "primary.emphasized"
+                    : "neutral.400"
+              }
+              borderRadius="lg"
+              cursor={isDisabled ? "default" : "pointer"}
+              opacity={isDisabled ? 0.4 : 1}
+              pointerEvents={isDisabled ? "none" : "auto"}
+              transition="border-color 0.15s ease"
+              _hover={
+                !isDisabled && !isPicked
+                  ? { borderColor: "primary.emphasized" }
+                  : undefined
+              }
               onClick={() => handlePick(d)}
             >
-              {d.dataset_name}
-              {d.recommended && (
-                <Badge ml={1} size="xs" colorPalette="teal" variant="solid">
-                  REC
-                </Badge>
+              <Flex direction="column" gap={1} flex={1} minW={0}>
+                <Text
+                  fontSize="xs"
+                  fontWeight="semibold"
+                  color={isPicked ? "primary.contrast" : "fg"}
+                  lineHeight="16px"
+                >
+                  {d.dataset_name}
+                </Text>
+                {d.reason && (
+                  <Text
+                    fontSize="xs"
+                    color={isPicked ? "primary.contrast" : "fg"}
+                    lineHeight="16px"
+                  >
+                    {d.reason}
+                  </Text>
+                )}
+              </Flex>
+              {isPicked && (
+                <CheckIcon
+                  size={16}
+                  weight="bold"
+                  color="var(--chakra-colors-primary-contrast)"
+                  style={{ flexShrink: 0 }}
+                />
               )}
-            </Button>
+            </Flex>
           );
         })}
       </Flex>

--- a/app/components/MessageBubble.tsx
+++ b/app/components/MessageBubble.tsx
@@ -33,6 +33,7 @@ import useChatStore from "../store/chatStore";
 import { toaster } from "./ui/toaster";
 import { apiFetch } from "@/app/lib/api-client";
 import CopySelectionTooltip from "./CopySelectionTooltip";
+import DatasetNudgeWidget from "./DatasetNudgeWidget";
 
 interface MessageBubbleProps {
   message: ChatMessage;
@@ -157,6 +158,14 @@ function MessageBubble({
     !isFirst &&
     !message.suppressFooter &&
     (!isConsecutive || analysisWidgets.length > 0 || isLast);
+  if (message.type === "dataset-nudge" && message.suggestedDatasets) {
+    return (
+      <Box my={2}>
+        <DatasetNudgeWidget datasets={message.suggestedDatasets} />
+      </Box>
+    );
+  }
+
   // For widget messages, render them in a full-width container
   if (isWidget && message.widgets) {
     return message.widgets.map((widget, idx) => (

--- a/app/components/MessageBubble.tsx
+++ b/app/components/MessageBubble.tsx
@@ -33,7 +33,7 @@ import useChatStore from "../store/chatStore";
 import { toaster } from "./ui/toaster";
 import { apiFetch } from "@/app/lib/api-client";
 import CopySelectionTooltip from "./CopySelectionTooltip";
-import DatasetNudgeWidget from "./DatasetNudgeWidget";
+import DatasetNudge from "./DatasetNudge";
 
 interface MessageBubbleProps {
   message: ChatMessage;
@@ -161,7 +161,7 @@ function MessageBubble({
   if (message.type === "dataset-nudge" && message.suggestedDatasets) {
     return (
       <Box my={2}>
-        <DatasetNudgeWidget datasets={message.suggestedDatasets} />
+        <DatasetNudge datasets={message.suggestedDatasets} />
       </Box>
     );
   }

--- a/app/lib/parse-stream-message.ts
+++ b/app/lib/parse-stream-message.ts
@@ -58,6 +58,7 @@ export function parseStreamMessage(
       name: kwargs.name,
       content: typeof content === "string" ? content : String(content),
       dataset: langChainMessage.dataset || undefined,
+      suggested_datasets: langChainMessage.suggested_datasets || undefined,
       insights: langChainMessage.insights || [],
       charts_data: langChainMessage.charts_data || [],
       codeact_parts: langChainMessage.codeact_parts || [],

--- a/app/store/chat-tools/__tests__/pickDataset.test.ts
+++ b/app/store/chat-tools/__tests__/pickDataset.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+vi.mock("@/app/store/contextStore", () => ({
+  default: {
+    getState: () => ({ upsertContextByType: vi.fn() }),
+  },
+}));
+
+vi.mock("@/app/utils/datasetLayerContext", () => ({
+  getDatasetLayerContextProps: () => ({
+    contextLayer: undefined,
+    parameters: undefined,
+    startDate: undefined,
+    endDate: undefined,
+  }),
+}));
+
+import { pickDatasetTool } from "../pickDataset";
+import { StreamMessage, ChatMessage, SuggestedDataset } from "@/app/types/chat";
+
+type AddMessageFn = (message: Omit<ChatMessage, "id">) => void;
+
+const timestamp = new Date().toISOString();
+
+const suggested: SuggestedDataset[] = [
+  { dataset_id: 4, dataset_name: "TCL Fires", reason: "Annual fire series." },
+  { dataset_id: 7, dataset_name: "DIST Alerts", reason: "Daily alerts." },
+];
+
+const baseMsg = (overrides: Partial<StreamMessage> = {}): StreamMessage => ({
+  type: "tool",
+  name: "pick_dataset",
+  timestamp,
+  ...overrides,
+});
+
+describe("pickDatasetTool", () => {
+  let addMessage: ReturnType<typeof vi.fn<AddMessageFn>>;
+
+  beforeEach(() => {
+    addMessage = vi.fn<AddMessageFn>();
+  });
+
+  it("emits dataset-nudge with suggested datasets when no direct dataset", () => {
+    pickDatasetTool(baseMsg({ suggested_datasets: suggested }), addMessage);
+
+    expect(addMessage).toHaveBeenCalledOnce();
+    const msg = addMessage.mock.calls[0][0];
+    expect(msg.type).toBe("dataset-nudge");
+    expect(
+      (msg as { suggestedDatasets: SuggestedDataset[] }).suggestedDatasets
+    ).toEqual(suggested);
+  });
+
+  it("emits dataset-card widget when dataset has tile_url", () => {
+    pickDatasetTool(
+      baseMsg({
+        dataset: {
+          dataset_id: 4,
+          dataset_name: "TCL Fires",
+          tile_url: "https://example.com/tiles",
+        },
+      }),
+      addMessage
+    );
+
+    expect(addMessage).toHaveBeenCalledOnce();
+    const msg = addMessage.mock.calls[0][0];
+    expect(msg.type).toBe("widget");
+  });
+
+  it("appends an assistant reason message when dataset includes a reason", () => {
+    pickDatasetTool(
+      baseMsg({
+        dataset: {
+          dataset_id: 4,
+          dataset_name: "TCL Fires",
+          tile_url: "https://example.com/tiles",
+          reason: "Best fit for trend questions.",
+        },
+      }),
+      addMessage
+    );
+
+    expect(addMessage).toHaveBeenCalledTimes(2);
+    const reasonMsg = addMessage.mock.calls[1][0];
+    expect(reasonMsg.type).toBe("assistant");
+    expect(reasonMsg.message).toBe("Best fit for trend questions.");
+  });
+
+  it("prefers dataset over suggested_datasets when both are present", () => {
+    pickDatasetTool(
+      baseMsg({
+        dataset: {
+          dataset_id: 4,
+          dataset_name: "TCL Fires",
+          tile_url: "https://example.com/tiles",
+        },
+        suggested_datasets: suggested,
+      }),
+      addMessage
+    );
+
+    const types = addMessage.mock.calls.map((c) => c[0].type);
+    expect(types).not.toContain("dataset-nudge");
+    expect(types).toContain("widget");
+  });
+
+  it("does nothing when neither dataset nor suggested_datasets are present", () => {
+    pickDatasetTool(baseMsg(), addMessage);
+    expect(addMessage).not.toHaveBeenCalled();
+  });
+});

--- a/app/store/chat-tools/pickDataset.ts
+++ b/app/store/chat-tools/pickDataset.ts
@@ -22,12 +22,10 @@ export function pickDatasetTool(
       | undefined;
 
     if (suggestedDatasets && suggestedDatasets.length > 0 && !dataset) {
-      const datasetList = suggestedDatasets
-        .map((d) => `**${d.dataset_name}**\n${d.reason ?? ""}`)
-        .join("\n\n");
       addMessage({
-        type: "assistant",
-        message: `A few datasets could work here, but they're not interchangeable. Before I run the analysis I want to make sure we use the one that actually fits your question.\n\n${datasetList}\n\nPick one to continue and I'll run the analysis.`,
+        type: "dataset-nudge",
+        message: "",
+        suggestedDatasets,
         timestamp: streamMessage.timestamp,
       });
       return;

--- a/app/store/chat-tools/pickDataset.ts
+++ b/app/store/chat-tools/pickDataset.ts
@@ -3,6 +3,7 @@ import {
   StreamMessage,
   DatasetInfo,
   InsightWidget,
+  SuggestedDataset,
 } from "@/app/types/chat";
 import useContextStore from "../contextStore";
 import { getDatasetLayerContextProps } from "@/app/utils/datasetLayerContext";
@@ -15,6 +16,22 @@ export function pickDatasetTool(
   try {
     // Check if we have dataset information with a tile_url
     const dataset = streamMessage.dataset as DatasetInfo | undefined;
+
+    const suggestedDatasets = streamMessage.suggested_datasets as
+      | SuggestedDataset[]
+      | undefined;
+
+    if (suggestedDatasets && suggestedDatasets.length > 0 && !dataset) {
+      const datasetList = suggestedDatasets
+        .map((d) => `**${d.dataset_name}**\n${d.reason ?? ""}`)
+        .join("\n\n");
+      addMessage({
+        type: "assistant",
+        message: `A few datasets could work here, but they're not interchangeable. Before I run the analysis I want to make sure we use the one that actually fits your question.\n\n${datasetList}\n\nPick one to continue and I'll run the analysis.`,
+        timestamp: streamMessage.timestamp,
+      });
+      return;
+    }
 
     if (dataset && dataset.tile_url) {
       // Create a dataset card widget for interactive tile layer adding

--- a/app/store/chatStore.ts
+++ b/app/store/chatStore.ts
@@ -782,20 +782,23 @@ const useChatStore = create<ChatState & ChatActions>((set, get) => ({
     // Simulate the AI text message that precedes the tool response
     const mockNarrative =
       "Three of our datasets cover forest fires, and they're not interchangeable. " +
-      "Before I run the analysis I want to make sure we use the one that actually fits your question rather than guessing.\n\n" +
+      "Before I run the analysis I want to make sure we use the one that actually fits your question rather than guessing.\n" +
+      "&nbsp;\n" +
       "**TCL Drivers (snapshot)**\n" +
       "Attributes tree cover loss to one of seven drivers. A single global snapshot, not a time series.\n" +
-      "*Useful for ranking fire against other drivers, but no trend.*\n\n" +
+      "*Useful for ranking fire against other drivers, but no trend.*\n" +
+      "&nbsp;\n" +
       "**TCL Fires**\n" +
       "Annual tree cover loss driven by fires, 2001 onwards. Forest scope only.\n" +
-      "*Best fit. Annual fire-loss series for Borneo.*\n\n" +
+      "*Best fit. Annual fire-loss series for Borneo.*\n" +
+      "&nbsp;\n" +
       "**DIST Alerts (driver)**\n" +
       "Daily land disturbance alerts with driver attribution. Finer resolution, covers more than just forest.\n" +
-      "*Pick if you want recent or ongoing fires.*\n\n" +
+      "*Pick if you want recent or ongoing fires.*\n" +
+      "&nbsp;\n" +
       "> **MY TAKE** — TCL Fires is probably the closest match here, since \"what's been happening\" suggests you want a trend over time and that's the only one of the three that's annual. " +
-      "If you really mean recent or current activity, DIST Alerts is a better fit (daily, 10m). I'd skip TCL Drivers (snapshot) for a trend question.\n\n" +
-      "Pick one to continue and I'll run the analysis.";
-
+      "If you really mean recent or current activity, DIST Alerts is a better fit (daily, 10m). I'd skip TCL Drivers (snapshot) for a trend question.\n" +
+      "&nbsp;\n";
     addMessage({ type: "assistant", message: mockNarrative, timestamp });
 
     // Simulate the pick_dataset tool response with suggested_datasets

--- a/app/store/chatStore.ts
+++ b/app/store/chatStore.ts
@@ -12,6 +12,7 @@ import {
   QueryType,
   UiContext,
   ToolStepData,
+  SuggestedDataset,
 } from "@/app/types/chat";
 import useContextStore from "./contextStore";
 import { readDataStream } from "@/app/lib/read-data-stream";
@@ -131,7 +132,9 @@ async function processStreamMessage(
   addToolStep: (toolData: StreamMessage) => void,
   getPendingTraceId: () => string | null,
   setPendingTraceId: (traceId: string | null) => void,
-  attachTraceToLastAssistant: (traceId: string) => boolean
+  attachTraceToLastAssistant: (traceId: string) => boolean,
+  getPendingNudge: () => SuggestedDataset[] | null,
+  setPendingNudge: (datasets: SuggestedDataset[] | null) => void
 ) {
   // Capture standalone trace metadata sent as a separate stream message
   if (streamMessage.type === "other" && streamMessage.name === "trace") {
@@ -226,6 +229,17 @@ async function processStreamMessage(
         traceId: traceToUse,
       });
     }
+    // Flush any buffered nudge immediately after the assistant message
+    const pendingNudge = getPendingNudge();
+    if (pendingNudge) {
+      addMessage({
+        type: "dataset-nudge",
+        message: "",
+        suggestedDatasets: pendingNudge,
+        timestamp: streamMessage.timestamp,
+      });
+      setPendingNudge(null);
+    }
     // Clear pending trace id once used
     if (pending && pending === traceToUse) {
       setPendingTraceId(null);
@@ -256,7 +270,14 @@ async function processStreamMessage(
     // Handling for pick_dataset tool
     else if (streamMessage.name === "pick_dataset") {
       void Promise.resolve().then(() =>
-        pickDatasetTool(streamMessage, addMessage)
+        pickDatasetTool(streamMessage, (message) => {
+          // Buffer dataset-nudge messages so they appear after the assistant narrative
+          if (message.type === "dataset-nudge" && message.suggestedDatasets) {
+            setPendingNudge(message.suggestedDatasets);
+          } else {
+            addMessage(message);
+          }
+        })
       );
       return;
     }
@@ -410,6 +431,7 @@ const useChatStore = create<ChatState & ChatActions>((set, get) => ({
       useAuthStore.getState().setUsageFromHeaders(response.headers);
 
       const reader = response.body.getReader();
+      let pendingNudge: SuggestedDataset[] | null = null;
 
       await readDataStream({
         abortController,
@@ -442,6 +464,10 @@ const useChatStore = create<ChatState & ChatActions>((set, get) => ({
                   return state;
                 });
                 return attached;
+              },
+              () => pendingNudge,
+              (datasets) => {
+                pendingNudge = datasets;
               }
             );
           } catch (err) {
@@ -631,6 +657,7 @@ const useChatStore = create<ChatState & ChatActions>((set, get) => ({
       }
 
       const reader = response.body.getReader();
+      let pendingNudgeThread: SuggestedDataset[] | null = null;
 
       await readDataStream({
         abortController,
@@ -707,6 +734,10 @@ const useChatStore = create<ChatState & ChatActions>((set, get) => ({
                   return state;
                 });
                 return attached;
+              },
+              () => pendingNudgeThread,
+              (datasets) => {
+                pendingNudgeThread = datasets;
               }
             );
           } catch (err) {

--- a/app/store/chatStore.ts
+++ b/app/store/chatStore.ts
@@ -59,7 +59,6 @@ interface ChatActions {
   addToolStep: (toolData: StreamMessage) => void;
   clearToolSteps: () => void;
   attachToolStepsToLastUserMessage: (durationOverride?: number) => void;
-  simulateDatasetNudge: () => void;
 }
 
 const initialState: ChatState = {
@@ -773,72 +772,6 @@ const useChatStore = create<ChatState & ChatActions>((set, get) => ({
 
       setLoading(false);
     }
-  },
-
-  simulateDatasetNudge: () => {
-    const { addMessage } = get();
-    const timestamp = new Date().toISOString();
-
-    // Simulate the AI text message that precedes the tool response
-    const mockNarrative =
-      "Three of our datasets cover forest fires, and they're not interchangeable. " +
-      "Before I run the analysis I want to make sure we use the one that actually fits your question rather than guessing.\n" +
-      "&nbsp;\n" +
-      "**TCL Drivers (snapshot)**\n" +
-      "Attributes tree cover loss to one of seven drivers. A single global snapshot, not a time series.\n" +
-      "*Useful for ranking fire against other drivers, but no trend.*\n" +
-      "&nbsp;\n" +
-      "**TCL Fires**\n" +
-      "Annual tree cover loss driven by fires, 2001 onwards. Forest scope only.\n" +
-      "*Best fit. Annual fire-loss series for Borneo.*\n" +
-      "&nbsp;\n" +
-      "**DIST Alerts (driver)**\n" +
-      "Daily land disturbance alerts with driver attribution. Finer resolution, covers more than just forest.\n" +
-      "*Pick if you want recent or ongoing fires.*\n" +
-      "&nbsp;\n" +
-      "> **MY TAKE** — TCL Fires is probably the closest match here, since \"what's been happening\" suggests you want a trend over time and that's the only one of the three that's annual. " +
-      "If you really mean recent or current activity, DIST Alerts is a better fit (daily, 10m). I'd skip TCL Drivers (snapshot) for a trend question.\n" +
-      "&nbsp;\n";
-    addMessage({ type: "assistant", message: mockNarrative, timestamp });
-
-    // Simulate the pick_dataset tool response with suggested_datasets
-    pickDatasetTool(
-      {
-        type: "tool",
-        name: "pick_dataset",
-        content:
-          "No single dataset directly matches the query. Here are the closest available options.",
-        suggested_datasets: [
-          {
-            dataset_id: 3,
-            dataset_name: "TCL Drivers (snapshot)",
-            context_layer: null,
-            start_date: "2001-01-01",
-            end_date: "2023-12-31",
-            reason: "Attributes tree cover loss to one of seven drivers.",
-          },
-          {
-            dataset_id: 4,
-            dataset_name: "TCL Fires",
-            context_layer: null,
-            start_date: "2001-01-01",
-            end_date: "2024-12-31",
-            reason: "Annual tree cover loss driven by fires, 2001 onwards.",
-            recommended: true,
-          },
-          {
-            dataset_id: 7,
-            dataset_name: "DIST Alerts (driver)",
-            context_layer: null,
-            start_date: "2023-01-01",
-            end_date: "2025-12-31",
-            reason: "Daily land disturbance alerts with driver attribution.",
-          },
-        ],
-        timestamp,
-      },
-      addMessage
-    );
   },
 }));
 

--- a/app/store/chatStore.ts
+++ b/app/store/chatStore.ts
@@ -59,6 +59,7 @@ interface ChatActions {
   addToolStep: (toolData: StreamMessage) => void;
   clearToolSteps: () => void;
   attachToolStepsToLastUserMessage: (durationOverride?: number) => void;
+  simulateDatasetNudge: () => void;
 }
 
 const initialState: ChatState = {
@@ -772,6 +773,38 @@ const useChatStore = create<ChatState & ChatActions>((set, get) => ({
 
       setLoading(false);
     }
+  },
+
+  simulateDatasetNudge: () => {
+    const { addMessage } = get();
+    const mockStreamMessage: StreamMessage = {
+      type: "tool",
+      name: "pick_dataset",
+      content:
+        "No single dataset directly matches the query. Here are the closest available options:\n- Tree cover loss: Annual tree cover loss driven by fires, 2001 onwards.",
+      suggested_datasets: [
+        {
+          dataset_id: 4,
+          dataset_name: "Tree cover loss",
+          context_layer: "primary_forest",
+          start_date: "2002-01-01",
+          end_date: "2025-12-31",
+          reason:
+            "Annual tree cover loss driven by fires, 2001 onwards. Forest scope only.",
+        },
+        {
+          dataset_id: 7,
+          dataset_name: "DIST Alerts (driver)",
+          context_layer: null,
+          start_date: "2023-01-01",
+          end_date: "2025-12-31",
+          reason:
+            "Daily land disturbance alerts with driver attribution. Finer resolution, covers more than just forest.",
+        },
+      ],
+      timestamp: new Date().toISOString(),
+    };
+    pickDatasetTool(mockStreamMessage, addMessage);
   },
 }));
 

--- a/app/store/chatStore.ts
+++ b/app/store/chatStore.ts
@@ -777,34 +777,65 @@ const useChatStore = create<ChatState & ChatActions>((set, get) => ({
 
   simulateDatasetNudge: () => {
     const { addMessage } = get();
-    const mockStreamMessage: StreamMessage = {
-      type: "tool",
-      name: "pick_dataset",
-      content:
-        "No single dataset directly matches the query. Here are the closest available options:\n- Tree cover loss: Annual tree cover loss driven by fires, 2001 onwards.",
-      suggested_datasets: [
-        {
-          dataset_id: 4,
-          dataset_name: "Tree cover loss",
-          context_layer: "primary_forest",
-          start_date: "2002-01-01",
-          end_date: "2025-12-31",
-          reason:
-            "Annual tree cover loss driven by fires, 2001 onwards. Forest scope only.",
-        },
-        {
-          dataset_id: 7,
-          dataset_name: "DIST Alerts (driver)",
-          context_layer: null,
-          start_date: "2023-01-01",
-          end_date: "2025-12-31",
-          reason:
-            "Daily land disturbance alerts with driver attribution. Finer resolution, covers more than just forest.",
-        },
-      ],
-      timestamp: new Date().toISOString(),
-    };
-    pickDatasetTool(mockStreamMessage, addMessage);
+    const timestamp = new Date().toISOString();
+
+    // Simulate the AI text message that precedes the tool response
+    const mockNarrative =
+      "Three of our datasets cover forest fires, and they're not interchangeable. " +
+      "Before I run the analysis I want to make sure we use the one that actually fits your question rather than guessing.\n\n" +
+      "**TCL Drivers (snapshot)**\n" +
+      "Attributes tree cover loss to one of seven drivers. A single global snapshot, not a time series.\n" +
+      "*Useful for ranking fire against other drivers, but no trend.*\n\n" +
+      "**TCL Fires**\n" +
+      "Annual tree cover loss driven by fires, 2001 onwards. Forest scope only.\n" +
+      "*Best fit. Annual fire-loss series for Borneo.*\n\n" +
+      "**DIST Alerts (driver)**\n" +
+      "Daily land disturbance alerts with driver attribution. Finer resolution, covers more than just forest.\n" +
+      "*Pick if you want recent or ongoing fires.*\n\n" +
+      "> **MY TAKE** — TCL Fires is probably the closest match here, since \"what's been happening\" suggests you want a trend over time and that's the only one of the three that's annual. " +
+      "If you really mean recent or current activity, DIST Alerts is a better fit (daily, 10m). I'd skip TCL Drivers (snapshot) for a trend question.\n\n" +
+      "Pick one to continue and I'll run the analysis.";
+
+    addMessage({ type: "assistant", message: mockNarrative, timestamp });
+
+    // Simulate the pick_dataset tool response with suggested_datasets
+    pickDatasetTool(
+      {
+        type: "tool",
+        name: "pick_dataset",
+        content:
+          "No single dataset directly matches the query. Here are the closest available options.",
+        suggested_datasets: [
+          {
+            dataset_id: 3,
+            dataset_name: "TCL Drivers (snapshot)",
+            context_layer: null,
+            start_date: "2001-01-01",
+            end_date: "2023-12-31",
+            reason: "Attributes tree cover loss to one of seven drivers.",
+          },
+          {
+            dataset_id: 4,
+            dataset_name: "TCL Fires",
+            context_layer: null,
+            start_date: "2001-01-01",
+            end_date: "2024-12-31",
+            reason: "Annual tree cover loss driven by fires, 2001 onwards.",
+            recommended: true,
+          },
+          {
+            dataset_id: 7,
+            dataset_name: "DIST Alerts (driver)",
+            context_layer: null,
+            start_date: "2023-01-01",
+            end_date: "2025-12-31",
+            reason: "Daily land disturbance alerts with driver attribution.",
+          },
+        ],
+        timestamp,
+      },
+      addMessage
+    );
   },
 }));
 

--- a/app/types/chat.ts
+++ b/app/types/chat.ts
@@ -120,6 +120,7 @@ export interface StreamMessage {
   name?: string;
   content?: string;
   dataset?: object;
+  suggested_datasets?: SuggestedDataset[];
   aoi?: object;
   aoi_selection?: AOISelection;
   insights?: object[];
@@ -155,6 +156,16 @@ export interface DatasetContextLayer {
 export interface DatasetParameter {
   name: string;
   values: unknown[];
+}
+
+export interface SuggestedDataset {
+  dataset_id: number;
+  dataset_name: string;
+  context_layer?: string | null;
+  parameters?: DatasetParameter[] | null;
+  start_date?: string;
+  end_date?: string;
+  reason?: string;
 }
 
 export interface DatasetInfo {
@@ -196,6 +207,7 @@ export interface LangChainResponse {
 // LangChain-based API response structure (for internal API use)
 export interface LangChainUpdate {
   dataset: object;
+  suggested_datasets?: SuggestedDataset[];
   aoi?: object;
   aoi_selection?: AOISelection;
   start_date?: string;

--- a/app/types/chat.ts
+++ b/app/types/chat.ts
@@ -16,10 +16,18 @@ export interface ToolStepData {
 
 export interface ChatMessage {
   id: string;
-  type: "user" | "assistant" | "system" | "widget" | "error" | "warning";
+  type:
+    | "user"
+    | "assistant"
+    | "system"
+    | "widget"
+    | "error"
+    | "warning"
+    | "dataset-nudge";
   message: string;
   timestamp: string;
   widgets?: InsightWidget[]; // For widget messages
+  suggestedDatasets?: SuggestedDataset[]; // For dataset-nudge messages
   context?: ContextItem[];
   traceId?: string;
   toolSteps?: ToolStepData[]; // For user messages - reasoning steps taken to respond
@@ -166,6 +174,7 @@ export interface SuggestedDataset {
   start_date?: string;
   end_date?: string;
   reason?: string;
+  recommended?: boolean;
 }
 
 export interface DatasetInfo {


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help -->

## What is the current behavior?
The agent picks a dataset silently based on a user's prompt even if there are other possible options.


## What is the new behavior?
Given the user's prompt is fires-related and more than one fire dataset could plausibly answer it, when the agent replies, then it surfaces those candidate datasets instead of picking one silently.


## Does this introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Demo

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
