### PR TITLE
PZB-906: Persist onboarding information info button in PREVIEW badge

### DIFF
--- a/app/components/DisclaimerPanel.tsx
+++ b/app/components/DisclaimerPanel.tsx
@@ -3,6 +3,12 @@
 import { useState, useEffect } from "react";
 import { Box, CloseButton, Flex, Icon, Link, Text } from "@chakra-ui/react";
 import { InfoIcon } from "@phosphor-icons/react";
+import {
+  PREVIEW_BODY,
+  PREVIEW_FEEDBACK_EMAIL,
+  PREVIEW_HELP_CENTER_URL,
+  PREVIEW_LINKS,
+} from "@/app/constants/preview-content";
 
 const STORAGE_KEY = "gnw_disclaimer_dismissed_v2";
 
@@ -21,6 +27,7 @@ export default function DisclaimerPanel() {
   const dismiss = () => {
     localStorage.setItem(STORAGE_KEY, "true");
     setVisible(false);
+    window.dispatchEvent(new Event("gnw-disclaimer-dismissed"));
   };
 
   return (
@@ -40,30 +47,22 @@ export default function DisclaimerPanel() {
           <InfoIcon weight="fill" size={16} />
         </Icon>
         <Box flex="1" pr={5}>
-          <Text mb={1}>
-            This is an{" "}
-            <Text as="span" fontWeight="medium">
-              experimental preview
-            </Text>{" "}
-            of Global Nature Watch. Results are grounded in trusted datasets,
-            but AI summaries can be incomplete or incorrect. Verify important
-            findings with source data.
-          </Text>
+          <Text mb={1}>{PREVIEW_BODY}</Text>
           <Text>
             Feedback is welcome at{" "}
             <Link
               color="fg.link"
               textDecoration="underline"
-              href="mailto:landcarbonlab@wri.org"
+              href={`mailto:${PREVIEW_FEEDBACK_EMAIL}`}
             >
-              landcarbonlab@wri.org.
+              {PREVIEW_FEEDBACK_EMAIL}.
             </Link>{" "}
             <br />
             Visit the{" "}
             <Link
               color="fg.link"
               textDecoration="underline"
-              href="https://help.globalnaturewatch.org/"
+              href={PREVIEW_HELP_CENTER_URL}
               target="_blank"
               rel="noopener noreferrer"
             >
@@ -79,42 +78,18 @@ export default function DisclaimerPanel() {
             fontSize="xs"
             fontFamily="heading"
           >
-            <Link
-              color="fg.link"
-              textDecoration="underline"
-              href="https://help.globalnaturewatch.org/methodology"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              Methodology
-            </Link>
-            <Link
-              color="fg.link"
-              textDecoration="underline"
-              href="https://help.globalnaturewatch.org/datasets"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              Datasets
-            </Link>
-            <Link
-              color="fg.link"
-              textDecoration="underline"
-              href="https://help.globalnaturewatch.org/accuracy"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              Accuracy
-            </Link>
-            <Link
-              color="fg.link"
-              textDecoration="underline"
-              href="https://help.globalnaturewatch.org/known-issues"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              Known Issues
-            </Link>
+            {PREVIEW_LINKS.map((link) => (
+              <Link
+                key={link.label}
+                color="fg.link"
+                textDecoration="underline"
+                href={link.href}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                {link.label}
+              </Link>
+            ))}
           </Flex>
         </Box>
         <CloseButton

--- a/app/components/PageHeader.tsx
+++ b/app/components/PageHeader.tsx
@@ -123,12 +123,13 @@ function PageHeader() {
               aria-label={disclaimerDismissed ? "Open preview info" : undefined}
             >
               <Text
-                fontFamily="sans-serif"
-                fontWeight="medium"
+                fontFamily="'IBM Plex Sans', sans-serif"
+                fontStyle="normal"
+                fontWeight="500"
                 fontSize="10px"
                 lineHeight="16px"
                 color="#3A4048"
-                letterSpacing="0"
+                flexShrink={0}
               >
                 PREVIEW
               </Text>

--- a/app/components/PageHeader.tsx
+++ b/app/components/PageHeader.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import {
+  Box,
   Flex,
   Heading,
   Button,
@@ -20,17 +21,45 @@ import {
   InfoIcon,
 } from "@phosphor-icons/react";
 import { Tooltip } from "./ui/tooltip";
+import { useState, useEffect, useRef } from "react";
+import PreviewInfoPanel from "./PreviewInfoPanel";
 
 import useAuthStore from "../store/authStore";
 import Link from "next/link";
 import { useLogout } from "@/app/hooks/useLogout";
 
 const isPrototype = process.env.NEXT_PUBLIC_PROTOTYPE_MODE === "true";
+const DISCLAIMER_STORAGE_KEY = "gnw_disclaimer_dismissed_v2";
 
 function PageHeader() {
   const { userEmail, usedPrompts, totalPrompts, isAuthenticated } =
     useAuthStore();
   const { logout } = useLogout();
+  const [disclaimerDismissed, setDisclaimerDismissed] = useState(false);
+  const [panelOpen, setPanelOpen] = useState(false);
+  const badgeRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const dismissed = localStorage.getItem(DISCLAIMER_STORAGE_KEY) === "true";
+    setDisclaimerDismissed(dismissed);
+
+    const handleDismiss = () => setDisclaimerDismissed(true);
+    window.addEventListener("gnw-disclaimer-dismissed", handleDismiss);
+    return () =>
+      window.removeEventListener("gnw-disclaimer-dismissed", handleDismiss);
+  }, []);
+
+  useEffect(() => {
+    if (!panelOpen) return;
+    const handleClickOutside = (e: MouseEvent) => {
+      if (badgeRef.current && !badgeRef.current.contains(e.target as Node)) {
+        setPanelOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, [panelOpen]);
+
   return (
     <Flex
       alignItems="center"
@@ -64,16 +93,54 @@ function PageHeader() {
             Global Nature Watch
           </Heading>
         </ChakraLink>
-        <Badge
-          colorPalette={isPrototype ? "gray" : "primary"}
-          bg={isPrototype ? "#1f2937" : "primary.800"}
-          color={isPrototype ? "#f3f4f6" : undefined}
-          letterSpacing="wider"
-          variant="solid"
-          size="xs"
-        >
-          {isPrototype ? "PROTOTYPE" : "PREVIEW"}
-        </Badge>
+        {isPrototype ? (
+          <Badge
+            colorPalette="gray"
+            bg="#1f2937"
+            color="#f3f4f6"
+            letterSpacing="wider"
+            variant="solid"
+            size="xs"
+          >
+            PROTOTYPE
+          </Badge>
+        ) : (
+          <Box position="relative" ref={badgeRef}>
+            <Flex
+              as={disclaimerDismissed ? "button" : "span"}
+              align="center"
+              gap="4px"
+              h="20px"
+              px="4px"
+              py="2px"
+              borderRadius="4px"
+              bg="#E0E2E5"
+              border="none"
+              cursor={disclaimerDismissed ? "pointer" : "default"}
+              onClick={
+                disclaimerDismissed ? () => setPanelOpen(!panelOpen) : undefined
+              }
+              aria-label={disclaimerDismissed ? "Open preview info" : undefined}
+            >
+              <Text
+                fontFamily="sans-serif"
+                fontWeight="medium"
+                fontSize="10px"
+                lineHeight="16px"
+                color="#3A4048"
+                letterSpacing="0"
+              >
+                PREVIEW
+              </Text>
+              {disclaimerDismissed && (
+                <InfoIcon size={13} color="#3A4048" weight="fill" />
+              )}
+            </Flex>
+            {panelOpen && (
+              <PreviewInfoPanel onClose={() => setPanelOpen(false)} />
+            )}
+          </Box>
+        )}
       </Flex>
       {isPrototype && (
         <Text

--- a/app/components/PreviewInfoPanel.tsx
+++ b/app/components/PreviewInfoPanel.tsx
@@ -1,0 +1,151 @@
+"use client";
+
+import { Box, Flex, Link, Text } from "@chakra-ui/react";
+import { ArrowSquareOutIcon, InfoIcon, XIcon } from "@phosphor-icons/react";
+import {
+  PREVIEW_BODY,
+  PREVIEW_FEEDBACK_EMAIL,
+  PREVIEW_HELP_CENTER_URL,
+  PREVIEW_LINKS,
+  PREVIEW_TITLE,
+} from "@/app/constants/preview-content";
+
+interface PreviewInfoPanelProps {
+  onClose: () => void;
+}
+
+export default function PreviewInfoPanel({ onClose }: PreviewInfoPanelProps) {
+  return (
+    <Box
+      position="absolute"
+      top="calc(100% + 8px)"
+      left={0}
+      w="400px"
+      bg="#FFFFFF"
+      borderRadius="8px"
+      borderWidth="1px"
+      borderColor="#E0E2E5"
+      p={4}
+      display="flex"
+      flexDirection="column"
+      gap={3}
+      boxShadow="0px 0px 1px 0px rgba(24,24,27,0.3), 0px 24px 40px 0px rgba(24,24,27,0.16)"
+      zIndex={1400}
+    >
+      {/* Close button */}
+      <Box
+        as="button"
+        position="absolute"
+        right={6}
+        top={5}
+        display="flex"
+        alignItems="center"
+        justifyContent="center"
+        bg="transparent"
+        border="none"
+        cursor="pointer"
+        p={0}
+        color="#B2B6BD"
+        _hover={{ color: "#656E7B" }}
+        onClick={onClose}
+        aria-label="Close preview info"
+      >
+        <XIcon size={16} />
+      </Box>
+
+      {/* Icon badge */}
+      <Flex
+        w={8}
+        h={8}
+        borderRadius="full"
+        bg="#F0F9B9"
+        align="center"
+        justify="center"
+        flexShrink={0}
+      >
+        <InfoIcon size={16} color="#8E9954" weight="fill" />
+      </Flex>
+
+      {/* Title + Body */}
+      <Box>
+        <Text
+          fontFamily="sans-serif"
+          fontWeight="medium"
+          fontSize="14px"
+          color="#131619"
+          lineHeight="1.4"
+        >
+          {PREVIEW_TITLE}
+        </Text>
+        <Text
+          fontFamily="sans-serif"
+          fontWeight="normal"
+          fontSize="xs"
+          color="#656E7B"
+          lineHeight="150%"
+          mt={1}
+        >
+          {PREVIEW_BODY}
+        </Text>
+        <Text
+          fontFamily="sans-serif"
+          fontWeight="normal"
+          fontSize="xs"
+          color="#656E7B"
+          lineHeight="150%"
+          mt={4}
+        >
+          Feedback is welcome at{" "}
+          <Link
+            color="#0049AA"
+            textDecoration="underline"
+            href={`mailto:${PREVIEW_FEEDBACK_EMAIL}`}
+          >
+            {PREVIEW_FEEDBACK_EMAIL}
+          </Link>
+          .
+          <br />
+          Visit the{" "}
+          <Link
+            color="#0049AA"
+            textDecoration="underline"
+            href={PREVIEW_HELP_CENTER_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Help Center
+          </Link>{" "}
+          to learn more about the preview.
+        </Text>
+      </Box>
+
+      {/* Footer separator */}
+      <Box borderTop="1px solid #E0E2E5" pt={3}>
+        <Flex gap={3} flexWrap="wrap">
+          {PREVIEW_LINKS.map((link) => (
+            <a
+              key={link.label}
+              href={link.href}
+              target="_blank"
+              rel="noopener noreferrer"
+              style={{
+                display: "inline-flex",
+                alignItems: "center",
+                gap: "4px",
+                fontFamily: "sans-serif",
+                fontWeight: 400,
+                fontSize: "12px",
+                lineHeight: "150%",
+                color: "#0049AA",
+                textDecoration: "none",
+              }}
+            >
+              <ArrowSquareOutIcon size={16} />
+              {link.label}
+            </a>
+          ))}
+        </Flex>
+      </Box>
+    </Box>
+  );
+}

--- a/app/constants/preview-content.ts
+++ b/app/constants/preview-content.ts
@@ -1,0 +1,21 @@
+export const PREVIEW_TITLE = "Preview Release";
+
+export const PREVIEW_BODY =
+  "This is an experimental preview of Global Nature Watch. Results are grounded in trusted datasets, but AI summaries can be incomplete or incorrect. Verify important findings with source data.";
+
+export const PREVIEW_FEEDBACK_EMAIL = "landcarbonlab@wri.org";
+
+export const PREVIEW_HELP_CENTER_URL = "https://help.globalnaturewatch.org/";
+
+export const PREVIEW_LINKS = [
+  {
+    label: "Methodology",
+    href: "https://help.globalnaturewatch.org/methodology",
+  },
+  { label: "Datasets", href: "https://help.globalnaturewatch.org/datasets" },
+  { label: "Accuracy", href: "https://help.globalnaturewatch.org/accuracy" },
+  {
+    label: "Known Issues",
+    href: "https://help.globalnaturewatch.org/known-issues",
+  },
+];


### PR DESCRIPTION
Please check the type of change your PR introduces:
- [x] Feature


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Once the DisclaimerPanel is dismissed, there is no way to retrieve the preview information (title, body, feedback email, help links). The PREVIEW badge in the page header is a static, non-interactive label and the disclaimer content is hardcoded inline in both the panel and the badge area.

Issue Number: 906


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

Extracted all preview-related copy (title, body, feedback email, help center URL, and footer links) into a shared preview-content.ts so both the disclaimer panel and the new info popover stay in sync.
After the DisclaimerPanel is dismissed, the PREVIEW badge in PageHeader becomes a clickable button that shows an InfoIcon indicator.
Clicking the badge opens a new PreviewInfoPanel popover (positioned below the badge) that reproduces the preview title, body, feedback email, help center link, and the footer resource links (Methodology, Datasets, Accuracy, Known Issues).
The popover closes when clicking outside it or via its own close (×) button. DisclaimerPanel now dispatches a gnw-disclaimer-dismissed window event so PageHeader can reactively update its state without a page reload.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Demo
<img width="619" height="389" alt="preview message panel" src="https://github.com/user-attachments/assets/9306f999-b04d-4758-ab27-2c60d4109f10" />
