### PR TITLE
PZB-839:  Move chat controls to header

### DIFF
--- a/app/ChatPanelHeader.tsx
+++ b/app/ChatPanelHeader.tsx
@@ -1,7 +1,6 @@
-import { useCallback, useMemo } from "react";
-import { Flex, Menu, Button, Portal, Text } from "@chakra-ui/react";
+import { Flex, Text } from "@chakra-ui/react";
 import {
-  CaretDownIcon,
+  SparkleIcon,
   ChartLineIcon,
   ListNumbersIcon,
   ChartBarIcon,
@@ -11,9 +10,6 @@ import {
   ChartScatterIcon,
   ChartPolarIcon,
 } from "@phosphor-icons/react";
-
-import { Tooltip } from "./components/ui/tooltip";
-import useChatStore from "./store/chatStore";
 
 export const WidgetIcons = {
   line: <ChartLineIcon />,
@@ -29,152 +25,31 @@ export const WidgetIcons = {
 };
 
 function ChatPanelHeader() {
-  const { messages } = useChatStore();
-
-  // Build list of widget anchors from chat messages
-  const widgetAnchors = useMemo(() => {
-    return messages.flatMap((m) =>
-      m.type === "widget" && m.widgets
-        ? m.widgets
-            .filter((w) => w.type !== "dataset-card")
-            .map((w, idx) => ({
-              id: `widget-${m.id}-${idx}`,
-              title: w.title || `Insight ${idx + 1}`,
-              type: w.type,
-              timestamp: m.timestamp,
-            }))
-        : []
-    );
-  }, [messages]);
-
-  const formatWidgetMeta = useCallback((isoTs?: string) => {
-    if (!isoTs) return "";
-    const d = new Date(isoTs);
-    const time = d.toLocaleTimeString([], {
-      hour: "2-digit",
-      minute: "2-digit",
-    });
-    const day = d.toLocaleDateString([], { day: "2-digit", month: "short" });
-    return `${time} on ${day}`;
-  }, []);
-
-  const scrollToWidget = useCallback((anchorId: string) => {
-    const el = document.getElementById(anchorId);
-    if (el) {
-      el.scrollIntoView({ behavior: "smooth", block: "start" });
-    }
-  }, []);
-
   return (
     <Flex
+      h="40px"
+      mt="3"
+      mx="3"
+      px="3"
+      py="1"
+      bg="#f4f5f6"
+      rounded="sm"
       alignItems="center"
-      justifyContent="flex-end"
-      px="4"
-      py="2"
-      gap="1"
-      h="14"
-      bg="bg"
-      color="fg"
-      boxShadow="sm"
+      gap="2"
       hideBelow="md"
-      zIndex={100}
     >
-      {/* Insights dropdown */}
-      {widgetAnchors.length === 0 ? (
-        <Tooltip content="Ask a question to generate insights" showArrow>
-          <span style={{ display: "inline-flex" }}>
-            <Button
-              variant="ghost"
-              color="primary.fg"
-              borderColor="primary.subtle"
-              rounded="sm"
-              h={6}
-              bgGradient="LCLGradientLight"
-              size="xs"
-              disabled
-            >
-              Go to insight
-              <CaretDownIcon />
-            </Button>
-          </span>
-        </Tooltip>
-      ) : (
-        <Menu.Root>
-          <Menu.Trigger asChild>
-            <Button
-              variant="ghost"
-              color="primary.fg"
-              borderColor="primary.subtle"
-              rounded="sm"
-              h={6}
-              bgGradient="LCLGradientLight"
-              fontWeight="semibold"
-              _hover={{
-                gradientFrom: "primary.400/30",
-                gradientTo: "secondary.400/30",
-              }}
-              size="xs"
-            >
-              Go to insight
-              <CaretDownIcon size="12" weight="bold" />
-            </Button>
-          </Menu.Trigger>
-          <Portal>
-            <Menu.Positioner>
-              <Menu.Content maxH="320px" overflowY="auto">
-                {widgetAnchors.map((w) => (
-                  <Menu.Item
-                    key={w.id}
-                    value={w.id}
-                    onSelect={() => {
-                      scrollToWidget(w.id);
-                    }}
-                    role="group"
-                    className="group"
-                    cursor="pointer"
-                  >
-                    <Flex
-                      align="center"
-                      gap={2}
-                      maxW="360px"
-                      fontSize="md"
-                      fontWeight="medium"
-                      color="primary.fg"
-                    >
-                      {WidgetIcons[w.type]}
-                      <Text
-                        as="span"
-                        flex="1"
-                        minW={0}
-                        whiteSpace="nowrap"
-                        overflow="hidden"
-                        textOverflow="ellipsis"
-                        fontSize="xs"
-                      >
-                        {w.title}
-                      </Text>
-                      <Text
-                        as="span"
-                        flexShrink={0}
-                        ml="2"
-                        display="none"
-                        fontSize="xs"
-                        fontWeight="normal"
-                        color="fg.muted"
-                        _groupHover={{
-                          display: "inline",
-                        }}
-                      >
-                        {formatWidgetMeta(w.timestamp)}
-                      </Text>
-                    </Flex>
-                  </Menu.Item>
-                ))}
-              </Menu.Content>
-            </Menu.Positioner>
-          </Portal>
-        </Menu.Root>
-      )}
+      <SparkleIcon size={16} color="#656e7b" />
+      <Text
+        fontFamily="mono"
+        fontSize="10px"
+        lineHeight="16px"
+        fontWeight="normal"
+        letterSpacing="0.3px"
+        textTransform="uppercase"
+        color="#656e7b"
+      >
+        AI Assistant
+      </Text>
     </Flex>
   );
 }

--- a/app/ChatPanelHeader.tsx
+++ b/app/ChatPanelHeader.tsx
@@ -1,28 +1,5 @@
 import { Flex, Text } from "@chakra-ui/react";
-import {
-  SparkleIcon,
-  ChartLineIcon,
-  ListNumbersIcon,
-  ChartBarIcon,
-  ChartPieSliceIcon,
-  PresentationChartIcon,
-  StackIcon,
-  ChartScatterIcon,
-  ChartPolarIcon,
-} from "@phosphor-icons/react";
-
-export const WidgetIcons = {
-  line: <ChartLineIcon />,
-  table: <ListNumbersIcon />,
-  bar: <ChartBarIcon />,
-  "stacked-bar": <ChartBarIcon />,
-  "grouped-bar": <ChartBarIcon />,
-  pie: <ChartPieSliceIcon />,
-  insight: <PresentationChartIcon />,
-  "dataset-card": <StackIcon />,
-  scatter: <ChartScatterIcon />,
-  area: <ChartPolarIcon />,
-};
+import { SparkleIcon } from "@phosphor-icons/react";
 
 function ChatPanelHeader() {
   return (

--- a/app/ChatPanelHeader.tsx
+++ b/app/ChatPanelHeader.tsx
@@ -9,13 +9,13 @@ function ChatPanelHeader() {
       mx="3"
       px="3"
       py="1"
-      bg="#f4f5f6"
+      bg="neutral.200"
       rounded="sm"
       alignItems="center"
       gap="2"
       hideBelow="md"
     >
-      <SparkleIcon size={16} color="#656e7b" />
+      <SparkleIcon size={16} color="var(--chakra-colors-neutral-500)" />
       <Text
         fontFamily="mono"
         fontSize="10px"
@@ -23,7 +23,7 @@ function ChatPanelHeader() {
         fontWeight="normal"
         letterSpacing="0.3px"
         textTransform="uppercase"
-        color="#656e7b"
+        color="neutral.500"
       >
         AI Assistant
       </Text>

--- a/app/ChatPanelHeader.tsx
+++ b/app/ChatPanelHeader.tsx
@@ -1,9 +1,7 @@
 import { useCallback, useMemo } from "react";
-import { Flex, IconButton, Menu, Button, Portal, Text } from "@chakra-ui/react";
+import { Flex, Menu, Button, Portal, Text } from "@chakra-ui/react";
 import {
   CaretDownIcon,
-  NotePencilIcon,
-  SidebarIcon,
   ChartLineIcon,
   ListNumbersIcon,
   ChartBarIcon,
@@ -13,12 +11,9 @@ import {
   ChartScatterIcon,
   ChartPolarIcon,
 } from "@phosphor-icons/react";
-import Link from "next/link";
 
 import { Tooltip } from "./components/ui/tooltip";
-import useSidebarStore from "./store/sidebarStore";
 import useChatStore from "./store/chatStore";
-import ThreadActionsMenu from "./components/ThreadActionsMenu";
 
 export const WidgetIcons = {
   line: <ChartLineIcon />,
@@ -34,13 +29,7 @@ export const WidgetIcons = {
 };
 
 function ChatPanelHeader() {
-  const { sideBarVisible, toggleSidebar, getThreadById } = useSidebarStore();
-  const { currentThreadId, messages } = useChatStore();
-
-  const currentThread = getThreadById(currentThreadId);
-  const currentThreadName = currentThread
-    ? currentThread.name
-    : "New Conversation";
+  const { messages } = useChatStore();
 
   // Build list of widget anchors from chat messages
   const widgetAnchors = useMemo(() => {
@@ -79,7 +68,7 @@ function ChatPanelHeader() {
   return (
     <Flex
       alignItems="center"
-      justifyContent="space-between"
+      justifyContent="flex-end"
       px="4"
       py="2"
       gap="1"
@@ -90,77 +79,6 @@ function ChatPanelHeader() {
       hideBelow="md"
       zIndex={100}
     >
-      {!sideBarVisible && (
-        <Tooltip
-          content="Open sidebar"
-          positioning={{ placement: "right" }}
-          showArrow
-        >
-          <IconButton
-            size="sm"
-            variant="ghost"
-            color="fg.muted"
-            onClick={toggleSidebar}
-          >
-            <SidebarIcon />
-          </IconButton>
-        </Tooltip>
-      )}
-      {currentThreadId && currentThread ? (
-        <ThreadActionsMenu thread={currentThread}>
-          <Button
-            variant="ghost"
-            size="sm"
-            flexShrink="1"
-            mr="auto"
-            px={2}
-            minW={0}
-            justifyContent="flex-start"
-          >
-            <Flex align="center" gap={1} w="100%" minW={0}>
-              <Tooltip content={currentThreadName} showArrow>
-                <Text
-                  as="span"
-                  flex="1"
-                  minW={0}
-                  whiteSpace="nowrap"
-                  overflow="hidden"
-                  textOverflow="ellipsis"
-                  fontWeight="normal"
-                >
-                  {currentThreadName}
-                </Text>
-              </Tooltip>
-              <CaretDownIcon />
-            </Flex>
-          </Button>
-        </ThreadActionsMenu>
-      ) : (
-        <Button
-          variant="ghost"
-          size="sm"
-          flexShrink="1"
-          mr="auto"
-          px={2}
-          minW={0}
-          justifyContent="flex-start"
-        >
-          <Tooltip content={currentThreadName} showArrow>
-            <Text
-              as="span"
-              flex="1"
-              minW={0}
-              whiteSpace="nowrap"
-              overflow="hidden"
-              textOverflow="ellipsis"
-              fontWeight="normal"
-            >
-              {currentThreadName}
-            </Text>
-          </Tooltip>
-        </Button>
-      )}
-
       {/* Insights dropdown */}
       {widgetAnchors.length === 0 ? (
         <Tooltip content="Ask a question to generate insights" showArrow>
@@ -256,15 +174,6 @@ function ChatPanelHeader() {
             </Menu.Positioner>
           </Portal>
         </Menu.Root>
-      )}
-      {!sideBarVisible && (
-        <Tooltip content="New conversation" showArrow>
-          <IconButton asChild variant="ghost" size="sm">
-            <Link href="/app" aria-label="New conversation">
-              <NotePencilIcon />
-            </Link>
-          </IconButton>
-        </Tooltip>
       )}
     </Flex>
   );

--- a/app/components/PageHeader.tsx
+++ b/app/components/PageHeader.tsx
@@ -54,9 +54,9 @@ function PageHeader() {
     <Flex
       alignItems="center"
       justifyContent="space-between"
-      px={{ base: 3, md: 5 }}
-      py="2"
-      h={{ base: 10, md: 12 }}
+      gap="4"
+      px="3"
+      h="40px"
       bg={isPrototype ? "#d1d5db" : "primary.solid"}
       color={isPrototype ? "#1f2937" : "fg.inverted"}
       zIndex={1300}
@@ -86,36 +86,43 @@ function PageHeader() {
             color={isPrototype ? "#f3f4f6" : undefined}
             letterSpacing="wider"
             variant="solid"
-            size="xs"
+            fontSize="10px"
+            lineHeight="16px"
+            fontWeight="medium"
+            px="1"
+            py="0.5"
+            rounded="sm"
           >
             {isPrototype ? "PROTOTYPE" : "PREVIEW"}
           </Badge>
         </Flex>
-        <Flex gap="1" alignItems="center" hideBelow="md" minW={0}>
+        <Flex gap="3" alignItems="center" hideBelow="md" minW={0}>
           <Tooltip content="Conversation history" showArrow>
             <IconButton
-              size="sm"
+              size="xs"
               variant="ghost"
               color={inverseColor}
               _hover={{ bg: inverseHoverBg }}
               onClick={toggleSidebar}
               aria-label="Toggle conversation history"
             >
-              <ClockCounterClockwiseIcon />
+              <ClockCounterClockwiseIcon size={16} />
             </IconButton>
           </Tooltip>
-          {currentThreadId && currentThread ? (
+          {currentThread ? (
             <ThreadActionsMenu thread={currentThread}>
               <Button
                 variant="ghost"
-                size="sm"
+                size="xs"
                 color={inverseColor}
                 _hover={{ bg: inverseHoverBg }}
-                px={2}
+                px={1}
                 minW={0}
                 maxW="280px"
                 justifyContent="flex-start"
                 fontWeight="normal"
+                fontSize="xs"
+                gap="1"
               >
                 <Tooltip content={currentThreadName} showArrow>
                   <Text
@@ -129,15 +136,15 @@ function PageHeader() {
                     {currentThreadName}
                   </Text>
                 </Tooltip>
-                <CaretDownIcon />
+                <CaretDownIcon size={12} />
               </Button>
             </ThreadActionsMenu>
           ) : (
             <Text
-              fontSize="sm"
+              fontSize="xs"
               color={inverseColor}
               opacity={0.8}
-              px={2}
+              px={1}
               maxW="240px"
               whiteSpace="nowrap"
               overflow="hidden"
@@ -149,13 +156,13 @@ function PageHeader() {
           <Tooltip content="New conversation" showArrow>
             <IconButton
               asChild
-              size="sm"
+              size="xs"
               variant="ghost"
               color={inverseColor}
               _hover={{ bg: inverseHoverBg }}
             >
               <Link href="/app" aria-label="New conversation">
-                <PlusIcon />
+                <PlusIcon size={16} />
               </Link>
             </IconButton>
           </Tooltip>
@@ -184,9 +191,14 @@ function PageHeader() {
             bg={isPrototype ? "#9ca3af" : undefined}
             color={isPrototype ? "#1f2937" : undefined}
             _hover={{ bg: isPrototype ? "#6b7280" : "primary.fg" }}
-            size="sm"
+            h="40px"
+            px="2"
+            gap="2"
+            fontSize="xs"
+            fontWeight="medium"
+            rounded="sm"
           >
-            <LifebuoyIcon />
+            <LifebuoyIcon size={16} />
             Help
           </Button>
         </Link>
@@ -195,8 +207,10 @@ function PageHeader() {
           size="xs"
           min={0}
           max={100}
-          value={(usedPrompts / totalPrompts) * 100}
-          minW="6rem"
+          value={totalPrompts > 0 ? (usedPrompts / totalPrompts) * 100 : 0}
+          minW="100px"
+          mt="1"
+          mb="2"
           textAlign="center"
           rounded="full"
           colorPalette="primary"
@@ -204,18 +218,12 @@ function PageHeader() {
           <Progress.Label
             mb="0.5"
             fontSize="xs"
+            lineHeight="1.5"
             fontWeight="normal"
+            whiteSpace="nowrap"
             color={isPrototype ? "#6b7280" : "primary.100"}
           >
-            {usedPrompts}/
-            {totalPrompts > 5000 ? (
-              <Text as="span" fontSize="xl" verticalAlign="bottom">
-                ∞
-              </Text>
-            ) : (
-              totalPrompts
-            )}{" "}
-            daily prompts
+            {usedPrompts} / {totalPrompts > 5000 ? "∞" : totalPrompts} prompts
             <Tooltip
               content={
                 totalPrompts > 5000
@@ -231,7 +239,7 @@ function PageHeader() {
                 verticalAlign="text-bottom"
                 cursor="help"
               >
-                <InfoIcon />
+                <InfoIcon size={12} />
               </Text>
             </Tooltip>
           </Progress.Label>
@@ -251,9 +259,14 @@ function PageHeader() {
                 bg={isPrototype ? "#9ca3af" : undefined}
                 color={isPrototype ? "#1f2937" : undefined}
                 _hover={{ bg: isPrototype ? "#6b7280" : "primary.fg" }}
-                size="sm"
+                h="40px"
+                px="2"
+                gap="2"
+                fontSize="xs"
+                fontWeight="medium"
+                rounded="sm"
               >
-                <UserIcon />
+                <UserIcon size={16} />
                 <Text truncate maxW="180px">
                   {userEmail || "User name"}
                 </Text>

--- a/app/components/PageHeader.tsx
+++ b/app/components/PageHeader.tsx
@@ -4,6 +4,7 @@ import {
   Flex,
   Heading,
   Button,
+  IconButton,
   Progress,
   Badge,
   Menu,
@@ -13,8 +14,11 @@ import {
 } from "@chakra-ui/react";
 import LclLogo from "./LclLogo";
 import {
+  CaretDownIcon,
+  ClockCounterClockwiseIcon,
   GearSixIcon,
   LifebuoyIcon,
+  PlusIcon,
   SignOutIcon,
   UserIcon,
   InfoIcon,
@@ -22,6 +26,9 @@ import {
 import { Tooltip } from "./ui/tooltip";
 
 import useAuthStore from "../store/authStore";
+import useChatStore from "../store/chatStore";
+import useSidebarStore from "../store/sidebarStore";
+import ThreadActionsMenu from "./ThreadActionsMenu";
 import Link from "next/link";
 import { useLogout } from "@/app/hooks/useLogout";
 
@@ -30,7 +37,19 @@ const isPrototype = process.env.NEXT_PUBLIC_PROTOTYPE_MODE === "true";
 function PageHeader() {
   const { userEmail, usedPrompts, totalPrompts, isAuthenticated } =
     useAuthStore();
+  const { toggleSidebar, getThreadById } = useSidebarStore();
+  const { currentThreadId } = useChatStore();
   const { logout } = useLogout();
+
+  const currentThread = currentThreadId
+    ? getThreadById(currentThreadId)
+    : undefined;
+  const currentThreadName = currentThread
+    ? currentThread.name
+    : "New Conversation";
+
+  const inverseColor = isPrototype ? "#1f2937" : "fg.inverted";
+  const inverseHoverBg = isPrototype ? "#6b7280" : "primary.fg";
   return (
     <Flex
       alignItems="center"
@@ -43,37 +62,104 @@ function PageHeader() {
       zIndex={1300}
       position="relative"
     >
-      <Flex gap="2" alignItems="center">
-        <ChakraLink
-          as={Link}
-          href="/"
-          display="flex"
-          transition="opacity 0.24s ease"
-          _hover={{ opacity: 0.8 }}
-        >
-          <LclLogo
-            width={16}
-            avatarOnly
-            fill={isPrototype ? "#1f2937" : "white"}
-          />
-          <Heading
-            as="h1"
-            size="sm"
-            color={isPrototype ? "#1f2937" : "fg.inverted"}
+      <Flex gap="5" alignItems="center" minW={0}>
+        <Flex gap="2" alignItems="center">
+          <ChakraLink
+            as={Link}
+            href="/"
+            display="flex"
+            transition="opacity 0.24s ease"
+            _hover={{ opacity: 0.8 }}
           >
-            Global Nature Watch
-          </Heading>
-        </ChakraLink>
-        <Badge
-          colorPalette={isPrototype ? "gray" : "primary"}
-          bg={isPrototype ? "#1f2937" : "primary.800"}
-          color={isPrototype ? "#f3f4f6" : undefined}
-          letterSpacing="wider"
-          variant="solid"
-          size="xs"
-        >
-          {isPrototype ? "PROTOTYPE" : "PREVIEW"}
-        </Badge>
+            <LclLogo
+              width={16}
+              avatarOnly
+              fill={isPrototype ? "#1f2937" : "white"}
+            />
+            <Heading as="h1" size="sm" color={inverseColor}>
+              Global Nature Watch
+            </Heading>
+          </ChakraLink>
+          <Badge
+            colorPalette={isPrototype ? "gray" : "primary"}
+            bg={isPrototype ? "#1f2937" : "primary.800"}
+            color={isPrototype ? "#f3f4f6" : undefined}
+            letterSpacing="wider"
+            variant="solid"
+            size="xs"
+          >
+            {isPrototype ? "PROTOTYPE" : "PREVIEW"}
+          </Badge>
+        </Flex>
+        <Flex gap="1" alignItems="center" hideBelow="md" minW={0}>
+          <Tooltip content="Conversation history" showArrow>
+            <IconButton
+              size="sm"
+              variant="ghost"
+              color={inverseColor}
+              _hover={{ bg: inverseHoverBg }}
+              onClick={toggleSidebar}
+              aria-label="Toggle conversation history"
+            >
+              <ClockCounterClockwiseIcon />
+            </IconButton>
+          </Tooltip>
+          {currentThreadId && currentThread ? (
+            <ThreadActionsMenu thread={currentThread}>
+              <Button
+                variant="ghost"
+                size="sm"
+                color={inverseColor}
+                _hover={{ bg: inverseHoverBg }}
+                px={2}
+                minW={0}
+                maxW="280px"
+                justifyContent="flex-start"
+                fontWeight="normal"
+              >
+                <Tooltip content={currentThreadName} showArrow>
+                  <Text
+                    as="span"
+                    flex="1"
+                    minW={0}
+                    whiteSpace="nowrap"
+                    overflow="hidden"
+                    textOverflow="ellipsis"
+                  >
+                    {currentThreadName}
+                  </Text>
+                </Tooltip>
+                <CaretDownIcon />
+              </Button>
+            </ThreadActionsMenu>
+          ) : (
+            <Text
+              fontSize="sm"
+              color={inverseColor}
+              opacity={0.8}
+              px={2}
+              maxW="240px"
+              whiteSpace="nowrap"
+              overflow="hidden"
+              textOverflow="ellipsis"
+            >
+              {currentThreadName}
+            </Text>
+          )}
+          <Tooltip content="New conversation" showArrow>
+            <IconButton
+              asChild
+              size="sm"
+              variant="ghost"
+              color={inverseColor}
+              _hover={{ bg: inverseHoverBg }}
+            >
+              <Link href="/app" aria-label="New conversation">
+                <PlusIcon />
+              </Link>
+            </IconButton>
+          </Tooltip>
+        </Flex>
       </Flex>
       {isPrototype && (
         <Text

--- a/app/components/PageHeader.tsx
+++ b/app/components/PageHeader.tsx
@@ -96,7 +96,7 @@ function PageHeader() {
             {isPrototype ? "PROTOTYPE" : "PREVIEW"}
           </Badge>
         </Flex>
-        <Flex gap="3" alignItems="center" hideBelow="md" minW={0}>
+        <Flex gap="1" alignItems="center" hideBelow="md" minW={0}>
           <Tooltip content="Conversation history" showArrow>
             <IconButton
               size="xs"
@@ -116,7 +116,7 @@ function PageHeader() {
                 size="xs"
                 color={inverseColor}
                 _hover={{ bg: inverseHoverBg }}
-                px={1}
+                px={0}
                 minW={0}
                 maxW="280px"
                 justifyContent="flex-start"
@@ -144,7 +144,7 @@ function PageHeader() {
               fontSize="xs"
               color={inverseColor}
               opacity={0.8}
-              px={1}
+              px={0}
               maxW="240px"
               whiteSpace="nowrap"
               overflow="hidden"

--- a/app/components/PageHeader.tsx
+++ b/app/components/PageHeader.tsx
@@ -223,7 +223,7 @@ function PageHeader() {
             whiteSpace="nowrap"
             color={isPrototype ? "#6b7280" : "primary.100"}
           >
-            {usedPrompts} / {totalPrompts > 5000 ? "∞" : totalPrompts} prompts
+            {usedPrompts} / {totalPrompts > 5000 ? "∞" : totalPrompts} daily prompts
             <Tooltip
               content={
                 totalPrompts > 5000

--- a/app/components/WidgetMessage.tsx
+++ b/app/components/WidgetMessage.tsx
@@ -23,7 +23,7 @@ import { InsightWidget, DatasetInfo } from "@/app/types/chat";
 import TableWidget from "./widgets/TableWidget";
 import DatasetCardWidget from "./widgets/DatasetCardWidget";
 import ChartWidget from "./widgets/ChartWidget";
-import { WidgetIcons } from "../ChatPanelHeader";
+import { WidgetIcons } from "../utils/widgetIcons";
 import InsightProvenanceDrawer from "./InsightProvenanceDrawer";
 import VisualizationDisclaimer from "./VisualizationDisclaimer";
 import WidgetErrorBoundary from "./widgets/WidgetErrorBoundary";

--- a/app/utils/widgetIcons.tsx
+++ b/app/utils/widgetIcons.tsx
@@ -5,6 +5,7 @@ import {
   ChartPolarIcon,
   ChartScatterIcon,
   ListNumbersIcon,
+  PresentationChartIcon,
   StackIcon,
 } from "@phosphor-icons/react";
 import type { Icon } from "@phosphor-icons/react";
@@ -13,9 +14,6 @@ import type { InsightWidget } from "@/app/types/chat";
 /**
  * Maps an InsightWidget type to the Phosphor icon *component* (not an
  * instance), so callers can pass their own size/color/weight props.
- *
- * Mirrors the `WidgetIcons` element map in ChatPanelHeader.tsx — kept in
- * sync manually for now since the two have different ergonomics.
  */
 export const WidgetIconComponent: Record<InsightWidget["type"], Icon> = {
   line: ChartLineIcon,
@@ -27,4 +25,18 @@ export const WidgetIconComponent: Record<InsightWidget["type"], Icon> = {
   scatter: ChartScatterIcon,
   table: ListNumbersIcon,
   "dataset-card": StackIcon,
+};
+
+/** Element-instance map for inline rendering without size/color overrides. */
+export const WidgetIcons = {
+  line: <ChartLineIcon />,
+  table: <ListNumbersIcon />,
+  bar: <ChartBarIcon />,
+  "stacked-bar": <ChartBarIcon />,
+  "grouped-bar": <ChartBarIcon />,
+  pie: <ChartPieSliceIcon />,
+  insight: <PresentationChartIcon />,
+  "dataset-card": <StackIcon />,
+  scatter: <ChartScatterIcon />,
+  area: <ChartPolarIcon />,
 };


### PR DESCRIPTION
Move chat controls from chat to the header and aligns styles with upcoming changes.

<img width="1920" height="991" alt="Screenshot 2026-06-01 at 13 06 23" src="https://github.com/user-attachments/assets/4acee0d4-c032-4315-b2b9-bfb62d3dadc9" />

- Moves Conversation History, Conversation Name + sharing, New conversation to header
- Updated header styles (retaining Blue primary colour)
- Removes "Go to Insights" dropdown (and tidies up)
- Adds new chat `AI ASSISTANT` header aligned with upcoming chat pane changes