### PR TITLE
PZB-904: Add Area Card to chat on AOI selection

### DIFF
--- a/app/components/AreaCard.tsx
+++ b/app/components/AreaCard.tsx
@@ -1,0 +1,242 @@
+"use client";
+import { Box, Image } from "@chakra-ui/react";
+import { CrosshairIcon, PolygonIcon } from "@phosphor-icons/react";
+import { AOISelection } from "@/app/types/chat";
+import { Tooltip } from "./ui/tooltip";
+import { InfoCard } from "./InfoCard";
+import useMapStore from "@/app/store/mapStore";
+import { unionAoiBboxes } from "@/app/utils/bboxUtils";
+import { FeatureCollection, Feature, Geometry } from "geojson";
+import { useState } from "react";
+
+const MAPBOX_TOKEN = process.env.NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN;
+// Same light style the app uses for its basemap
+const STATIC_STYLE = "devseed/cmazl5ws500bz01scaa27dqi4";
+// Max safe URL length for Mapbox Static API
+const MAX_URL_LENGTH = 8192;
+
+/**
+ * Round all coordinates in a geometry to `precision` decimal places.
+ */
+function reduceCoordPrecision(geom: Geometry, precision: number): Geometry {
+  const round = (n: number) => parseFloat(n.toFixed(precision));
+  const roundRing = (ring: number[][]): number[][] =>
+    ring.map((c) => c.map(round));
+  const roundPolygon = (coords: number[][][]): number[][][] =>
+    coords.map(roundRing);
+
+  switch (geom.type) {
+    case "Polygon":
+      return { ...geom, coordinates: roundPolygon(geom.coordinates) };
+    case "MultiPolygon":
+      return { ...geom, coordinates: geom.coordinates.map(roundPolygon) };
+    default:
+      return geom;
+  }
+}
+
+/**
+ * Subsample a ring to at most `maxPoints` evenly-spaced vertices,
+ * always preserving the closing point.
+ */
+function decimateRing(ring: number[][], maxPoints: number): number[][] {
+  if (ring.length <= maxPoints) return ring;
+  const step = (ring.length - 1) / (maxPoints - 1);
+  const result: number[][] = [];
+  for (let i = 0; i < maxPoints - 1; i++) {
+    result.push(ring[Math.round(i * step)]);
+  }
+  result.push(ring[ring.length - 1]);
+  return result;
+}
+
+/**
+ * Reduce geometry to a single exterior ring suitable for a small thumbnail:
+ * - MultiPolygon → largest sub-polygon only
+ * - Only the exterior ring (holes removed)
+ * - Decimated to `maxPoints` vertices
+ */
+function thumbnailGeometry(geom: Geometry, maxPoints = 200): Geometry {
+  if (geom.type === "Polygon") {
+    return {
+      type: "Polygon",
+      coordinates: [decimateRing(geom.coordinates[0], maxPoints)],
+    };
+  }
+  if (geom.type === "MultiPolygon") {
+    const largest = geom.coordinates.reduce((best, poly) =>
+      poly[0].length > best[0].length ? poly : best
+    );
+    return {
+      type: "Polygon",
+      coordinates: [decimateRing(largest[0], maxPoints)],
+    };
+  }
+  return geom;
+}
+
+function buildStaticMapUrl(
+  aoiSelection: AOISelection,
+  geometry: FeatureCollection | Feature | Geometry | null,
+  size = 80
+): string | null {
+  if (!MAPBOX_TOKEN) return null;
+  const bbox = unionAoiBboxes(aoiSelection.aois);
+  if (!bbox) return null;
+  const [west, south, east, north] = bbox;
+
+  const w = Math.max(west, -180).toFixed(4);
+  const s = Math.max(south, -85).toFixed(4);
+  const e = Math.min(east, 180).toFixed(4);
+  const n = Math.min(north, 85).toFixed(4);
+
+  const boundsPath = `[${w},${s},${e},${n}]/${size}x${size}@2x`;
+  const qs = `?access_token=${MAPBOX_TOKEN}&attribution=false&logo=false`;
+  const baseUrl = `https://api.mapbox.com/styles/v1/${STATIC_STYLE}/static`;
+
+  // Try to add a GeoJSON boundary overlay, aggressively simplified for URL length.
+  if (geometry) {
+    let rawGeom: Geometry | null | undefined;
+    if (geometry.type === "FeatureCollection") {
+      rawGeom = (geometry as FeatureCollection).features[0]?.geometry;
+    } else if (geometry.type === "Feature") {
+      rawGeom = (geometry as Feature).geometry;
+    } else {
+      // Already a raw Geometry (Polygon, MultiPolygon, etc.)
+      rawGeom = geometry as Geometry;
+    }
+    if (rawGeom) {
+      // Decimate + reduce precision; retry with fewer points if still too long
+      for (const maxPoints of [200, 100, 50]) {
+        const geom = reduceCoordPrecision(
+          thumbnailGeometry(rawGeom, maxPoints),
+          2
+        );
+        const overlayGeoJson = {
+          type: "Feature",
+          properties: {
+            stroke: "#0A3785",
+            "stroke-width": 1,
+            "fill-opacity": 0,
+          },
+          geometry: geom,
+        };
+        const encoded = encodeURIComponent(JSON.stringify(overlayGeoJson));
+        const withOverlay = `${baseUrl}/geojson(${encoded})/${boundsPath}${qs}`;
+        if (withOverlay.length <= MAX_URL_LENGTH) {
+          return withOverlay;
+        }
+      }
+    }
+  }
+
+  // Fall back to bounds-only (no overlay)
+  return `${baseUrl}/${boundsPath}${qs}`;
+}
+
+function getAreaTypeLabel(aoiSelection: AOISelection): string {
+  const aoi = aoiSelection.aois[0];
+  if (!aoi) return "";
+  if (aoi.subtype === "custom-area") return "Custom Polygon";
+  switch (aoi.source) {
+    case "gadm":
+      return "Administrative Areas";
+    case "kba":
+      return "Key Biodiversity Areas";
+    case "wdpa":
+      return "Protected Areas";
+    case "landmark":
+      return "Indigenous Territories";
+    default:
+      return aoi.source
+        ? aoi.source.charAt(0).toUpperCase() + aoi.source.slice(1)
+        : "";
+  }
+}
+
+export interface AreaCardProps {
+  aoiSelection: AOISelection;
+}
+
+export function AreaCard({ aoiSelection }: AreaCardProps) {
+  const { flyToBounds, flyToGeoJsonWithRetry, geoJsonRegistry } = useMapStore();
+  const [imgError, setImgError] = useState(false);
+
+  // Find the first matching geometry from the map registry
+  const registryEntry = aoiSelection.aois
+    .map((aoi) =>
+      geoJsonRegistry.find(
+        (e) => e.ref.name === aoi.name && e.ref.source === aoi.source
+      )
+    )
+    .find(Boolean);
+  const geometry =
+    registryEntry?.data ?? aoiSelection.aois[0]?.geometry ?? null;
+
+  const staticMapUrl = buildStaticMapUrl(aoiSelection, geometry);
+  const showMap = staticMapUrl && !imgError;
+
+  const handleLocate = () => {
+    const unionBbox = unionAoiBboxes(aoiSelection.aois);
+    if (unionBbox) {
+      let east = unionBbox[2];
+      if (east > 180) east -= 360;
+      flyToBounds([
+        [unionBbox[0], unionBbox[1]],
+        [east, unionBbox[3]],
+      ]);
+      return;
+    }
+    const fallbackGeom = aoiSelection.aois[0]?.geometry;
+    if (fallbackGeom) {
+      flyToGeoJsonWithRetry(fallbackGeom);
+    }
+  };
+
+  const areaTypeLabel = getAreaTypeLabel(aoiSelection);
+
+  const thumbnail = showMap ? (
+    <Image
+      src={staticMapUrl!}
+      alt={aoiSelection.name}
+      width="80px"
+      height="80px"
+      objectFit="cover"
+      onError={() => setImgError(true)}
+    />
+  ) : (
+    <PolygonIcon size={32} color="#656E7B" />
+  );
+
+  const locateAction = (
+    <Tooltip
+      content="Center on map"
+      positioning={{ placement: "top" }}
+      showArrow
+      variant="dark"
+    >
+      <Box
+        as="button"
+        onClick={handleLocate}
+        display="inline-flex"
+        alignItems="center"
+        cursor="pointer"
+        flexShrink={0}
+      >
+        <CrosshairIcon size={16} color="#656E7B" />
+      </Box>
+    </Tooltip>
+  );
+
+  return (
+    <InfoCard
+      thumbnail={thumbnail}
+      thumbnailBg="gray.100"
+      typeLabel="AREA"
+      typeLabelColor="#2D6BE4"
+      title={aoiSelection.name}
+      description={areaTypeLabel || undefined}
+      titleActions={locateAction}
+    />
+  );
+}

--- a/app/components/AreaCard.tsx
+++ b/app/components/AreaCard.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { Box, Image } from "@chakra-ui/react";
+import { Image } from "@chakra-ui/react";
 import { CrosshairIcon, PolygonIcon } from "@phosphor-icons/react";
 import { AOISelection } from "@/app/types/chat";
 import { Tooltip } from "./ui/tooltip";
@@ -84,6 +84,9 @@ function buildStaticMapUrl(
   const bbox = unionAoiBboxes(aoiSelection.aois);
   if (!bbox) return null;
   const [west, south, east, north] = bbox;
+
+  // Static API can't render a dateline-crossing bbox camera; skip thumbnail.
+  if (east > 180) return null;
 
   const w = Math.max(west, -180).toFixed(4);
   const s = Math.max(south, -85).toFixed(4);
@@ -215,16 +218,22 @@ export function AreaCard({ aoiSelection }: AreaCardProps) {
       showArrow
       variant="dark"
     >
-      <Box
-        as="button"
+      <button
+        type="button"
+        aria-label="Center on map"
         onClick={handleLocate}
-        display="inline-flex"
-        alignItems="center"
-        cursor="pointer"
-        flexShrink={0}
+        style={{
+          display: "inline-flex",
+          alignItems: "center",
+          cursor: "pointer",
+          flexShrink: 0,
+          background: "transparent",
+          border: "none",
+          padding: 0,
+        }}
       >
         <CrosshairIcon size={16} color="#656E7B" />
-      </Box>
+      </button>
     </Tooltip>
   );
 

--- a/app/components/DatasetCard.tsx
+++ b/app/components/DatasetCard.tsx
@@ -1,13 +1,13 @@
-import { Card, Image, Text, useDisclosure } from "@chakra-ui/react";
+import { Image, useDisclosure } from "@chakra-ui/react";
 import { InfoIcon } from "@phosphor-icons/react";
 import { DatasetInfo } from "@/app/types/chat";
 import { DatasetInfoModal } from "./DatasetInfoModal";
+import { InfoCard } from "./InfoCard";
 import { Tooltip } from "./ui/tooltip";
 
 export type DatasetCardProps = {
   dataset: DatasetInfo;
   img?: string;
-  size?: "sm" | "md" | "lg";
   label?: string;
   labelColor?: string;
   selected?: boolean;
@@ -27,98 +27,42 @@ export function DatasetCard({
   const cardText =
     [dataset.cadence, dataset.geographic_coverage, dataset.provider]
       .filter(Boolean)
-      .join(" · ") || null;
+      .join(" · ") || undefined;
+
+  const thumbnail = (
+    <Image
+      objectFit="cover"
+      width="80px"
+      height="80px"
+      src={effectiveImg}
+      alt={dataset.dataset_name}
+    />
+  );
+
+  const infoAction = (
+    <Tooltip
+      content="Show dataset info"
+      positioning={{ placement: "top" }}
+      showArrow
+      variant="dark"
+    >
+      <InfoIcon cursor="pointer" size={16} color="#656E7B" onClick={onOpen} />
+    </Tooltip>
+  );
 
   return (
     <>
       <DatasetInfoModal isOpen={open} onClose={onClose} dataset={dataset} />
-      <Card.Root
-        flexDirection="row"
-        flexShrink={0}
-        overflow="hidden"
-        width="100%"
-        height="80px"
-        border={selected ? "2px solid" : "1px solid rgba(19, 22, 25, 0.3)"}
-        borderColor={selected ? "primary.solid" : undefined}
-        borderRadius="4px"
+      <InfoCard
+        thumbnail={thumbnail}
+        typeLabel={label}
+        typeLabelColor={labelColor}
+        title={dataset.dataset_name}
+        description={cardText}
+        titleActions={infoAction}
+        selected={selected}
         onClick={onClick}
-        cursor={onClick ? "pointer" : "default"}
-        _hover={
-          onClick
-            ? { borderColor: "primary.300", border: "2px solid" }
-            : undefined
-        }
-      >
-        <Image
-          objectFit="cover"
-          width="80px"
-          minHeight="80px"
-          flexShrink={0}
-          src={effectiveImg}
-          alt={dataset.dataset_name}
-          borderRight="1px solid rgba(19, 22, 25, 0.1)"
-          borderRadius={0}
-        />
-        <Card.Body
-          display="flex"
-          flexDir="column"
-          px="16px"
-          py={0}
-          gap="2px"
-          justifyContent="center"
-        >
-          <Text
-            fontFamily="'IBM Plex Mono', monospace"
-            fontSize="10px"
-            fontWeight="400"
-            letterSpacing="0.5px"
-            lineHeight="16px"
-            color={labelColor}
-          >
-            {label}
-          </Text>
-          <Card.Title
-            display="flex"
-            alignItems="center"
-            gap="8px"
-            marginBottom={0}
-          >
-            <Text
-              fontFamily="'IBM Plex Sans', sans-serif"
-              fontSize="12px"
-              fontWeight="500"
-              lineHeight="150%"
-              color="#3A4048"
-            >
-              {dataset.dataset_name}
-            </Text>
-            <Tooltip
-              content="Show dataset info"
-              positioning={{ placement: "top" }}
-              showArrow
-              variant="dark"
-            >
-              <InfoIcon
-                cursor="pointer"
-                size={16}
-                color="#656E7B"
-                onClick={onOpen}
-              />
-            </Tooltip>
-          </Card.Title>
-          {cardText && (
-            <Card.Description
-              fontFamily="'IBM Plex Mono', monospace"
-              fontSize="10px"
-              fontWeight="400"
-              lineHeight="16px"
-              color="#656E7B"
-            >
-              {cardText}
-            </Card.Description>
-          )}
-        </Card.Body>
-      </Card.Root>
+      />
     </>
   );
 }

--- a/app/components/InfoCard.tsx
+++ b/app/components/InfoCard.tsx
@@ -20,6 +20,8 @@ export interface InfoCardProps {
   selected?: boolean;
   /** Optional action node (e.g. info icon) anchored to the right of the title row. */
   titleActions?: React.ReactNode;
+  /** Optional action node placed inline after the description text. */
+  descriptionActions?: React.ReactNode;
 }
 
 export function InfoCard({
@@ -32,6 +34,7 @@ export function InfoCard({
   onClick,
   selected = false,
   titleActions,
+  descriptionActions,
 }: InfoCardProps) {
   return (
     <Flex
@@ -93,8 +96,6 @@ export function InfoCard({
             fontWeight="medium"
             lineHeight="150%"
             color="#3A4048"
-            flex="1"
-            minW={0}
             whiteSpace="nowrap"
             overflow="hidden"
             textOverflow="ellipsis"
@@ -103,19 +104,24 @@ export function InfoCard({
           </Text>
           {titleActions}
         </Flex>
-        {description && (
-          <Text
-            fontFamily="mono"
-            fontSize="10px"
-            fontWeight="normal"
-            lineHeight="16px"
-            color="#656E7B"
-            whiteSpace="nowrap"
-            overflow="hidden"
-            textOverflow="ellipsis"
-          >
-            {description}
-          </Text>
+        {(description || descriptionActions) && (
+          <Flex align="center" gap="8px" minW={0}>
+            {description && (
+              <Text
+                fontFamily="mono"
+                fontSize="10px"
+                fontWeight="normal"
+                lineHeight="16px"
+                color="#656E7B"
+                whiteSpace="nowrap"
+                overflow="hidden"
+                textOverflow="ellipsis"
+              >
+                {description}
+              </Text>
+            )}
+            {descriptionActions}
+          </Flex>
         )}
       </Box>
     </Flex>

--- a/app/components/InfoCard.tsx
+++ b/app/components/InfoCard.tsx
@@ -108,6 +108,8 @@ export function InfoCard({
           <Flex align="center" gap="8px" minW={0}>
             {description && (
               <Text
+                flex="1"
+                minW={0}
                 fontFamily="mono"
                 fontSize="10px"
                 fontWeight="normal"

--- a/app/components/MessageBubble.tsx
+++ b/app/components/MessageBubble.tsx
@@ -14,6 +14,7 @@ import { Tooltip } from "./ui/tooltip";
 import { ChatMessage } from "@/app/types/chat";
 import WidgetMessage from "./WidgetMessage";
 import { AnalysisCard } from "./AnalysisCard";
+import { AreaCard } from "./AreaCard";
 import Markdown from "react-markdown";
 import {
   ArrowBendDownRightIcon,
@@ -143,6 +144,7 @@ function MessageBubble({
 
   const isUser = message.type === "user";
   const isWidget = message.type === "widget";
+  const isAreaCard = message.type === "area-card";
   const isError = message.type === "error";
   const isWarning = message.type === "warning";
   const isAssistant = message.type === "assistant";
@@ -152,11 +154,21 @@ function MessageBubble({
   const hasContext = isUser && message.context && message.context.length > 0;
   const showFooter =
     !isUser &&
+    !isAreaCard &&
     !isError &&
     !isWarning &&
     !isFirst &&
     !message.suppressFooter &&
     (!isConsecutive || analysisWidgets.length > 0 || isLast);
+
+  if (isAreaCard && message.aoiSelection) {
+    return (
+      <Box my={2} width="100%">
+        <AreaCard aoiSelection={message.aoiSelection} />
+      </Box>
+    );
+  }
+
   // For widget messages, render them in a full-width container
   if (isWidget && message.widgets) {
     return message.widgets.map((widget, idx) => (

--- a/app/components/widgets/DatasetCardWidget.tsx
+++ b/app/components/widgets/DatasetCardWidget.tsx
@@ -20,5 +20,5 @@ export default function DatasetCardWidget({ dataset }: DatasetCardWidgetProps) {
     provider: dataset.provider ?? cardConfig?.provider,
   };
 
-  return <DatasetCard dataset={enrichedDataset} img={img} size="md" />;
+  return <DatasetCard dataset={enrichedDataset} img={img} />;
 }

--- a/app/store/chat-tools/pickAoi.ts
+++ b/app/store/chat-tools/pickAoi.ts
@@ -239,12 +239,16 @@ export async function pickAoiTool(
       });
     }
 
-    addMessage({
-      type: "area-card",
-      message: "",
-      aoiSelection: selectionForContext,
-      timestamp: streamMessage.timestamp,
-    });
+    // Only show the area card if at least one AOI rendered successfully,
+    // and only include the successful AOIs in the card.
+    if (successfulAois.length > 0) {
+      addMessage({
+        type: "area-card",
+        message: "",
+        aoiSelection: { name: selectionName, aois: successfulAois },
+        timestamp: streamMessage.timestamp,
+      });
+    }
 
     // If some AOIs failed, show a partial-failure message
     if (failures.length > 0 && failures.length < aois.length) {

--- a/app/store/chat-tools/pickAoi.ts
+++ b/app/store/chat-tools/pickAoi.ts
@@ -135,6 +135,13 @@ export async function pickAoiTool(
         });
       }
 
+      addMessage({
+        type: "area-card",
+        message: "",
+        aoiSelection: aoiSelection ?? { name: selectionName, aois },
+        timestamp: streamMessage.timestamp,
+      });
+
       return;
     }
 
@@ -231,6 +238,13 @@ export async function pickAoiTool(
         aoiSelection: selectionForContext,
       });
     }
+
+    addMessage({
+      type: "area-card",
+      message: "",
+      aoiSelection: selectionForContext,
+      timestamp: streamMessage.timestamp,
+    });
 
     // If some AOIs failed, show a partial-failure message
     if (failures.length > 0 && failures.length < aois.length) {

--- a/app/types/chat.ts
+++ b/app/types/chat.ts
@@ -16,10 +16,18 @@ export interface ToolStepData {
 
 export interface ChatMessage {
   id: string;
-  type: "user" | "assistant" | "system" | "widget" | "error" | "warning";
+  type:
+    | "user"
+    | "assistant"
+    | "system"
+    | "widget"
+    | "area-card"
+    | "error"
+    | "warning";
   message: string;
   timestamp: string;
   widgets?: InsightWidget[]; // For widget messages
+  aoiSelection?: AOISelection; // For area-card messages
   context?: ContextItem[];
   traceId?: string;
   toolSteps?: ToolStepData[]; // For user messages - reasoning steps taken to respond


### PR DESCRIPTION
## Pull request type
- [x] Feature

## What is the current behavior?
When the AI selects an area of interest (AOI), no visual confirmation appears in the chat thread. The user has no immediate feedback about which area was selected or what type it is, and must look at the map to understand what happened.

## What is the new behavior?
A new Area Card appears in the chat thread immediately after the AI selects an AOI, showing a Mapbox static map thumbnail of the area, its name, source type (e.g. "Administrative Areas"), and a crosshair icon button to re-center the map on it
The DatasetCard component was refactored to compose the existing InfoCard primitive, removing ~90 lines of duplicated layout code; AreaCard and AnalysisCard also share the same InfoCard base — all three card variants are now consistent
The unused size prop was removed from DatasetCard

## Does this introduce a breaking change?
- [x] No

## Demo
<img width="1347" height="914" alt="Screenshot 2026-06-02 at 17 16 36" src="https://github.com/user-attachments/assets/930a9014-c852-4d68-8656-b4aec3116dd2" />
