### PR TITLE
PZB-835: Hotfix/loosen insight card matching criteria

### DIFF
--- a/app/lib/__tests__/insight-chat-messages.test.ts
+++ b/app/lib/__tests__/insight-chat-messages.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect } from "vitest";
+import { buildInsightChatMessages } from "@/app/lib/insight-chat-messages";
+import { InsightWidget } from "@/app/types/chat";
+
+const TS = "2026-06-02T00:00:00.000Z";
+const TRACE = "trace-123";
+
+function widget(id: string, title: string): InsightWidget {
+  return {
+    id,
+    type: "bar",
+    title,
+    description: "",
+    data: [],
+    xAxis: "x",
+    yAxis: "y",
+  };
+}
+
+describe("buildInsightChatMessages", () => {
+  describe("fallback path (no [Chart N] markers — current staging)", () => {
+    it("renders pending cards before the assistant text", () => {
+      const widgets = [widget("chart_0", "A"), widget("chart_1", "B")];
+      const msgs = buildInsightChatMessages(
+        "Here is your analysis.",
+        widgets,
+        TS,
+        TRACE
+      );
+
+      expect(msgs).toHaveLength(3);
+      // 1) + 2) one card per pending widget, in order, before the narrative
+      expect(msgs[0]).toMatchObject({ type: "assistant", message: "" });
+      expect(msgs[0].widgets?.[0]?.title).toBe("A");
+      expect(msgs[0].suppressFooter).toBe(true);
+      expect(msgs[1].widgets?.[0]?.title).toBe("B");
+      expect(msgs[1].suppressFooter).toBe(true);
+      // 3) the narrative is the terminal message: shows footer, carries trace
+      expect(msgs[2]).toMatchObject({
+        type: "assistant",
+        message: "Here is your analysis.",
+        traceId: TRACE,
+      });
+      expect(msgs[2].suppressFooter).toBeUndefined();
+    });
+
+    it("emits only the text (with trace) when there are no pending cards", () => {
+      const msgs = buildInsightChatMessages("Just a reply.", [], TS, TRACE);
+
+      expect(msgs).toHaveLength(1);
+      expect(msgs[0]).toMatchObject({
+        type: "assistant",
+        message: "Just a reply.",
+        traceId: TRACE,
+      });
+      expect(msgs[0].suppressFooter).toBeUndefined();
+    });
+  });
+
+  describe("marker path ([Chart N] present)", () => {
+    it("places cards positionally where markers appear", () => {
+      const widgets = [widget("chart_0", "A"), widget("chart_1", "B")];
+      const msgs = buildInsightChatMessages(
+        "Intro [Chart 1] middle [Chart 2] outro",
+        widgets,
+        TS,
+        TRACE
+      );
+
+      // text, card A, text, card B, text
+      expect(msgs.map((m) => m.message)).toEqual([
+        "Intro ",
+        "",
+        " middle ",
+        "",
+        " outro",
+      ]);
+      expect(msgs[1].widgets?.[0]?.title).toBe("A");
+      expect(msgs[3].widgets?.[0]?.title).toBe("B");
+      // trailing text is the last segment, so it carries the trace
+      expect(msgs[4].traceId).toBe(TRACE);
+      // non-terminal text segments suppress their footer
+      expect(msgs[0].suppressFooter).toBe(true);
+    });
+
+    it("places a card at a lowercase [Chart <uuid>] marker", () => {
+      const uuid = "550e8400-e29b-41d4-a716-446655440000";
+      const widgets = [widget(uuid, "A")];
+      const msgs = buildInsightChatMessages(
+        `See [Chart ${uuid}] above.`,
+        widgets,
+        TS,
+        TRACE
+      );
+
+      // text, card, text
+      expect(msgs.map((m) => m.message)).toEqual(["See ", "", " above."]);
+      expect(msgs[1].widgets?.[0]?.title).toBe("A");
+      // trailing text is the last segment, so it carries the trace
+      expect(msgs[2].traceId).toBe(TRACE);
+    });
+
+    it("places cards at multiple [Chart <uuid>] markers, in order", () => {
+      const uuidA = "550e8400-e29b-41d4-a716-446655440000";
+      const uuidB = "6ba7b810-9dad-11d1-80b4-00c04fd430c8";
+      const widgets = [widget(uuidA, "A"), widget(uuidB, "B")];
+      const msgs = buildInsightChatMessages(
+        `Intro [Chart ${uuidA}] middle [Chart ${uuidB}] outro`,
+        widgets,
+        TS,
+        TRACE
+      );
+
+      expect(msgs.map((m) => m.message)).toEqual([
+        "Intro ",
+        "",
+        " middle ",
+        "",
+        " outro",
+      ]);
+      expect(msgs[1].widgets?.[0]?.title).toBe("A");
+      expect(msgs[3].widgets?.[0]?.title).toBe("B");
+      expect(msgs[4].traceId).toBe(TRACE);
+    });
+
+    it("matches an uppercase [Chart <uuid>] marker (case-insensitive)", () => {
+      const uuid = "550E8400-E29B-41D4-A716-446655440000";
+      const widgets = [widget(uuid, "A")];
+      const msgs = buildInsightChatMessages(`[Chart ${uuid}]`, widgets, TS);
+
+      // marker is the whole message, so only the injected card remains
+      expect(msgs).toHaveLength(1);
+      expect(msgs[0].widgets?.[0]?.title).toBe("A");
+    });
+
+    it("skips markers that have no matching pending widget", () => {
+      const msgs = buildInsightChatMessages(
+        "Intro [Chart 1] outro",
+        [], // no widgets available
+        TS
+      );
+      // only the surrounding text survives; the unmatched marker is dropped
+      expect(msgs.map((m) => m.message)).toEqual(["Intro ", " outro"]);
+      expect(msgs.every((m) => !m.widgets)).toBe(true);
+    });
+  });
+});

--- a/app/lib/insight-chat-messages.ts
+++ b/app/lib/insight-chat-messages.ts
@@ -1,0 +1,128 @@
+import { ChatMessage, InsightWidget } from "@/app/types/chat";
+
+// Matches the `[Chart <id>]` markers the backend is meant to inject into the
+// assistant reply so cards can be placed positionally. `<id>` is hex/digits/
+// hyphen (covers both UUID-style ids and the integer indices the backend emits).
+const CHART_MARKER_RE = /\[Chart\s+[a-f0-9-]+\]/gi;
+
+type AssistantChatMessage = Omit<ChatMessage, "id">;
+
+/**
+ * Builds the chat messages produced by a single assistant text chunk,
+ * injecting any insight cards from the most recent `generate_insights` call.
+ *
+ * Two paths:
+ *
+ * 1. **Marker path** — when the reply text contains `[Chart N]` markers, each
+ *    card is placed positionally where its marker appears.
+ *
+ * 2. **Fallback path** — staging (`origin/main`) delivers chart data via the
+ *    `generate_insights` tool message but does NOT inject `[Chart N]` markers
+ *    into the reply (that backend change currently lives on the
+ *    `feat/fao-fra-handler` branch and is not deployed). Until it ships, render
+ *    any pending cards immediately before the assistant text so the narrative
+ *    reads as a conclusion to the charts above it. Remove this fallback once
+ *    markers reach staging.
+ *
+ * `pendingWidgets` is the already-consumed batch from `insightStore` — the
+ * caller owns the consume so this function stays pure and unit-testable.
+ */
+export function buildInsightChatMessages(
+  text: string,
+  pendingWidgets: InsightWidget[],
+  timestamp: string,
+  traceToUse?: string
+): AssistantChatMessage[] {
+  // Fresh regex instances: the `g` flag carries `lastIndex` across calls.
+  const hasMarkers = new RegExp(CHART_MARKER_RE).test(text);
+
+  if (hasMarkers) {
+    return buildPositionalMessages(text, pendingWidgets, timestamp, traceToUse);
+  }
+
+  return buildFallbackMessages(text, pendingWidgets, timestamp, traceToUse);
+}
+
+// Marker path: split the text on `[Chart N]` markers and interleave cards.
+function buildPositionalMessages(
+  text: string,
+  pendingWidgets: InsightWidget[],
+  timestamp: string,
+  traceToUse?: string
+): AssistantChatMessage[] {
+  const re = new RegExp(CHART_MARKER_RE);
+  const segments: Array<{ text?: string; widgetIdx?: number }> = [];
+  let lastIndex = 0;
+  let widgetIdx = 0;
+  let match: RegExpExecArray | null;
+  while ((match = re.exec(text)) !== null) {
+    const textBefore = text.slice(lastIndex, match.index);
+    if (textBefore.trim()) {
+      segments.push({ text: textBefore });
+    }
+    segments.push({ widgetIdx: widgetIdx++ });
+    lastIndex = re.lastIndex;
+  }
+  const textAfter = text.slice(lastIndex);
+  if (textAfter.trim()) {
+    segments.push({ text: textAfter });
+  }
+
+  const messages: AssistantChatMessage[] = [];
+  segments.forEach((seg, i) => {
+    const isLast = i === segments.length - 1;
+    if (seg.text !== undefined) {
+      messages.push({
+        type: "assistant",
+        message: seg.text,
+        timestamp,
+        ...(!isLast ? { suppressFooter: true } : {}),
+        ...(isLast && traceToUse ? { traceId: traceToUse } : {}),
+      });
+    } else if (seg.widgetIdx !== undefined) {
+      const widget = pendingWidgets[seg.widgetIdx];
+      if (widget) {
+        messages.push({
+          type: "assistant",
+          message: "",
+          timestamp,
+          widgets: [widget],
+          ...(isLast && traceToUse ? { traceId: traceToUse } : {}),
+        });
+      }
+    }
+  });
+  return messages;
+}
+
+// Fallback path: render each pending card first, then the narrative text so
+// the text reads as a conclusion to the charts above it.
+function buildFallbackMessages(
+  text: string,
+  pendingWidgets: InsightWidget[],
+  timestamp: string,
+  traceToUse?: string
+): AssistantChatMessage[] {
+  const messages: AssistantChatMessage[] = [];
+
+  // Cards precede the narrative, so they are non-terminal: suppress their
+  // footer and let the trace/footer live on the closing text message.
+  pendingWidgets.forEach((widget) => {
+    messages.push({
+      type: "assistant",
+      message: "",
+      timestamp,
+      widgets: [widget],
+      suppressFooter: true,
+    });
+  });
+
+  messages.push({
+    type: "assistant",
+    message: text,
+    timestamp,
+    ...(traceToUse ? { traceId: traceToUse } : {}),
+  });
+
+  return messages;
+}

--- a/app/store/chatStore.ts
+++ b/app/store/chatStore.ts
@@ -17,6 +17,7 @@ import {
 import useContextStore from "./contextStore";
 import { readDataStream } from "@/app/lib/read-data-stream";
 import { parseStreamMessage } from "@/app/lib/parse-stream-message";
+import { buildInsightChatMessages } from "@/app/lib/insight-chat-messages";
 import { apiFetch } from "@/app/lib/api-client";
 import { getToolErrorMessage } from "@/app/lib/tool-display";
 import { DATASET_BY_ID } from "../constants/datasets";
@@ -177,58 +178,18 @@ async function processStreamMessage(
     const pending = getPendingTraceId();
     const traceToUse = streamMessage.trace_id || pending || undefined;
 
-    const chartRefRe = /\[Chart\s+[a-f0-9-]+\]/gi;
-    if (chartRefRe.test(streamMessage.text)) {
-      // Split the text on [Chart <uuid>] markers and inject insight cards positionally
-      const re = /\[Chart\s+[a-f0-9-]+\]/gi;
-      const pendingWidgets = useInsightStore.getState().consumePendingBatch();
-      let lastIndex = 0;
-      let match: RegExpExecArray | null;
-      let widgetIdx = 0;
-      const segments: Array<{ text?: string; widgetIdx?: number }> = [];
-      while ((match = re.exec(streamMessage.text)) !== null) {
-        const textBefore = streamMessage.text.slice(lastIndex, match.index);
-        if (textBefore.trim()) {
-          segments.push({ text: textBefore });
-        }
-        segments.push({ widgetIdx: widgetIdx++ });
-        lastIndex = re.lastIndex;
-      }
-      const textAfter = streamMessage.text.slice(lastIndex);
-      if (textAfter.trim()) {
-        segments.push({ text: textAfter });
-      }
-      segments.forEach((seg, i) => {
-        const isLast = i === segments.length - 1;
-        if (seg.text !== undefined) {
-          addMessage({
-            type: "assistant",
-            message: seg.text,
-            timestamp: streamMessage.timestamp,
-            ...(!isLast ? { suppressFooter: true } : {}),
-            ...(isLast && traceToUse ? { traceId: traceToUse } : {}),
-          });
-        } else if (seg.widgetIdx !== undefined) {
-          const widget = pendingWidgets[seg.widgetIdx];
-          if (widget) {
-            addMessage({
-              type: "assistant",
-              message: "",
-              timestamp: streamMessage.timestamp,
-              widgets: [widget],
-              ...(isLast && traceToUse ? { traceId: traceToUse } : {}),
-            });
-          }
-        }
-      });
-    } else {
-      addMessage({
-        type: "assistant",
-        message: streamMessage.text,
-        timestamp: streamMessage.timestamp,
-        traceId: traceToUse,
-      });
-    }
+    // Consume the most recent generate_insights batch and render it with the
+    // assistant text. When the reply contains [Chart N] markers, cards are
+    // placed positionally; otherwise (e.g. current staging, which emits chart
+    // data but no markers) they are appended after the text. See
+    // buildInsightChatMessages for the full contract.
+    const pendingWidgets = useInsightStore.getState().consumePendingBatch();
+    buildInsightChatMessages(
+      streamMessage.text,
+      pendingWidgets,
+      streamMessage.timestamp,
+      traceToUse
+    ).forEach(addMessage);
     // Flush any buffered nudge immediately after the assistant message
     const pendingNudge = getPendingNudge();
     if (pendingNudge) {


### PR DESCRIPTION
## Problem

Insight cards stopped rendering inline in the chat thread. Cards only appeared in the map-overlay
InsightWorkspace, not in the conversation where users expect them.

Root cause seems to be FE/BE contract drift which changed insight rendering to a two-part handshake:

1. The generate_insights tool message carries charts_data → generateInsightsTool populates
insightStore (insights[] + pendingBatch).
2. The assistant reply text must then contain `[Chart N]` or `[Chart {uuid}]` markers, which the FE detects and uses to inject cards into chat

Staging currently emits the chart data but no `[Chart ...]` markers in the reply.

## Fix

A frontend bridge that uses what staging already emits (the chart data), with no backend
dependency:

- New `app/lib/insight-chat-messages.ts` extracts the _assistant-message → chat-messages_ logic into a
pure, tested helper with two paths:
  - Marker path (unchanged): when [Chart N] markers are present, cards are placed positionally.
Preserved exactly, so when the backend marker change deploys it takes over automatically — no
further FE change needed. (The regex matches both UUID and integer-index marker forms.)
  - Fallback path (new): when there are no markers but a generate_insights batch is pending,
render the cards immediately before the narrative text, so the text reads as a conclusion to the
chart card above it.
- `app/store/chatStore.ts` now uses a single call into the helper and `pendingBatch` is now always consumed in the text branch.

## Testing

- app/lib/__tests__/insight-chat-messages.test.ts — 4 new tests covering both paths
(cards-before-text fallback, text-only when no cards, positional marker injection,
unmatched-marker skip).
- pnpm test (27/27), pnpm typecheck, pnpm lint, pnpm format:check all pass.

Should observe the following:
<img width="575" height="707" alt="Screenshot 2026-06-03 at 09 44 17" src="https://github.com/user-attachments/assets/27a2c336-d163-4fc7-a9ee-3e20cbae7e31" />

