### PR TITLE
Add default start and end years

### DIFF
--- a/app/components/ContextMenu.tsx
+++ b/app/components/ContextMenu.tsx
@@ -88,10 +88,14 @@ function LayerCardList({
     if (existing) {
       removeContext(existing.id);
     } else {
-      const year = card.defaultYear;
+      const startYear = card.defaultStartYear;
+      const endYear = card.defaultEndYear;
+      // Only scope the layer when both bounds are present, so a half-configured
+      // card falls back to the unfiltered tile_url rather than a broken range.
+      const hasYears = startYear != null && endYear != null;
       const tileUrl =
-        year && card.tile_url
-          ? `${card.tile_url}&start_year=${year}&end_year=${year}`
+        hasYears && card.tile_url
+          ? `${card.tile_url}&start_year=${startYear}&end_year=${endYear}`
           : card.tile_url;
       upsertContextByType({
         contextType: "layer",
@@ -99,10 +103,10 @@ function LayerCardList({
         datasetId: card.dataset_id,
         tileUrl,
         layerName: card.dataset_name,
-        ...(year
+        ...(hasYears
           ? {
-              startDate: `${year}-01-01`,
-              endDate: `${year}-12-31`,
+              startDate: `${startYear}-01-01`,
+              endDate: `${endYear}-12-31`,
             }
           : {}),
         isAiContext: false,

--- a/app/constants/datasets.ts
+++ b/app/constants/datasets.ts
@@ -35,7 +35,8 @@ export type DatasetCardConfig = {
   methodology?: string;
   citation?: string;
   viewOnly?: boolean;
-  defaultYear?: number;
+  defaultStartYear?: number;
+  defaultEndYear?: number;
 };
 
 export type ContextLayerMetadata = {
@@ -206,6 +207,8 @@ export const DATASET_CARDS: (DatasetCardConfig & { img?: string })[] = [
     resolution: "30 m",
     geographic_coverage: "global",
     provider: "UMD",
+    defaultStartYear: 2001,
+    defaultEndYear: 2025,
     description:
       "Tree Cover Loss (Hansen/UMD/GLAD) maps annual global forest loss from 2001 to 2025 at 30-meter resolution using Landsat satellite imagery. It detects stand-replacement disturbances in vegetation over 5 meters tall, including natural forests and plantations. The dataset supports monitoring annual tree cover loss and deforestation trends, fire impacts, and forestry practices, and is widely used for conservation, land-use planning, and environmental policy analysis.",
     tile_url:
@@ -313,7 +316,8 @@ export const DATASET_CARDS: (DatasetCardConfig & { img?: string })[] = [
     resolution: "30 m",
     geographic_coverage: "global",
     provider: "UMD",
-    defaultYear: 2025,
+    defaultStartYear: 2001,
+    defaultEndYear: 2025,
     description:
       "Tree Cover Loss due to Fires (Hansen/UMD/GLAD) maps annual global tree cover loss attributed to fire from 2001 to 2025 at 30-meter resolution. This subset of the broader Tree Cover Loss dataset isolates fire-driven stand-replacement disturbances in vegetation over 5 meters tall, helping users understand where fire is a dominant driver of forest loss.",
     tile_url:


### PR DESCRIPTION
Adds start AND end years for manually selected temporal data.

- select TCL or TCL fires from dataset catalogue
- check that tiles return 2001-2025