### PR TITLE
Pzb 772 tweaks

### DIFF
--- a/app/ChatPanelCompact.tsx
+++ b/app/ChatPanelCompact.tsx
@@ -10,9 +10,17 @@ import ChatStatusInfo from "./components/ChatStatusInfo";
 import ChatPanelHeader from "./ChatPanelHeader";
 import useAuthStore from "./store/authStore";
 import useChatStore from "./store/chatStore";
-import { useState } from "react";
+import { useState, useEffect, useRef, useCallback } from "react";
 
 const PANEL_WIDTH = 400;
+
+// Cap the scrollable message list at ~50vh per design (~440px on a 900px-tall
+// viewport). The compact panel is bottom-anchored and grows upward, so when the
+// preview DisclaimerPanel banner is showing (a separate top-left map overlay at
+// the same left edge) we shrink the cap further so the panel never grows up far
+// enough to overlap it.
+const MESSAGES_MAX_VH = 0.5;
+const DISCLAIMER_CLEARANCE = 12; // px of breathing room below the disclaimer
 
 const cardStyle = {
   w: { base: "full", md: `${PANEL_WIDTH}px` } as const,
@@ -36,6 +44,53 @@ function ChatPanelCompact({ onToggleSize }: ChatPanelCompactProps) {
   );
   const [isCollapsed, setIsCollapsed] = useState(false);
 
+  const topCardRef = useRef<HTMLDivElement>(null);
+  const messagesRef = useRef<HTMLDivElement>(null);
+  const inputCardRef = useRef<HTMLDivElement>(null);
+  const [messagesMaxH, setMessagesMaxH] = useState(`${MESSAGES_MAX_VH * 100}vh`);
+
+  // The disclaimer lives in a sibling map overlay, not in this panel's flex
+  // flow, so layout can't keep them apart. Shrink the message list so the whole
+  // (bottom-anchored) panel — including the header that sits above the list —
+  // stays DISCLAIMER_CLEARANCE px below the disclaimer's bottom edge, capped at
+  // the design 50vh.
+  const recomputeMaxH = useCallback(() => {
+    const messages = messagesRef.current;
+    const topCard = topCardRef.current;
+    if (!messages || !topCard) return;
+    const cap = window.innerHeight * MESSAGES_MAX_VH;
+    const messagesRect = messages.getBoundingClientRect();
+    // Header + card border above the list. Constant regardless of list height,
+    // so panel top = messagesRect.bottom − listHeight − headerOffset.
+    const headerOffset = messagesRect.top - topCard.getBoundingClientRect().top;
+    const disclaimer = document.getElementById("gnw-disclaimer-panel");
+    const disclaimerVisible = !!disclaimer && disclaimer.offsetParent !== null;
+    const topLimit = disclaimerVisible
+      ? disclaimer.getBoundingClientRect().bottom + DISCLAIMER_CLEARANCE
+      : 0;
+    const available = messagesRect.bottom - headerOffset - topLimit;
+    setMessagesMaxH(`${Math.round(Math.max(0, Math.min(cap, available)))}px`);
+  }, []);
+
+  useEffect(() => {
+    recomputeMaxH();
+    const raf = requestAnimationFrame(recomputeMaxH);
+    // Input card height changes (e.g. the quota notice) shift the message
+    // list's bottom edge, so re-measure when it resizes.
+    const observer = new ResizeObserver(recomputeMaxH);
+    if (inputCardRef.current) observer.observe(inputCardRef.current);
+    window.addEventListener("resize", recomputeMaxH);
+    window.addEventListener("gnw-disclaimer-shown", recomputeMaxH);
+    window.addEventListener("gnw-disclaimer-dismissed", recomputeMaxH);
+    return () => {
+      cancelAnimationFrame(raf);
+      observer.disconnect();
+      window.removeEventListener("resize", recomputeMaxH);
+      window.removeEventListener("gnw-disclaimer-shown", recomputeMaxH);
+      window.removeEventListener("gnw-disclaimer-dismissed", recomputeMaxH);
+    };
+  }, [recomputeMaxH, isCollapsed]);
+
   return (
     <Flex
       flexDir="column"
@@ -43,7 +98,7 @@ function ChatPanelCompact({ onToggleSize }: ChatPanelCompactProps) {
       h="100%"
       pt={2}
       pb={1}
-      pl={{ base: 0, md: 2 }}
+      pl={{ base: 0, md: 3 }}
       pointerEvents="none"
     >
       <Flex
@@ -53,7 +108,7 @@ function ChatPanelCompact({ onToggleSize }: ChatPanelCompactProps) {
         pointerEvents="auto"
       >
         {/* Top card: header + content */}
-        <Flex flexDir="column" flex="0 0 auto" {...cardStyle}>
+        <Flex ref={topCardRef} flexDir="column" flex="0 0 auto" {...cardStyle}>
           <ChatPanelHeader
             isFullSize={false}
             hasConversation={hasConversation}
@@ -72,7 +127,14 @@ function ChatPanelCompact({ onToggleSize }: ChatPanelCompactProps) {
                 transition={{ duration: 0.22, ease: "easeInOut" }}
                 style={{ overflow: "hidden" }}
               >
-                <Box overflowY="auto" px={4} pt={4} pb={4} maxH="590px">
+                <Box
+                  ref={messagesRef}
+                  overflowY="auto"
+                  px={4}
+                  pt={4}
+                  pb={4}
+                  maxH={messagesMaxH}
+                >
                   <ChatMessages />
                 </Box>
               </motion.div>
@@ -82,6 +144,7 @@ function ChatPanelCompact({ onToggleSize }: ChatPanelCompactProps) {
 
         {/* Bottom card: input — always visible */}
         <Flex
+          ref={inputCardRef}
           flexDir="column"
           {...cardStyle}
           boxShadow="none"

--- a/app/components/DisclaimerPanel.tsx
+++ b/app/components/DisclaimerPanel.tsx
@@ -22,6 +22,14 @@ export default function DisclaimerPanel() {
     }
   }, []);
 
+  // Notify the compact chat panel once we're actually rendered so it can
+  // reserve the space below this banner and avoid overlapping it.
+  useEffect(() => {
+    if (visible) {
+      window.dispatchEvent(new Event("gnw-disclaimer-shown"));
+    }
+  }, [visible]);
+
   if (!visible) return null;
 
   const dismiss = () => {
@@ -32,6 +40,7 @@ export default function DisclaimerPanel() {
 
   return (
     <Box
+      id="gnw-disclaimer-panel"
       px={2}
       pt={2}
       pb={3}


### PR DESCRIPTION
Ensure chat pane and disclaimer do not collide, regardless of screen size.

- Drop cookies
- ensure green disclaimer component is in view
- send prompt and wait for compact panel to go to max height
- zoom and ensure they do not collide