### PR TITLE
PZB-948 - Whats new header UI

### DIFF
--- a/app/app/(chat)/layout.tsx
+++ b/app/app/(chat)/layout.tsx
@@ -15,6 +15,7 @@ import UploadAreaDialog from "@/app/components/UploadAreaDialog";
 import Map from "@/app/components/Map";
 import { Sidebar } from "@/app/sidebar";
 import PageHeader from "@/app/components/PageHeader";
+import WhatsNewModal from "@/app/components/WhatsNewModal";
 import DebugToastsPanel from "@/app/components/DebugToastsPanel";
 import { useAuthGuard } from "@/app/hooks/useAuthGuard";
 import { useSearchParams } from "next/navigation";
@@ -161,6 +162,7 @@ export default function DashboardLayout({
       bg="bg"
     >
       <UploadAreaDialog />
+      <WhatsNewModal />
 
       {!isMobile && <PageHeader />}
       {isMobile ? MobileLayout : DesktopLayout}

--- a/app/components/ChatMessages.tsx
+++ b/app/components/ChatMessages.tsx
@@ -5,7 +5,6 @@ import useChatStore from "@/app/store/chatStore";
 import MessageBubble from "./MessageBubble";
 import Reasoning from "./Reasoning";
 import SamplePrompts from "./SamplePrompts";
-import WhatsNewModal from "./WhatsNewModal";
 
 function ChatMessages() {
   const containerRef = useRef<HTMLDivElement>(null);
@@ -102,7 +101,6 @@ function ChatMessages() {
         return (
           <Fragment key={message.id}>
             {isLastUserMessage && <Box ref={lastUserMessageRef} />}
-            {isFirst && <WhatsNewModal />}
             <MessageBubble
               message={message}
               isConsecutive={isConsecutive}

--- a/app/components/PageHeader.tsx
+++ b/app/components/PageHeader.tsx
@@ -38,6 +38,7 @@ import { useLogout } from "@/app/hooks/useLogout";
 
 const isPrototype = process.env.NEXT_PUBLIC_PROTOTYPE_MODE === "true";
 const DISCLAIMER_STORAGE_KEY = "gnw_disclaimer_dismissed_v2";
+const WHATS_NEW_STORAGE_KEY = "whats-new-v3-dismissed";
 
 function PageHeader() {
   const { userEmail, usedPrompts, totalPrompts, isAuthenticated } =
@@ -64,6 +65,7 @@ function PageHeader() {
 
   const [disclaimerDismissed, setDisclaimerDismissed] = useState(false);
   const [panelOpen, setPanelOpen] = useState(false);
+  const [showWhatsNewDot, setShowWhatsNewDot] = useState(false);
   const badgeRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
@@ -74,6 +76,14 @@ function PageHeader() {
     window.addEventListener("gnw-disclaimer-dismissed", handleDismiss);
     return () =>
       window.removeEventListener("gnw-disclaimer-dismissed", handleDismiss);
+  }, []);
+
+  useEffect(() => {
+    setShowWhatsNewDot(localStorage.getItem(WHATS_NEW_STORAGE_KEY) !== "true");
+    const handleDismissed = () => setShowWhatsNewDot(false);
+    window.addEventListener("gnw-whats-new-dismissed", handleDismissed);
+    return () =>
+      window.removeEventListener("gnw-whats-new-dismissed", handleDismissed);
   }, []);
 
   useEffect(() => {
@@ -278,12 +288,23 @@ function PageHeader() {
           gap="2"
           fontWeight="medium"
           fontSize="xs"
-          onClick={() =>
-            window.dispatchEvent(new CustomEvent("gnw-whats-new-open"))
-          }
+          onClick={() => {
+            localStorage.setItem(WHATS_NEW_STORAGE_KEY, "true");
+            window.dispatchEvent(new CustomEvent("gnw-whats-new-dismissed"));
+            window.dispatchEvent(new CustomEvent("gnw-whats-new-open"));
+          }}
         >
           <ShootingStarIcon size={16} />
           {"What's new"}
+          {showWhatsNewDot && (
+            <Box
+              w="8px"
+              h="8px"
+              borderRadius="8px"
+              bg="#C3D16F"
+              flexShrink={0}
+            />
+          )}
         </Button>
         <ChakraLink
           as={Link}

--- a/app/components/PageHeader.tsx
+++ b/app/components/PageHeader.tsx
@@ -52,8 +52,8 @@ function PageHeader() {
     ? currentThread.name
     : "New Conversation";
 
-  const inverseColor = isPrototype ? "#1f2937" : "fg.inverted";
-  const inverseHoverBg = isPrototype ? "#6b7280" : "primary.fg";
+  const inverseColor = isPrototype ? "#1f2937" : "#3A4048";
+  const inverseHoverBg = isPrototype ? "#6b7280" : "#F0F1F2";
   const focusRing = {
     outline: "2px solid",
     outlineColor: inverseColor,
@@ -93,8 +93,9 @@ function PageHeader() {
       gap="4"
       px="3"
       h="40px"
-      bg={isPrototype ? "#d1d5db" : "primary.solid"}
-      color={isPrototype ? "#1f2937" : "fg.inverted"}
+      bg={isPrototype ? "#d1d5db" : "white"}
+      color={isPrototype ? "#1f2937" : "#131E47"}
+      borderTop={isPrototype ? undefined : "4px solid #E3F37F"}
       zIndex={1300}
       position="relative"
     >
@@ -111,9 +112,13 @@ function PageHeader() {
             <LclLogo
               width={16}
               avatarOnly
-              fill={isPrototype ? "#1f2937" : "white"}
+              fill={isPrototype ? "#1f2937" : "#131E47"}
             />
-            <Heading as="h1" size="sm" color={inverseColor}>
+            <Heading
+              as="h1"
+              size="sm"
+              color={isPrototype ? "#1f2937" : "#131E47"}
+            >
               Global Nature Watch
             </Heading>
           </ChakraLink>
@@ -269,7 +274,7 @@ function PageHeader() {
           display="flex"
           alignItems="center"
           gap="2"
-          color={inverseColor}
+          color={isPrototype ? "#1f2937" : "#656E7B"}
           fontSize="xs"
           fontWeight="medium"
           transition="opacity 0.24s ease"
@@ -298,7 +303,7 @@ function PageHeader() {
             lineHeight="1.5"
             fontWeight="normal"
             whiteSpace="nowrap"
-            color={isPrototype ? "#6b7280" : "primary.100"}
+            color={isPrototype ? "#6b7280" : "#656E7B"}
           >
             {usedPrompts} / {totalPrompts > 5000 ? "∞" : totalPrompts} daily
             prompts
@@ -321,22 +326,19 @@ function PageHeader() {
               </Text>
             </Tooltip>
           </Progress.Label>
-          <Progress.Track
-            bg={isPrototype ? "#6b7280" : "primary.950"}
-            maxH="4px"
-          >
-            <Progress.Range bg={isPrototype ? "#1f2937" : "white"} />
+          <Progress.Track bg={isPrototype ? "#6b7280" : "#E0E2E5"} maxH="4px">
+            <Progress.Range bg={isPrototype ? "#1f2937" : "#0049AA"} />
           </Progress.Track>
         </Progress.Root>
         {isAuthenticated ? (
           <Menu.Root positioning={{ placement: "bottom-end" }}>
             <Menu.Trigger asChild>
               <Button
-                variant="solid"
-                colorPalette={isPrototype ? "gray" : "primary"}
+                variant={isPrototype ? "solid" : "ghost"}
+                colorPalette={isPrototype ? "gray" : undefined}
                 bg={isPrototype ? "#9ca3af" : undefined}
-                color={isPrototype ? "#1f2937" : undefined}
-                _hover={{ bg: isPrototype ? "#6b7280" : "primary.fg" }}
+                color={isPrototype ? "#1f2937" : "#656E7B"}
+                _hover={{ bg: isPrototype ? "#6b7280" : "#F0F1F2" }}
                 _focusVisible={focusRing}
                 h="40px"
                 px="2"
@@ -383,7 +385,7 @@ function PageHeader() {
             display="flex"
             alignItems="center"
             gap="2"
-            color={inverseColor}
+            color={isPrototype ? "#1f2937" : "#656E7B"}
             fontSize="xs"
             fontWeight="medium"
             transition="opacity 0.24s ease"

--- a/app/components/PageHeader.tsx
+++ b/app/components/PageHeader.tsx
@@ -54,8 +54,8 @@ function PageHeader() {
     ? currentThread.name
     : "New Conversation";
 
-  const inverseColor = isPrototype ? "#1f2937" : "#3A4048";
-  const inverseHoverBg = isPrototype ? "#6b7280" : "#F0F1F2";
+  const inverseColor = isPrototype ? "#1f2937" : "neutral.600";
+  const inverseHoverBg = isPrototype ? "#6b7280" : "neutral.200";
   const focusRing = {
     outline: "2px solid",
     outlineColor: inverseColor,

--- a/app/components/PageHeader.tsx
+++ b/app/components/PageHeader.tsx
@@ -20,6 +20,7 @@ import {
   GearSixIcon,
   LifebuoyIcon,
   PlusIcon,
+  ShootingStarIcon,
   SignOutIcon,
   UserIcon,
   InfoIcon,
@@ -267,6 +268,23 @@ function PageHeader() {
         </Text>
       )}
       <Flex gap="6" alignItems="center" hideBelow="md">
+        <Button
+          variant="ghost"
+          size="xs"
+          color={isPrototype ? "#1f2937" : "#656E7B"}
+          fill={isPrototype ? "#1f2937" : "#F4F5F6"}
+          _hover={{ bg: inverseHoverBg }}
+          _focusVisible={focusRing}
+          gap="2"
+          fontWeight="medium"
+          fontSize="xs"
+          onClick={() =>
+            window.dispatchEvent(new CustomEvent("gnw-whats-new-open"))
+          }
+        >
+          <ShootingStarIcon size={16} />
+          {"What's new"}
+        </Button>
         <ChakraLink
           as={Link}
           href="https://help.globalnaturewatch.org/"

--- a/app/components/WhatsNewModal.tsx
+++ b/app/components/WhatsNewModal.tsx
@@ -10,10 +10,10 @@ import {
 } from "@phosphor-icons/react";
 import { useEffect, useState } from "react";
 
-const STORAGE_KEY = "whats-new-v3-dismissed";
 const LEGACY_STORAGE_KEYS = [
   "whats-new-v1-dismissed",
   "whats-new-v2-dismissed",
+  "whats-new-v3-dismissed",
 ];
 
 const FEATURE_IMAGES: Record<number, string> = {
@@ -132,15 +132,15 @@ const WhatsNewModal = () => {
 
   useEffect(() => {
     LEGACY_STORAGE_KEYS.forEach((key) => localStorage.removeItem(key));
-    if (localStorage.getItem(STORAGE_KEY) !== "true") {
-      setIsOpen(true);
-    }
   }, []);
 
-  const dismiss = () => {
-    localStorage.setItem(STORAGE_KEY, "true");
-    setIsOpen(false);
-  };
+  useEffect(() => {
+    const handleOpen = () => setIsOpen(true);
+    window.addEventListener("gnw-whats-new-open", handleOpen);
+    return () => window.removeEventListener("gnw-whats-new-open", handleOpen);
+  }, []);
+
+  const dismiss = () => setIsOpen(false);
 
   if (!isOpen) return null;
 

--- a/app/components/WhatsNewModal.tsx
+++ b/app/components/WhatsNewModal.tsx
@@ -163,19 +163,19 @@ const WhatsNewModal = () => {
         <Flex
           bg="#f4f5f6"
           px={6}
-          h="48px"
+          h="40px"
           align="center"
           justify="space-between"
           flexShrink={0}
         >
           <HStack gap={2}>
-            <ShootingStarIcon size={20} color="#172b7a" />
+            <ShootingStarIcon size={16} color="#172b7a" />
             <Text
-              fontSize="18px"
+              fontSize="14px"
               color="#172b7a"
               fontFamily="'IBM Plex Sans', sans-serif"
               fontWeight="normal"
-              lineHeight="40px"
+              lineHeight="1"
             >
               {"What's "}
               <Box as="span" fontWeight="medium">

--- a/app/constants/preview-content.ts
+++ b/app/constants/preview-content.ts
@@ -12,8 +12,14 @@ export const PREVIEW_LINKS = [
     label: "FAQs",
     href: "https://help.globalnaturewatch.org/support/faqs",
   },
-  { label: "Capabilities", href: "https://help.globalnaturewatch.org/get-started/capabilities-and-datasets" },
-  { label: "Accuracy", href: "https://help.globalnaturewatch.org/get-started/accuracy-and-performance" },
+  {
+    label: "Capabilities",
+    href: "https://help.globalnaturewatch.org/get-started/capabilities-and-datasets",
+  },
+  {
+    label: "Accuracy",
+    href: "https://help.globalnaturewatch.org/get-started/accuracy-and-performance",
+  },
   {
     label: "Known Issues",
     href: "https://help.globalnaturewatch.org/resources/known-issues",


### PR DESCRIPTION
### Summary
Replaces the blue header style background with white + lime-green top border, and adds a **What's new** button with notification indicator.

Moves WhatsNewModal from ChatMessages (only mounted when messages exist) to the chat layout, so it is always available regardless of conversation state. Auto-open on first visit is removed and the panel is now purely opt-in via the header button.

<img width="246" height="64" alt="image" src="https://github.com/user-attachments/assets/dba43c70-c04f-469b-ad6b-e58352e1fe95" />
