### PR TITLE
PZB-954: enable TCL as the default active layer on landing

### DIFF
--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,0 +1,1 @@
+pnpm format:check

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,7 +24,7 @@ pnpm test app/utils/__tests__/formatText.test.ts
 
 CI runs `format:check → lint → typecheck → build` in that order. All four must pass before merge.
 
-The pre-commit hook (Husky + lint-staged) runs ESLint and Prettier automatically on staged files. **Do not bypass it with `--no-verify`.**
+The pre-commit hook (Husky + lint-staged) runs ESLint and Prettier automatically on staged files. The pre-push hook runs `pnpm format:check` on the full repo (same as CI). **Do not bypass hooks with `--no-verify`.**
 
 ## Environment
 

--- a/app/app/(chat)/page.tsx
+++ b/app/app/(chat)/page.tsx
@@ -1,11 +1,15 @@
 "use client";
 
-import { useEffect, useState, Suspense } from "react";
+import { useEffect, useRef, useState, Suspense } from "react";
 import { Loader } from "@chakra-ui/react";
 import { useRouter, useSearchParams } from "next/navigation";
 import useChatStore from "@/app/store/chatStore";
 import useContextStore from "@/app/store/contextStore";
 import useMapStore from "@/app/store/mapStore";
+import { DATASET_CARDS } from "@/app/constants/datasets";
+import { getLayerContextFromDatasetCard } from "@/app/utils/datasetCardLayerContext";
+
+const DEFAULT_LANDING_DATASET_ID = 4;
 
 function NewThread() {
   const {
@@ -13,21 +17,49 @@ function NewThread() {
     sendMessage,
     currentThreadId,
   } = useChatStore();
-  const { reset: resetContextStore } = useContextStore();
+  const {
+    reset: resetContextStore,
+    upsertContextByType,
+    context,
+  } = useContextStore();
   const { reset: resetMapStore } = useMapStore();
   const searchParams = useSearchParams();
   const [hasMounted, setHasMounted] = useState(false);
+  const defaultLayerSeededRef = useRef(false);
   const router = useRouter();
 
   useEffect(() => {
     resetChatStore();
     resetMapStore();
     resetContextStore();
+    defaultLayerSeededRef.current = false;
   }, [resetChatStore, resetContextStore, resetMapStore]);
 
   useEffect(() => {
     setHasMounted(true);
   }, []);
+
+  useEffect(() => {
+    if (defaultLayerSeededRef.current) return;
+
+    const hasLayerContext = context.some((c) => c.contextType === "layer");
+    if (hasLayerContext) {
+      defaultLayerSeededRef.current = true;
+      return;
+    }
+
+    const defaultCard = DATASET_CARDS.find(
+      (card) => card.dataset_id === DEFAULT_LANDING_DATASET_ID
+    );
+    if (!defaultCard) return;
+
+    upsertContextByType({
+      contextType: "layer",
+      ...getLayerContextFromDatasetCard(defaultCard),
+      isAiContext: false,
+    });
+    defaultLayerSeededRef.current = true;
+  }, [context, upsertContextByType]);
 
   const submitPrompt = async (prompt: string) => {
     const result = await sendMessage(prompt);

--- a/app/components/ContextMenu.tsx
+++ b/app/components/ContextMenu.tsx
@@ -35,6 +35,7 @@ import { useCustomAreasListSuspense } from "../hooks/useCustomAreasList";
 import type { CustomArea } from "../schemas/api/custom_areas/get";
 import useMapStore from "../store/mapStore";
 import type { Feature, MultiPolygon } from "geojson";
+import { getLayerContextFromDatasetCard } from "../utils/datasetCardLayerContext";
 
 const LAYER_CARDS = DATASET_CARDS;
 
@@ -88,27 +89,9 @@ function LayerCardList({
     if (existing) {
       removeContext(existing.id);
     } else {
-      const startYear = card.defaultStartYear;
-      const endYear = card.defaultEndYear;
-      // Only scope the layer when both bounds are present, so a half-configured
-      // card falls back to the unfiltered tile_url rather than a broken range.
-      const hasYears = startYear != null && endYear != null;
-      const tileUrl =
-        hasYears && card.tile_url
-          ? `${card.tile_url}&start_year=${startYear}&end_year=${endYear}`
-          : card.tile_url;
       upsertContextByType({
         contextType: "layer",
-        content: card.dataset_name,
-        datasetId: card.dataset_id,
-        tileUrl,
-        layerName: card.dataset_name,
-        ...(hasYears
-          ? {
-              startDate: `${startYear}-01-01`,
-              endDate: `${endYear}-12-31`,
-            }
-          : {}),
+        ...getLayerContextFromDatasetCard(card),
         isAiContext: false,
       });
     }

--- a/app/constants/preview-content.ts
+++ b/app/constants/preview-content.ts
@@ -12,8 +12,14 @@ export const PREVIEW_LINKS = [
     label: "FAQs",
     href: "https://help.globalnaturewatch.org/support/faqs",
   },
-  { label: "Capabilities", href: "https://help.globalnaturewatch.org/get-started/capabilities-and-datasets" },
-  { label: "Accuracy", href: "https://help.globalnaturewatch.org/get-started/accuracy-and-performance" },
+  {
+    label: "Capabilities",
+    href: "https://help.globalnaturewatch.org/get-started/capabilities-and-datasets",
+  },
+  {
+    label: "Accuracy",
+    href: "https://help.globalnaturewatch.org/get-started/accuracy-and-performance",
+  },
   {
     label: "Known Issues",
     href: "https://help.globalnaturewatch.org/resources/known-issues",

--- a/app/utils/__tests__/datasetCardLayerContext.test.ts
+++ b/app/utils/__tests__/datasetCardLayerContext.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import type { DatasetCardConfig } from "@/app/constants/datasets";
+import { getLayerContextFromDatasetCard } from "../datasetCardLayerContext";
+
+describe("getLayerContextFromDatasetCard", () => {
+  it("adds start/end year query params and dates when both defaults exist", () => {
+    const card = {
+      dataset_id: 4,
+      dataset_name: "Tree cover loss",
+      description: "",
+      tile_url: "https://example.com/tiles?x=1",
+      defaultStartYear: 2001,
+      defaultEndYear: 2025,
+    } as DatasetCardConfig;
+
+    expect(getLayerContextFromDatasetCard(card)).toEqual({
+      content: "Tree cover loss",
+      datasetId: 4,
+      tileUrl: "https://example.com/tiles?x=1&start_year=2001&end_year=2025",
+      layerName: "Tree cover loss",
+      startDate: "2001-01-01",
+      endDate: "2025-12-31",
+    });
+  });
+
+  it("keeps tile url unchanged when the default year range is partial", () => {
+    const card = {
+      dataset_id: 7,
+      dataset_name: "Tree cover",
+      description: "",
+      tile_url: "https://example.com/tiles?x=1",
+      defaultStartYear: 2000,
+    } as DatasetCardConfig;
+
+    expect(getLayerContextFromDatasetCard(card)).toEqual({
+      content: "Tree cover",
+      datasetId: 7,
+      tileUrl: "https://example.com/tiles?x=1",
+      layerName: "Tree cover",
+    });
+  });
+});

--- a/app/utils/datasetCardLayerContext.ts
+++ b/app/utils/datasetCardLayerContext.ts
@@ -1,0 +1,33 @@
+import type { ContextItem } from "@/app/store/contextStore";
+import type { DatasetCardConfig } from "@/app/constants/datasets";
+
+type LayerContextFromCard = Omit<
+  ContextItem,
+  "id" | "contextType" | "isAiContext"
+>;
+
+export function getLayerContextFromDatasetCard(
+  card: DatasetCardConfig
+): LayerContextFromCard {
+  const startYear = card.defaultStartYear;
+  const endYear = card.defaultEndYear;
+  // Only scope the layer when both bounds are present, so a half-configured
+  // card falls back to the unfiltered tile_url rather than a broken range.
+  const hasYears = startYear != null && endYear != null;
+
+  return {
+    content: card.dataset_name,
+    datasetId: card.dataset_id,
+    tileUrl:
+      hasYears && card.tile_url
+        ? `${card.tile_url}&start_year=${startYear}&end_year=${endYear}`
+        : card.tile_url,
+    layerName: card.dataset_name,
+    ...(hasYears
+      ? {
+          startDate: `${startYear}-01-01`,
+          endDate: `${endYear}-12-31`,
+        }
+      : {}),
+  };
+}


### PR DESCRIPTION
## Pull request type
- [x] Feature

## What is the current behavior?
When users open the app on a new thread (/app), no dataset layer is active by default — the map loads without Tree Cover Loss visible. Users must open the data catalog and manually select a layer to see TCL on the map.

Layer context (tile URL, date range, display name) was built inline in ContextMenu.tsx when toggling dataset cards, with no shared logic for the landing-page default.


## What is the new behavior?
Tree Cover Loss (dataset id 4) is automatically activated when landing on a new thread, using the card’s default start/end years for the tile URL and legend date range.
Layer context construction is extracted into getLayerContextFromDatasetCard, shared by the landing page and the data catalog so both paths stay in sync.
Dismissing the default TCL layer (context chip, legend, or catalog toggle) works correctly — the layer is not re-added on the same visit; it only re-seeds after a store reset (e.g. starting a new thread).
Unit tests cover year-range handling: full defaults append query params and dates; partial defaults fall back to the unfiltered tile URL.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Demo
<img width="1759" height="917" alt="Screenshot 2026-06-05 at 17 23 02" src="https://github.com/user-attachments/assets/d5e6c5c2-34d8-4fab-9809-78e46016d0c0" />
