### PR TITLE
Adjust Policy links & other cosmetic tweaks

### DIFF
--- a/app/ChatPanelCompact.tsx
+++ b/app/ChatPanelCompact.tsx
@@ -176,23 +176,23 @@ function ChatPanelCompact({ onToggleSize }: ChatPanelCompactProps) {
           />
         </Flex>
       </Flex>
-      {/* Frosted-glass disclaimer — 16px below cards 
+      {/* Frosted-glass disclaimer — sits just below the input card
         // TODO: use chakra styles and theming for this */}
       <Box
         px={2}
-        py={1}
-        mt={4}
+        py={0}
+        mt={2}
         borderRadius="sm"
         backdropFilter="blur(24px)"
         bg="whiteAlpha.200"
         fontSize="10px"
         lineHeight="20px"
         color="#131619"
-        opacity={0.5}
+        opacity={0.6}
         whiteSpace="nowrap"
       >
-        AI makes mistakes. Verify outputs and do not share any sensitive or
-        personal information.
+        AI makes mistakes. Verify outputs and do not share sensitive or personal
+        information.
       </Box>
     </Flex>
   );

--- a/app/ChatPanelFullSize.tsx
+++ b/app/ChatPanelFullSize.tsx
@@ -44,8 +44,9 @@ function ChatPanelFullSize({ onToggleSize }: ChatPanelFullSizeProps) {
         <ChatMessages />
       </Box>
 
-      {/* Input area — 12px inset, rounded bordered box */}
-      <Flex flexDir="column" flexShrink={0} px={3} pb={3}>
+      {/* Input area — rounded bordered box. pb matches ChatPanelCompact so the
+          input box bottom lines up across compact/full-size. */}
+      <Flex flexDir="column" flexShrink={0} px={3} pb={1}>
         {promptsExhausted && (
           <Box pb={2}>
             <ChatStatusInfo type="error">

--- a/app/components/Map.tsx
+++ b/app/components/Map.tsx
@@ -175,7 +175,7 @@ function Map({ disableMapAreaControls }: { disableMapAreaControls?: boolean }) {
           position="absolute"
           top={4}
           right={3}
-          bottom={{ base: "4.5rem", md: 12 }}
+          bottom={{ base: "4.5rem", md: 7 }}
           zIndex={400}
           w="420px"
           flexDirection="column"

--- a/app/components/Map.tsx
+++ b/app/components/Map.tsx
@@ -228,12 +228,12 @@ function Map({ disableMapAreaControls }: { disableMapAreaControls?: boolean }) {
           right="3"
           px="2"
           py="1"
-          fontSize="xs"
+          fontSize="0.675rem"
+          color="gray"
           bg="transparent"
           hideBelow="md"
           alignItems="center"
           gap={2}
-          style={{ fontSize: "0.675rem", color: "gray" }}
         >
           <ChLink
             href="https://www.wri.org/about/privacy-policy?sitename=landcarbonlab.org&osanoid=5a6c3f87-bd10-4df7-80c7-375ce6a77691"
@@ -280,7 +280,7 @@ function Map({ disableMapAreaControls }: { disableMapAreaControls?: boolean }) {
           >
             lat, lon: {mapCenter[1].toFixed(3)}, {mapCenter[0].toFixed(3)}
           </Code>
-          <span style={{ marginLeft: "0.5rem" }}>
+          <Box as="span" ml={2}>
             Background tiles: ©{" "}
             <ChLink
               href="https://www.openstreetmap.org/copyright"
@@ -290,7 +290,7 @@ function Map({ disableMapAreaControls }: { disableMapAreaControls?: boolean }) {
             >
               OpenStreetMap contributors
             </ChLink>
-          </span>
+          </Box>
         </Flex>
       </MapGl>
     </Box>

--- a/app/components/Map.tsx
+++ b/app/components/Map.tsx
@@ -1,11 +1,6 @@
 "use client";
 import "maplibre-gl/dist/maplibre-gl.css";
-import MapGl, {
-  Layer,
-  Source,
-  AttributionControl,
-  MapRef,
-} from "react-map-gl/maplibre";
+import MapGl, { Layer, Source, MapRef } from "react-map-gl/maplibre";
 import { useState, useRef, useEffect } from "react";
 import { registerPrimaryForestProtocol } from "@/app/utils/primaryForestTileProtocol";
 import {
@@ -13,7 +8,6 @@ import {
   Code,
   Box,
   Button,
-  useBreakpointValue,
   Flex,
   Link as ChLink,
   Spinner,
@@ -41,7 +35,6 @@ function Map({ disableMapAreaControls }: { disableMapAreaControls?: boolean }) {
   const mapRef = useRef<MapRef>(null);
   const [mapCenter, setMapCenter] = useState([0, 0]);
   const [showLegend, setShowLegend] = useState(false);
-  const isMobile = useBreakpointValue({ base: true, md: false });
   const [basemapTiles, setBasemapTiles] = useState(
     "devseed/cmazl5ws500bz01scaa27dqi4"
   );
@@ -229,27 +222,18 @@ function Map({ disableMapAreaControls }: { disableMapAreaControls?: boolean }) {
         <AbsoluteCenter fontSize="sm" opacity={0.375} hideBelow="md">
           <PlusIcon />
         </AbsoluteCenter>
-        <AttributionControl
-          customAttribution="Background tiles: © <a href='https://www.openstreetmap.org/copyright'>OpenStreetMap contributors</a>"
-          position="bottom-right"
-          compact={isMobile ? true : false}
-          style={{
-            background: "transparent",
-            fontSize: "0.675rem",
-            color: "gray",
-          }}
-        />
-
         <Flex
           pos="absolute"
-          bottom="4"
+          bottom="0"
           right="3"
-          p="2"
+          px="2"
+          py="1"
           fontSize="xs"
           bg="transparent"
           hideBelow="md"
-          alignItems="baseline"
+          alignItems="center"
           gap={2}
+          style={{ fontSize: "0.675rem", color: "gray" }}
         >
           <ChLink
             href="https://www.wri.org/about/privacy-policy?sitename=landcarbonlab.org&osanoid=5a6c3f87-bd10-4df7-80c7-375ce6a77691"
@@ -296,6 +280,17 @@ function Map({ disableMapAreaControls }: { disableMapAreaControls?: boolean }) {
           >
             lat, lon: {mapCenter[1].toFixed(3)}, {mapCenter[0].toFixed(3)}
           </Code>
+          <span style={{ marginLeft: "0.5rem" }}>
+            Background tiles: ©{" "}
+            <ChLink
+              href="https://www.openstreetmap.org/copyright"
+              target="_blank"
+              rel="noopener noreferrer"
+              color="inherit"
+            >
+              OpenStreetMap contributors
+            </ChLink>
+          </span>
         </Flex>
       </MapGl>
     </Box>

--- a/app/components/MapAreaControls.tsx
+++ b/app/components/MapAreaControls.tsx
@@ -22,6 +22,7 @@ import {
   MapTrifoldIcon,
 } from "@phosphor-icons/react";
 
+import { MapRef } from "react-map-gl/maplibre";
 import { LayerId, selectLayerOptions } from "../types/map";
 import useMapStore from "../store/mapStore";
 import { Tooltip } from "./ui/tooltip";
@@ -32,6 +33,68 @@ import useContextStore from "../store/contextStore";
 import { BasemapSelector } from "./map/BasemapSelector";
 import useSidebarStore from "../store/sidebarStore";
 import { FeatureRef } from "../store/layerManagerSlice";
+
+const NICE_DISTANCES = [
+  1, 2, 5, 10, 20, 50, 100, 200, 500, 1_000, 2_000, 5_000, 10_000, 20_000,
+  50_000, 100_000, 200_000, 500_000, 1_000_000, 2_000_000, 5_000_000,
+  10_000_000,
+];
+const TARGET_WIDTH_PX = 80;
+
+function ScaleBar({ mapRef }: { mapRef: MapRef | null }) {
+  const [bar, setBar] = useState<{ label: string; width: number } | null>(null);
+
+  useEffect(() => {
+    if (!mapRef) return;
+    const map = mapRef.getMap();
+
+    const update = () => {
+      const zoom = map.getZoom();
+      const lat = map.getCenter().lat;
+      const metersPerPx =
+        (40075016.686 * Math.cos((lat * Math.PI) / 180)) /
+        Math.pow(2, zoom + 9);
+      const maxMeters = TARGET_WIDTH_PX * metersPerPx;
+      const nice =
+        [...NICE_DISTANCES].reverse().find((d) => d <= maxMeters) ??
+        NICE_DISTANCES[0];
+      const width = nice / metersPerPx;
+      const label = nice >= 1000 ? `${nice / 1000} km` : `${nice} m`;
+      setBar({ label, width });
+    };
+
+    update();
+    map.on("move", update);
+    return () => {
+      map.off("move", update);
+    };
+  }, [mapRef]);
+
+  if (!bar) return null;
+
+  return (
+    <Box
+      minW={`${bar.width}px`}
+      whiteSpace="nowrap"
+      borderBottom="2px solid"
+      borderLeft="2px solid"
+      borderRight="2px solid"
+      borderColor="rgba(0,0,0,0.5)"
+      bg="transparent"
+      px={1}
+      textAlign="center"
+      fontSize="0.6rem"
+      color="rgba(0,0,0,0.7)"
+      lineHeight="1.4"
+      _dark={{
+        borderColor: "bg.subtle",
+        color: "fg",
+      }}
+    >
+      {bar.label}
+    </Box>
+  );
+}
 
 function Wrapper({
   children,
@@ -174,7 +237,7 @@ function MapAreaControls({
         gap={1}
         pointerEvents="auto"
         zIndex={200}
-        alignItems="center"
+        alignItems="flex-start"
       >
         <BasemapSelector
           inline
@@ -217,6 +280,7 @@ function MapAreaControls({
             </IconButton>
           </Tooltip>
         </Box>
+        <ScaleBar mapRef={mapRef} />
       </Flex>
       {/* Area tools: in full-size mode, anchor just right of the chat panel
           (aligned with the zoom/basemap controls above); otherwise top-left. */}

--- a/app/components/MapAreaControls.tsx
+++ b/app/components/MapAreaControls.tsx
@@ -22,7 +22,6 @@ import {
   MapTrifoldIcon,
 } from "@phosphor-icons/react";
 
-import { MapRef } from "react-map-gl/maplibre";
 import { LayerId, selectLayerOptions } from "../types/map";
 import useMapStore from "../store/mapStore";
 import { Tooltip } from "./ui/tooltip";
@@ -31,70 +30,9 @@ import { formatAreaWithUnits } from "../utils/formatArea";
 import { useCustomAreasCreate } from "../hooks/useCustomAreasCreate";
 import useContextStore from "../store/contextStore";
 import { BasemapSelector } from "./map/BasemapSelector";
+import { ScaleBar } from "./map/ScaleBar";
 import useSidebarStore from "../store/sidebarStore";
 import { FeatureRef } from "../store/layerManagerSlice";
-
-const NICE_DISTANCES = [
-  1, 2, 5, 10, 20, 50, 100, 200, 500, 1_000, 2_000, 5_000, 10_000, 20_000,
-  50_000, 100_000, 200_000, 500_000, 1_000_000, 2_000_000, 5_000_000,
-  10_000_000,
-];
-const TARGET_WIDTH_PX = 80;
-
-function ScaleBar({ mapRef }: { mapRef: MapRef | null }) {
-  const [bar, setBar] = useState<{ label: string; width: number } | null>(null);
-
-  useEffect(() => {
-    if (!mapRef) return;
-    const map = mapRef.getMap();
-
-    const update = () => {
-      const zoom = map.getZoom();
-      const lat = map.getCenter().lat;
-      const metersPerPx =
-        (40075016.686 * Math.cos((lat * Math.PI) / 180)) /
-        Math.pow(2, zoom + 9);
-      const maxMeters = TARGET_WIDTH_PX * metersPerPx;
-      const nice =
-        [...NICE_DISTANCES].reverse().find((d) => d <= maxMeters) ??
-        NICE_DISTANCES[0];
-      const width = nice / metersPerPx;
-      const label = nice >= 1000 ? `${nice / 1000} km` : `${nice} m`;
-      setBar({ label, width });
-    };
-
-    update();
-    map.on("move", update);
-    return () => {
-      map.off("move", update);
-    };
-  }, [mapRef]);
-
-  if (!bar) return null;
-
-  return (
-    <Box
-      minW={`${bar.width}px`}
-      whiteSpace="nowrap"
-      borderBottom="2px solid"
-      borderLeft="2px solid"
-      borderRight="2px solid"
-      borderColor="rgba(0,0,0,0.5)"
-      bg="transparent"
-      px={1}
-      textAlign="center"
-      fontSize="0.6rem"
-      color="rgba(0,0,0,0.7)"
-      lineHeight="1.4"
-      _dark={{
-        borderColor: "bg.subtle",
-        color: "fg",
-      }}
-    >
-      {bar.label}
-    </Box>
-  );
-}
 
 function Wrapper({
   children,
@@ -227,7 +165,10 @@ function MapAreaControls({
       borderColor={selectionMode ? "secondary.400" : "transparent"}
       pl={{ base: 2, md: isChatFullSize ? 0 : 3 }}
     >
-      {/* Chat-panel-adjacent controls: basemap + zoom — desktop only */}
+      {/* Chat-panel-adjacent controls: basemap + zoom — desktop only.
+          bottom={8} (32px) aligns the stack with the bottom of ChatPanelCompact's
+          input card — i.e. its pb + disclaimer height + mt. If that disclaimer's
+          spacing changes, this offset must follow. */}
       <Flex
         display={{ base: "none", md: "flex" }}
         position="absolute"

--- a/app/components/MapAreaControls.tsx
+++ b/app/components/MapAreaControls.tsx
@@ -231,7 +231,7 @@ function MapAreaControls({
       <Flex
         display={{ base: "none", md: "flex" }}
         position="absolute"
-        bottom={12}
+        bottom={8}
         left={{ base: 2, md: isChatFullSize ? "436px" : "416px" }}
         flexDirection="column"
         gap={1}

--- a/app/components/map/ScaleBar.tsx
+++ b/app/components/map/ScaleBar.tsx
@@ -1,0 +1,72 @@
+"use client";
+import { useEffect, useState } from "react";
+import { Box } from "@chakra-ui/react";
+import { MapRef } from "react-map-gl/maplibre";
+
+const NICE_DISTANCES = [
+  1, 2, 5, 10, 20, 50, 100, 200, 500, 1_000, 2_000, 5_000, 10_000, 20_000,
+  50_000, 100_000, 200_000, 500_000, 1_000_000, 2_000_000, 5_000_000,
+  10_000_000,
+];
+const TARGET_WIDTH_PX = 80;
+
+export function ScaleBar({ mapRef }: { mapRef: MapRef | null }) {
+  const [bar, setBar] = useState<{ label: string; width: number } | null>(null);
+
+  useEffect(() => {
+    if (!mapRef) return;
+    const map = mapRef.getMap();
+
+    const update = () => {
+      const zoom = map.getZoom();
+      const lat = map.getCenter().lat;
+      const metersPerPx =
+        (40075016.686 * Math.cos((lat * Math.PI) / 180)) /
+        Math.pow(2, zoom + 9);
+      const maxMeters = TARGET_WIDTH_PX * metersPerPx;
+      const nice =
+        NICE_DISTANCES.findLast((d) => d <= maxMeters) ?? NICE_DISTANCES[0];
+      const width = nice / metersPerPx;
+      const label = nice >= 1000 ? `${nice / 1000} km` : `${nice} m`;
+      // Bail out of the re-render when the bar is unchanged — `move` fires
+      // every frame during pan/zoom, but the label/width only shift across
+      // discrete zoom thresholds.
+      setBar((prev) =>
+        prev && prev.label === label && prev.width === width
+          ? prev
+          : { label, width }
+      );
+    };
+
+    update();
+    map.on("move", update);
+    return () => {
+      map.off("move", update);
+    };
+  }, [mapRef]);
+
+  if (!bar) return null;
+
+  return (
+    <Box
+      minW={`${bar.width}px`}
+      whiteSpace="nowrap"
+      borderBottom="2px solid"
+      borderLeft="2px solid"
+      borderRight="2px solid"
+      borderColor="rgba(0,0,0,0.5)"
+      bg="transparent"
+      px={1}
+      textAlign="center"
+      fontSize="0.6rem"
+      color="rgba(0,0,0,0.7)"
+      lineHeight="1.4"
+      _dark={{
+        borderColor: "bg.subtle",
+        color: "fg",
+      }}
+    >
+      {bar.label}
+    </Box>
+  );
+}


### PR DESCRIPTION
Small tidy up of map styles and component alignment:
- move policy links inline with OSM attribution
- reposition map controls and add back zoom scale bar
- drop chat and legend components to use full space
- align compact chat pane with disclaimer panel
- expand conversation history panel to use all available space