### PR TITLE
Prototype - floating panel

### DIFF
--- a/app/ChatPanel.tsx
+++ b/app/ChatPanel.tsx
@@ -1,54 +1,167 @@
 "use client";
 
-import { useState } from "react";
-import { AnimatePresence, motion } from "framer-motion";
+import { useRef, useState } from "react";
+import {
+  AnimatePresence,
+  animate,
+  motion,
+  useDragControls,
+  useMotionValue,
+} from "framer-motion";
 import ChatPanelCompact from "./ChatPanelCompact";
 import ChatPanelFullSize from "./ChatPanelFullSize";
 import useSidebarStore from "./store/sidebarStore";
 
+// [PROTOTYPE] Floating compact panel
+// ─────────────────────────────────────────────────────────────────────────────
+// The compact panel is rendered as a `position:fixed` framer-motion element
+// so it can be freely dragged anywhere on screen, independent of the normal
+// flex layout used by the full-size panel.
+//
+// Key decisions:
+//  • `dragListener={false}` + `dragControls` — drag only starts when the user
+//    grabs the explicit handle in ChatPanelHeader, not by clicking anywhere on
+//    the panel.
+//  • `useMotionValue` for x/y — lets us read the current position imperatively
+//    in onDragEnd and animate it back to 0 via framer-motion's spring without
+//    triggering a re-render on every frame.
+//  • `constraintRef` div — a transparent fixed overlay whose bounding box
+//    framer-motion uses to clamp the drag. Its top is offset by the page-header
+//    height (40px) so the panel header can never slide behind the page header.
+//  • `isChatPanelAtHome` in sidebarStore — shared flag that MapAreaControls
+//    reads to reposition the zoom/basemap controls when the panel moves away
+//    from its default left-anchored position.
+// ─────────────────────────────────────────────────────────────────────────────
+
+// If the panel is released within this many px of its home position (x=0),
+// spring it back to the default bottom-left corner.
+const SNAP_THRESHOLD_PX = 120;
+
 function ChatPanel() {
   const [isFullSize, setIsFullSize] = useState(false);
-  const { setChatFullSize } = useSidebarStore();
+  const { setChatFullSize, setChatPanelAtHome } = useSidebarStore();
+
+  // dragControls is passed down to ChatPanelHeader so only the drag-handle
+  // icon triggers a drag, not accidental clicks on buttons or text.
+  const dragControls = useDragControls();
+
+  // x/y are framer-motion MotionValues — they drive the CSS transform applied
+  // on top of the fixed bottom/left CSS position. Reset to 0 = panel is home.
+  const x = useMotionValue(0);
+  const y = useMotionValue(0);
+
+  // Transparent full-viewport div. framer-motion measures its bounding box on
+  // each drag start and uses it to clamp the element's transform range.
+  const constraintRef = useRef<HTMLDivElement>(null);
 
   const toggleSize = () => {
     setIsFullSize((prev) => {
-      setChatFullSize(!prev);
-      return !prev;
+      const next = !prev;
+      if (next) {
+        // Switching to full-size: reset position so that switching back to
+        // compact always starts from the default bottom-left corner.
+        x.set(0);
+        y.set(0);
+        setChatPanelAtHome(true);
+      }
+      setChatFullSize(next);
+      return next;
     });
   };
 
+  // Tell MapAreaControls to move the zoom/basemap stack to the left edge as
+  // soon as a drag begins — so they don't sit behind a dragged panel.
+  const handleDragStart = () => {
+    setChatPanelAtHome(false);
+  };
+
+  // On release, snap back if the panel is still close to its home column.
+  // If it's been dragged further away the user intentionally repositioned it,
+  // so we leave it in place (controls stay left-anchored via isChatPanelAtHome).
+  const handleDragEnd = () => {
+    if (Math.abs(x.get()) < SNAP_THRESHOLD_PX) {
+      animate(x, 0, { type: "spring", stiffness: 400, damping: 40 });
+      animate(y, 0, { type: "spring", stiffness: 400, damping: 40 });
+      setChatPanelAtHome(true);
+    }
+  };
+
   return (
-    <AnimatePresence mode="wait">
-      {isFullSize ? (
-        <motion.div
-          key="fullsize"
-          initial={{ opacity: 0, x: -16 }}
-          animate={{ opacity: 1, x: 0 }}
-          exit={{ opacity: 0, x: -16 }}
-          transition={{ duration: 0.2, ease: "easeInOut" }}
-          style={{
-            display: "flex",
-            flexDirection: "column",
-            flex: "1 1 auto",
-            minHeight: 0,
-            height: "100%",
-          }}
-        >
-          <ChatPanelFullSize onToggleSize={toggleSize} />
-        </motion.div>
-      ) : (
-        <motion.div
-          key="compact"
-          initial={{ opacity: 0, x: -16 }}
-          animate={{ opacity: 1, x: 0 }}
-          exit={{ opacity: 0, x: -16 }}
-          transition={{ duration: 0.2, ease: "easeInOut" }}
-          style={{ display: "flex", flexDirection: "column", height: "100%" }}
-        >
-          <ChatPanelCompact onToggleSize={toggleSize} />
-        </motion.div>
-      )}
-    </AnimatePresence>
+    <>
+      {/* Drag boundary — covers the viewport below the 40px page header.
+          framer-motion computes allowed transform ranges from this rect, so
+          the panel header can never overlap the page header. */}
+      <div
+        ref={constraintRef}
+        style={{
+          position: "fixed",
+          top: 40, // page header height — update if PageHeader h changes
+          left: 0,
+          right: 0,
+          bottom: 0,
+          pointerEvents: "none",
+          zIndex: 0,
+        }}
+      />
+      <AnimatePresence mode="wait">
+        {isFullSize ? (
+          <motion.div
+            key="fullsize"
+            initial={{ opacity: 0, x: -16 }}
+            animate={{ opacity: 1, x: 0 }}
+            exit={{ opacity: 0, x: -16 }}
+            transition={{ duration: 0.2, ease: "easeInOut" }}
+            style={{
+              display: "flex",
+              flexDirection: "column",
+              flex: "1 1 auto",
+              minHeight: 0,
+              height: "100%",
+            }}
+          >
+            <ChatPanelFullSize onToggleSize={toggleSize} />
+          </motion.div>
+        ) : (
+          // [PROTOTYPE] The compact panel escapes the normal flex layout by
+          // using position:fixed. The x/y MotionValues are applied as a CSS
+          // transform on top of the static bottom/left anchoring, so:
+          //   • at rest  → panel sits at bottom:8px, left:12px
+          //   • dragging → transform:translate(x,y) offsets from that anchor
+          //   • snap     → spring animation back to x=0, y=0
+          <motion.div
+            key="compact"
+            drag
+            dragControls={dragControls}
+            dragListener={false} // only the handle icon starts a drag
+            dragMomentum={false} // no inertia after release — feels more precise
+            dragConstraints={constraintRef}
+            onDragStart={handleDragStart}
+            onDragEnd={handleDragEnd}
+            style={{
+              x,
+              y,
+              position: "fixed",
+              bottom: 8,
+              left: 12,
+              zIndex: 9999, // above chart overlays (9000) and all other UI layers
+              pointerEvents: "auto",
+              // Prevent the browser from selecting text in the panel (and across
+              // the rest of the page) while the user is dragging.
+              userSelect: "none",
+            }}
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.2, ease: "easeInOut" }}
+          >
+            <ChatPanelCompact
+              onToggleSize={toggleSize}
+              dragControls={dragControls}
+            />
+          </motion.div>
+        )}
+      </AnimatePresence>
+    </>
   );
 }
 

--- a/app/ChatPanelCompact.tsx
+++ b/app/ChatPanelCompact.tsx
@@ -2,7 +2,7 @@
 
 import { Flex, Box, Text, Link as ChLink } from "@chakra-ui/react";
 import Link from "next/link";
-import { AnimatePresence, motion } from "framer-motion";
+import { AnimatePresence, motion, type DragControls } from "framer-motion";
 
 import ChatInput from "./components/ChatInput";
 import ChatMessages from "./components/ChatMessages";
@@ -33,9 +33,13 @@ const cardStyle = {
 
 interface ChatPanelCompactProps {
   onToggleSize: () => void;
+  dragControls?: DragControls;
 }
 
-function ChatPanelCompact({ onToggleSize }: ChatPanelCompactProps) {
+function ChatPanelCompact({
+  onToggleSize,
+  dragControls,
+}: ChatPanelCompactProps) {
   const { usedPrompts, totalPrompts } = useAuthStore();
   const promptsExhausted = usedPrompts >= totalPrompts;
   const { messages } = useChatStore();
@@ -93,14 +97,22 @@ function ChatPanelCompact({ onToggleSize }: ChatPanelCompactProps) {
     };
   }, [recomputeMaxH, isCollapsed]);
 
+  // [PROTOTYPE] dragControls being present signals the panel is in floating
+  // (position:fixed, draggable) mode. In this mode the outer Flex wrapper no
+  // longer needs h="100%" / justifyContent="flex-end" for bottom-anchoring —
+  // that's handled by the fixed CSS in ChatPanel. The disclaimer is also hidden
+  // here because floating mode shows it as a tooltip on an info icon in the
+  // header instead (see ChatPanelHeader).
+  const isFloating = !!dragControls;
+
   return (
     <Flex
       flexDir="column"
-      justifyContent="flex-end"
-      h="100%"
-      pt={2}
-      pb={1}
-      pl={{ base: 0, md: 3 }}
+      justifyContent={isFloating ? undefined : "flex-end"}
+      h={isFloating ? undefined : "100%"}
+      pt={isFloating ? 1 : 2}
+      pb={isFloating ? 1 : 1}
+      pl={isFloating ? 0 : { base: 0, md: 3 }} // fixed left:12 in parent provides margin in floating mode
       pointerEvents="none"
     >
       <Flex
@@ -117,6 +129,7 @@ function ChatPanelCompact({ onToggleSize }: ChatPanelCompactProps) {
             onToggleSize={onToggleSize}
             isCollapsed={isCollapsed}
             onToggleCollapse={() => setIsCollapsed((v) => !v)}
+            dragControls={dragControls}
           />
           {/* Animated collapse/expand of message content */}
           <AnimatePresence initial={false}>
@@ -176,24 +189,27 @@ function ChatPanelCompact({ onToggleSize }: ChatPanelCompactProps) {
           />
         </Flex>
       </Flex>
-      {/* Frosted-glass disclaimer — sits just below the input card
-        // TODO: use chakra styles and theming for this */}
-      <Box
-        px={2}
-        py={0}
-        mt={2}
-        borderRadius="sm"
-        backdropFilter="blur(24px)"
-        bg="whiteAlpha.200"
-        fontSize="10px"
-        lineHeight="20px"
-        color="#131619"
-        opacity={0.6}
-        whiteSpace="nowrap"
-      >
-        AI makes mistakes. Verify outputs and do not share sensitive or personal
-        information.
-      </Box>
+      {/* Frosted-glass disclaimer — sits just below the input card.
+          Hidden in floating mode; an info button in the header serves instead.
+          TODO: use chakra styles and theming for this */}
+      {!isFloating && (
+        <Box
+          px={2}
+          py={0}
+          mt={2}
+          borderRadius="sm"
+          backdropFilter="blur(24px)"
+          bg="whiteAlpha.200"
+          fontSize="10px"
+          lineHeight="20px"
+          color="#131619"
+          opacity={0.6}
+          whiteSpace="nowrap"
+        >
+          AI makes mistakes. Verify outputs and do not share sensitive or
+          personal information.
+        </Box>
+      )}
     </Flex>
   );
 }

--- a/app/ChatPanelCompact.tsx
+++ b/app/ChatPanelCompact.tsx
@@ -176,23 +176,23 @@ function ChatPanelCompact({ onToggleSize }: ChatPanelCompactProps) {
           />
         </Flex>
       </Flex>
-      {/* Frosted-glass disclaimer — 16px below cards 
+      {/* Frosted-glass disclaimer — sits just below the input card
         // TODO: use chakra styles and theming for this */}
       <Box
         px={2}
-        py={1}
-        mt={4}
+        py={0}
+        mt={2}
         borderRadius="sm"
         backdropFilter="blur(24px)"
         bg="whiteAlpha.200"
         fontSize="10px"
         lineHeight="20px"
         color="#131619"
-        opacity={0.5}
+        opacity={0.6}
         whiteSpace="nowrap"
       >
-        AI makes mistakes. Verify outputs and do not share any sensitive or
-        personal information.
+        AI makes mistakes. Verify outputs and do not share sensitive or personal
+        information.
       </Box>
     </Flex>
   );

--- a/app/ChatPanelFullSize.tsx
+++ b/app/ChatPanelFullSize.tsx
@@ -44,8 +44,9 @@ function ChatPanelFullSize({ onToggleSize }: ChatPanelFullSizeProps) {
         <ChatMessages />
       </Box>
 
-      {/* Input area — 12px inset, rounded bordered box */}
-      <Flex flexDir="column" flexShrink={0} px={3} pb={3}>
+      {/* Input area — rounded bordered box. pb matches ChatPanelCompact so the
+          input box bottom lines up across compact/full-size. */}
+      <Flex flexDir="column" flexShrink={0} px={3} pb={1}>
         {promptsExhausted && (
           <Box pb={2}>
             <ChatStatusInfo type="error">

--- a/app/ChatPanelHeader.tsx
+++ b/app/ChatPanelHeader.tsx
@@ -1,11 +1,14 @@
-import { Flex, IconButton, Text } from "@chakra-ui/react";
+import { Flex, IconButton, Text, Box } from "@chakra-ui/react";
 import {
   SidebarSimpleIcon,
   SparkleIcon,
   CaretDownIcon,
   CaretUpIcon,
+  DotsSixVerticalIcon,
+  InfoIcon,
 } from "@phosphor-icons/react";
 import { Tooltip } from "./components/ui/tooltip";
+import type { DragControls } from "framer-motion";
 
 interface ChatPanelHeaderProps {
   /** Whether the panel is in full-size mode (vs compact) */
@@ -18,6 +21,8 @@ interface ChatPanelHeaderProps {
   isCollapsed?: boolean;
   /** Called when the user clicks the caret (collapse/expand compact). Compact only. */
   onToggleCollapse?: () => void;
+  /** Framer-motion drag controls — when provided, shows a drag handle icon */
+  dragControls?: DragControls;
 }
 
 function ChatPanelHeader({
@@ -26,6 +31,7 @@ function ChatPanelHeader({
   onToggleSize,
   isCollapsed = false,
   onToggleCollapse,
+  dragControls,
 }: ChatPanelHeaderProps) {
   return (
     <Flex
@@ -38,18 +44,58 @@ function ChatPanelHeader({
       hideBelow="md"
       flexShrink={0}
     >
+      {/* [PROTOTYPE] Drag handle — only rendered in floating compact mode.
+          onPointerDown calls dragControls.start(e) which tells framer-motion
+          to begin a drag on the parent motion.div. Because the parent has
+          dragListener={false}, this is the ONLY way a drag can start, keeping
+          clicks on buttons and text from accidentally moving the panel. */}
+      {dragControls && (
+        <Box
+          as="span"
+          cursor="grab"
+          color="neutral.400"
+          display="flex"
+          alignItems="center"
+          flexShrink={0}
+          onPointerDown={(e: React.PointerEvent) => dragControls.start(e)}
+          _active={{ cursor: "grabbing" }}
+        >
+          <DotsSixVerticalIcon size={16} />
+        </Box>
+      )}
       <SparkleIcon size={16} color="var(--chakra-colors-neutral-500)" />
-      <Text
-        fontFamily="mono"
-        fontSize="10px"
-        lineHeight="16px"
-        fontWeight="normal"
-        letterSpacing="0.3px"
-        textTransform="uppercase"
-        color="neutral.500"
-      >
-        AI Assistant
-      </Text>
+      <Flex alignItems="center" gap={1}>
+        <Text
+          fontFamily="mono"
+          fontSize="10px"
+          lineHeight="16px"
+          fontWeight="normal"
+          letterSpacing="0.3px"
+          textTransform="uppercase"
+          color="neutral.500"
+        >
+          AI Assistant
+        </Text>
+        {/* [PROTOTYPE] Disclaimer info icon — shown inline with the label in
+            floating mode instead of the frosted-glass text below the cards.
+            The full disclaimer text lives in the Tooltip content. */}
+        {dragControls && (
+          <Tooltip
+            content="AI makes mistakes. Verify outputs and do not share any sensitive or personal information."
+            showArrow
+          >
+            <Box
+              as="span"
+              color="neutral.400"
+              display="flex"
+              alignItems="center"
+              cursor="default"
+            >
+              <InfoIcon size={12} />
+            </Box>
+          </Tooltip>
+        )}
+      </Flex>
       <Flex ml="auto" gap={1}>
         <Tooltip
           content={

--- a/app/app/(chat)/layout.tsx
+++ b/app/app/(chat)/layout.tsx
@@ -85,7 +85,7 @@ export default function DashboardLayout({
         <Portal>
           <Drawer.Backdrop backdropFilter="blur(2px)" />
           <Drawer.Positioner>
-            <Drawer.Content maxW="16rem" w="16rem">
+            <Drawer.Content maxW="428px" w="428px">
               <Sidebar />
             </Drawer.Content>
           </Drawer.Positioner>

--- a/app/components/ChatMessages.tsx
+++ b/app/components/ChatMessages.tsx
@@ -90,7 +90,7 @@ function ChatMessages() {
   );
 
   return (
-    <Box ref={containerRef} fontSize="sm">
+    <Box ref={containerRef} fontSize="xs">
       {messages.map((message, index) => {
         // Check if this message is consecutive to the previous one of the same type
         const previousMessage = index > 0 ? messages[index - 1] : null;

--- a/app/components/ContextButton.tsx
+++ b/app/components/ContextButton.tsx
@@ -28,7 +28,7 @@ function ContextButton({ contextType = "area", ...props }: ContextButtonProps) {
       px="2"
       h="8"
       gap="1"
-      fontSize="sm"
+      fontSize="xs"
       fontWeight="normal"
       {...props}
     >

--- a/app/components/Map.tsx
+++ b/app/components/Map.tsx
@@ -175,7 +175,7 @@ function Map({ disableMapAreaControls }: { disableMapAreaControls?: boolean }) {
           position="absolute"
           top={4}
           right={3}
-          bottom={{ base: "4.5rem", md: 12 }}
+          bottom={{ base: "4.5rem", md: 7 }}
           zIndex={400}
           w="420px"
           flexDirection="column"

--- a/app/components/Map.tsx
+++ b/app/components/Map.tsx
@@ -228,12 +228,12 @@ function Map({ disableMapAreaControls }: { disableMapAreaControls?: boolean }) {
           right="3"
           px="2"
           py="1"
-          fontSize="xs"
+          fontSize="0.675rem"
+          color="gray"
           bg="transparent"
           hideBelow="md"
           alignItems="center"
           gap={2}
-          style={{ fontSize: "0.675rem", color: "gray" }}
         >
           <ChLink
             href="https://www.wri.org/about/privacy-policy?sitename=landcarbonlab.org&osanoid=5a6c3f87-bd10-4df7-80c7-375ce6a77691"
@@ -280,7 +280,7 @@ function Map({ disableMapAreaControls }: { disableMapAreaControls?: boolean }) {
           >
             lat, lon: {mapCenter[1].toFixed(3)}, {mapCenter[0].toFixed(3)}
           </Code>
-          <span style={{ marginLeft: "0.5rem" }}>
+          <Box as="span" ml={2}>
             Background tiles: ©{" "}
             <ChLink
               href="https://www.openstreetmap.org/copyright"
@@ -290,7 +290,7 @@ function Map({ disableMapAreaControls }: { disableMapAreaControls?: boolean }) {
             >
               OpenStreetMap contributors
             </ChLink>
-          </span>
+          </Box>
         </Flex>
       </MapGl>
     </Box>

--- a/app/components/Map.tsx
+++ b/app/components/Map.tsx
@@ -1,11 +1,6 @@
 "use client";
 import "maplibre-gl/dist/maplibre-gl.css";
-import MapGl, {
-  Layer,
-  Source,
-  AttributionControl,
-  MapRef,
-} from "react-map-gl/maplibre";
+import MapGl, { Layer, Source, MapRef } from "react-map-gl/maplibre";
 import { useState, useRef, useEffect } from "react";
 import { registerPrimaryForestProtocol } from "@/app/utils/primaryForestTileProtocol";
 import {
@@ -13,7 +8,6 @@ import {
   Code,
   Box,
   Button,
-  useBreakpointValue,
   Flex,
   Link as ChLink,
   Spinner,
@@ -41,7 +35,6 @@ function Map({ disableMapAreaControls }: { disableMapAreaControls?: boolean }) {
   const mapRef = useRef<MapRef>(null);
   const [mapCenter, setMapCenter] = useState([0, 0]);
   const [showLegend, setShowLegend] = useState(false);
-  const isMobile = useBreakpointValue({ base: true, md: false });
   const [basemapTiles, setBasemapTiles] = useState(
     "devseed/cmazl5ws500bz01scaa27dqi4"
   );
@@ -229,27 +222,18 @@ function Map({ disableMapAreaControls }: { disableMapAreaControls?: boolean }) {
         <AbsoluteCenter fontSize="sm" opacity={0.375} hideBelow="md">
           <PlusIcon />
         </AbsoluteCenter>
-        <AttributionControl
-          customAttribution="Background tiles: © <a href='https://www.openstreetmap.org/copyright'>OpenStreetMap contributors</a>"
-          position="bottom-right"
-          compact={isMobile ? true : false}
-          style={{
-            background: "transparent",
-            fontSize: "0.675rem",
-            color: "gray",
-          }}
-        />
-
         <Flex
           pos="absolute"
-          bottom="4"
+          bottom="0"
           right="3"
-          p="2"
+          px="2"
+          py="1"
           fontSize="xs"
           bg="transparent"
           hideBelow="md"
-          alignItems="baseline"
+          alignItems="center"
           gap={2}
+          style={{ fontSize: "0.675rem", color: "gray" }}
         >
           <ChLink
             href="https://www.wri.org/about/privacy-policy?sitename=landcarbonlab.org&osanoid=5a6c3f87-bd10-4df7-80c7-375ce6a77691"
@@ -296,6 +280,17 @@ function Map({ disableMapAreaControls }: { disableMapAreaControls?: boolean }) {
           >
             lat, lon: {mapCenter[1].toFixed(3)}, {mapCenter[0].toFixed(3)}
           </Code>
+          <span style={{ marginLeft: "0.5rem" }}>
+            Background tiles: ©{" "}
+            <ChLink
+              href="https://www.openstreetmap.org/copyright"
+              target="_blank"
+              rel="noopener noreferrer"
+              color="inherit"
+            >
+              OpenStreetMap contributors
+            </ChLink>
+          </span>
         </Flex>
       </MapGl>
     </Box>

--- a/app/components/MapAreaControls.tsx
+++ b/app/components/MapAreaControls.tsx
@@ -86,7 +86,7 @@ function MapAreaControls({
     mapRef,
   } = useMapStore();
   const { addContext } = useContextStore();
-  const { isChatFullSize } = useSidebarStore();
+  const { isChatFullSize, isChatPanelAtHome } = useSidebarStore();
 
   const { createAreaAsync, isCreating } = useCustomAreasCreate();
   const [showTools, setShowTools] = useState(false);
@@ -173,7 +173,16 @@ function MapAreaControls({
         display={{ base: "none", md: "flex" }}
         position="absolute"
         bottom={8}
-        left={{ base: 2, md: isChatFullSize ? "436px" : "416px" }}
+        // [PROTOTYPE] When the compact panel has been dragged away from its
+        // default left position (isChatPanelAtHome=false), anchor the controls
+        // at 16px from the left edge so they're always reachable. When the
+        // panel is home they sit right of it at 416px (or 436px in full-size).
+        // CSS transition smooths the jump between the two positions.
+        left={{
+          base: 2,
+          md: isChatFullSize ? "436px" : isChatPanelAtHome ? "416px" : "16px",
+        }}
+        transition="left 0.2s ease-in-out"
         flexDirection="column"
         gap={1}
         pointerEvents="auto"

--- a/app/components/MapAreaControls.tsx
+++ b/app/components/MapAreaControls.tsx
@@ -22,6 +22,7 @@ import {
   MapTrifoldIcon,
 } from "@phosphor-icons/react";
 
+import { MapRef } from "react-map-gl/maplibre";
 import { LayerId, selectLayerOptions } from "../types/map";
 import useMapStore from "../store/mapStore";
 import { Tooltip } from "./ui/tooltip";
@@ -32,6 +33,68 @@ import useContextStore from "../store/contextStore";
 import { BasemapSelector } from "./map/BasemapSelector";
 import useSidebarStore from "../store/sidebarStore";
 import { FeatureRef } from "../store/layerManagerSlice";
+
+const NICE_DISTANCES = [
+  1, 2, 5, 10, 20, 50, 100, 200, 500, 1_000, 2_000, 5_000, 10_000, 20_000,
+  50_000, 100_000, 200_000, 500_000, 1_000_000, 2_000_000, 5_000_000,
+  10_000_000,
+];
+const TARGET_WIDTH_PX = 80;
+
+function ScaleBar({ mapRef }: { mapRef: MapRef | null }) {
+  const [bar, setBar] = useState<{ label: string; width: number } | null>(null);
+
+  useEffect(() => {
+    if (!mapRef) return;
+    const map = mapRef.getMap();
+
+    const update = () => {
+      const zoom = map.getZoom();
+      const lat = map.getCenter().lat;
+      const metersPerPx =
+        (40075016.686 * Math.cos((lat * Math.PI) / 180)) /
+        Math.pow(2, zoom + 9);
+      const maxMeters = TARGET_WIDTH_PX * metersPerPx;
+      const nice =
+        [...NICE_DISTANCES].reverse().find((d) => d <= maxMeters) ??
+        NICE_DISTANCES[0];
+      const width = nice / metersPerPx;
+      const label = nice >= 1000 ? `${nice / 1000} km` : `${nice} m`;
+      setBar({ label, width });
+    };
+
+    update();
+    map.on("move", update);
+    return () => {
+      map.off("move", update);
+    };
+  }, [mapRef]);
+
+  if (!bar) return null;
+
+  return (
+    <Box
+      minW={`${bar.width}px`}
+      whiteSpace="nowrap"
+      borderBottom="2px solid"
+      borderLeft="2px solid"
+      borderRight="2px solid"
+      borderColor="rgba(0,0,0,0.5)"
+      bg="transparent"
+      px={1}
+      textAlign="center"
+      fontSize="0.6rem"
+      color="rgba(0,0,0,0.7)"
+      lineHeight="1.4"
+      _dark={{
+        borderColor: "bg.subtle",
+        color: "fg",
+      }}
+    >
+      {bar.label}
+    </Box>
+  );
+}
 
 function Wrapper({
   children,
@@ -174,7 +237,7 @@ function MapAreaControls({
         gap={1}
         pointerEvents="auto"
         zIndex={200}
-        alignItems="center"
+        alignItems="flex-start"
       >
         <BasemapSelector
           inline
@@ -217,6 +280,7 @@ function MapAreaControls({
             </IconButton>
           </Tooltip>
         </Box>
+        <ScaleBar mapRef={mapRef} />
       </Flex>
       {/* Area tools: in full-size mode, anchor just right of the chat panel
           (aligned with the zoom/basemap controls above); otherwise top-left. */}

--- a/app/components/MapAreaControls.tsx
+++ b/app/components/MapAreaControls.tsx
@@ -22,7 +22,6 @@ import {
   MapTrifoldIcon,
 } from "@phosphor-icons/react";
 
-import { MapRef } from "react-map-gl/maplibre";
 import { LayerId, selectLayerOptions } from "../types/map";
 import useMapStore from "../store/mapStore";
 import { Tooltip } from "./ui/tooltip";
@@ -31,70 +30,9 @@ import { formatAreaWithUnits } from "../utils/formatArea";
 import { useCustomAreasCreate } from "../hooks/useCustomAreasCreate";
 import useContextStore from "../store/contextStore";
 import { BasemapSelector } from "./map/BasemapSelector";
+import { ScaleBar } from "./map/ScaleBar";
 import useSidebarStore from "../store/sidebarStore";
 import { FeatureRef } from "../store/layerManagerSlice";
-
-const NICE_DISTANCES = [
-  1, 2, 5, 10, 20, 50, 100, 200, 500, 1_000, 2_000, 5_000, 10_000, 20_000,
-  50_000, 100_000, 200_000, 500_000, 1_000_000, 2_000_000, 5_000_000,
-  10_000_000,
-];
-const TARGET_WIDTH_PX = 80;
-
-function ScaleBar({ mapRef }: { mapRef: MapRef | null }) {
-  const [bar, setBar] = useState<{ label: string; width: number } | null>(null);
-
-  useEffect(() => {
-    if (!mapRef) return;
-    const map = mapRef.getMap();
-
-    const update = () => {
-      const zoom = map.getZoom();
-      const lat = map.getCenter().lat;
-      const metersPerPx =
-        (40075016.686 * Math.cos((lat * Math.PI) / 180)) /
-        Math.pow(2, zoom + 9);
-      const maxMeters = TARGET_WIDTH_PX * metersPerPx;
-      const nice =
-        [...NICE_DISTANCES].reverse().find((d) => d <= maxMeters) ??
-        NICE_DISTANCES[0];
-      const width = nice / metersPerPx;
-      const label = nice >= 1000 ? `${nice / 1000} km` : `${nice} m`;
-      setBar({ label, width });
-    };
-
-    update();
-    map.on("move", update);
-    return () => {
-      map.off("move", update);
-    };
-  }, [mapRef]);
-
-  if (!bar) return null;
-
-  return (
-    <Box
-      minW={`${bar.width}px`}
-      whiteSpace="nowrap"
-      borderBottom="2px solid"
-      borderLeft="2px solid"
-      borderRight="2px solid"
-      borderColor="rgba(0,0,0,0.5)"
-      bg="transparent"
-      px={1}
-      textAlign="center"
-      fontSize="0.6rem"
-      color="rgba(0,0,0,0.7)"
-      lineHeight="1.4"
-      _dark={{
-        borderColor: "bg.subtle",
-        color: "fg",
-      }}
-    >
-      {bar.label}
-    </Box>
-  );
-}
 
 function Wrapper({
   children,
@@ -227,7 +165,10 @@ function MapAreaControls({
       borderColor={selectionMode ? "secondary.400" : "transparent"}
       pl={{ base: 2, md: isChatFullSize ? 0 : 3 }}
     >
-      {/* Chat-panel-adjacent controls: basemap + zoom — desktop only */}
+      {/* Chat-panel-adjacent controls: basemap + zoom — desktop only.
+          bottom={8} (32px) aligns the stack with the bottom of ChatPanelCompact's
+          input card — i.e. its pb + disclaimer height + mt. If that disclaimer's
+          spacing changes, this offset must follow. */}
       <Flex
         display={{ base: "none", md: "flex" }}
         position="absolute"

--- a/app/components/MapAreaControls.tsx
+++ b/app/components/MapAreaControls.tsx
@@ -231,7 +231,7 @@ function MapAreaControls({
       <Flex
         display={{ base: "none", md: "flex" }}
         position="absolute"
-        bottom={12}
+        bottom={8}
         left={{ base: 2, md: isChatFullSize ? "436px" : "416px" }}
         flexDirection="column"
         gap={1}

--- a/app/components/map/ScaleBar.tsx
+++ b/app/components/map/ScaleBar.tsx
@@ -1,0 +1,72 @@
+"use client";
+import { useEffect, useState } from "react";
+import { Box } from "@chakra-ui/react";
+import { MapRef } from "react-map-gl/maplibre";
+
+const NICE_DISTANCES = [
+  1, 2, 5, 10, 20, 50, 100, 200, 500, 1_000, 2_000, 5_000, 10_000, 20_000,
+  50_000, 100_000, 200_000, 500_000, 1_000_000, 2_000_000, 5_000_000,
+  10_000_000,
+];
+const TARGET_WIDTH_PX = 80;
+
+export function ScaleBar({ mapRef }: { mapRef: MapRef | null }) {
+  const [bar, setBar] = useState<{ label: string; width: number } | null>(null);
+
+  useEffect(() => {
+    if (!mapRef) return;
+    const map = mapRef.getMap();
+
+    const update = () => {
+      const zoom = map.getZoom();
+      const lat = map.getCenter().lat;
+      const metersPerPx =
+        (40075016.686 * Math.cos((lat * Math.PI) / 180)) /
+        Math.pow(2, zoom + 9);
+      const maxMeters = TARGET_WIDTH_PX * metersPerPx;
+      const nice =
+        NICE_DISTANCES.findLast((d) => d <= maxMeters) ?? NICE_DISTANCES[0];
+      const width = nice / metersPerPx;
+      const label = nice >= 1000 ? `${nice / 1000} km` : `${nice} m`;
+      // Bail out of the re-render when the bar is unchanged — `move` fires
+      // every frame during pan/zoom, but the label/width only shift across
+      // discrete zoom thresholds.
+      setBar((prev) =>
+        prev && prev.label === label && prev.width === width
+          ? prev
+          : { label, width }
+      );
+    };
+
+    update();
+    map.on("move", update);
+    return () => {
+      map.off("move", update);
+    };
+  }, [mapRef]);
+
+  if (!bar) return null;
+
+  return (
+    <Box
+      minW={`${bar.width}px`}
+      whiteSpace="nowrap"
+      borderBottom="2px solid"
+      borderLeft="2px solid"
+      borderRight="2px solid"
+      borderColor="rgba(0,0,0,0.5)"
+      bg="transparent"
+      px={1}
+      textAlign="center"
+      fontSize="0.6rem"
+      color="rgba(0,0,0,0.7)"
+      lineHeight="1.4"
+      _dark={{
+        borderColor: "bg.subtle",
+        color: "fg",
+      }}
+    >
+      {bar.label}
+    </Box>
+  );
+}

--- a/app/sidebar.tsx
+++ b/app/sidebar.tsx
@@ -163,7 +163,7 @@ export function Sidebar() {
     <Flex
       flexDir="column"
       bg="bg.subtle"
-      w={{ base: "full", md: !sideBarVisible ? "0px" : "16rem" }}
+      w={{ base: "full", md: !sideBarVisible ? "0px" : "full" }}
       h="100%"
       gridArea="sidebar"
       overflow="hidden"

--- a/app/store/sidebarStore.ts
+++ b/app/store/sidebarStore.ts
@@ -36,6 +36,11 @@ interface SidebarState {
   apiStatus: "Idle" | "OK" | "Error";
   isChatFullSize: boolean;
   setChatFullSize: (value: boolean) => void;
+  // [PROTOTYPE] Tracks whether the floating compact panel is at its default
+  // bottom-left position (x=0, y=0). MapAreaControls reads this to shift the
+  // zoom/basemap controls to the left when the panel has been dragged away.
+  isChatPanelAtHome: boolean;
+  setChatPanelAtHome: (value: boolean) => void;
 }
 
 const computeThreadGroups = (data: ThreadEntry[]): ThreadGroups => {
@@ -72,6 +77,8 @@ const useSidebarStore = create<SidebarState>((set, get) => ({
   apiStatus: "Idle",
   isChatFullSize: false,
   setChatFullSize: (value) => set({ isChatFullSize: value }),
+  isChatPanelAtHome: true,
+  setChatPanelAtHome: (value) => set({ isChatPanelAtHome: value }),
   toggleSidebar: () =>
     set((state) => ({ sideBarVisible: !state.sideBarVisible })),
 


### PR DESCRIPTION
## Prototype: Floating Compact Chat Panel

Explores making the compact chat panel a freely draggable floating widget on desktop. The intent is to give users full access to the map while keeping the AI assistant visible — particularly useful during area selection or when inspecting map layers.

This is a **prototype branch** — code is commented for developer reference
and can be lifted directly into production work.

## What changed

### Floating compact panel (`ChatPanel.tsx`, `ChatPanelCompact.tsx`)
- Compact panel is now `position: fixed`, escaping the normal flex layout so it can be dragged anywhere on the map
- Drag is initiated **only** from an explicit grip handle in the
header (`dragListener={false}` + `dragControls`) — accidental drags from
clicks on buttons or text are prevented
- Position tracked via framer-motion `MotionValue` (no re-renders per frame)
- Panel is constrained to the viewport below the page header (40px
top offset) so it can never slide behind the nav bar
- `userSelect: none` prevents text selection across the page during drag
- `z-index: 9999` — sits above chart overlays and all other UI layers

### Magnetic snap (`ChatPanel.tsx`)
- On release, if the panel is within 120px of its home position it spring-animates back to the default bottom-left corner
- If released further away it stays put

### Map controls reposition (`MapAreaControls.tsx`, `sidebarStore.ts`)
- Added `isChatPanelAtHome` to `sidebarStore` — set `false` on drag
start, `true` on snap-back or full-size toggle
- Zoom / basemap / scale controls shift from `left: 416px` (next to panel) to `left: 16px` (left-anchored) when the panel moves away; CSS transition smooths the jump

### Header changes (`ChatPanelHeader.tsx`)
- Grip handle icon (`DotsSixVertical`) added to the left — the only drag trigger
- Disclaimer text moved out of the frosted strip below the cards and
into an info icon (`ⓘ`) tooltip inline with the "AI Assistant" label

### Conversation history panel (`sidebar.tsx`, `layout.tsx`)
- Drawer width expanded from `16rem` → `428px` to match the full-size chat panel
- Sidebar inner `Flex` changed from fixed `16rem` to `w="full"` so
it fills the wider drawer

### Typography
- Message font size: `sm` → `xs` (14px → 12px) to match the system welcome message
- Context button labels ("Open data catalog" / "Open area tools"): `sm` → `xs`