### PR TITLE
Chat panel tweaks

### DIFF
--- a/app/app/(chat)/layout.tsx
+++ b/app/app/(chat)/layout.tsx
@@ -85,7 +85,7 @@ export default function DashboardLayout({
         <Portal>
           <Drawer.Backdrop backdropFilter="blur(2px)" />
           <Drawer.Positioner>
-            <Drawer.Content maxW="16rem" w="16rem">
+            <Drawer.Content maxW="428px" w="428px">
               <Sidebar />
             </Drawer.Content>
           </Drawer.Positioner>

--- a/app/components/ContextButton.tsx
+++ b/app/components/ContextButton.tsx
@@ -6,8 +6,8 @@ import {
 } from "@phosphor-icons/react";
 
 export const ChatContextOptions = {
-  layer: { icon: <StackSimpleIcon />, label: "Open data catalog" },
-  area: { icon: <PolygonIcon />, label: "Open area tools" },
+  layer: { icon: <StackSimpleIcon />, label: "Data catalog" },
+  area: { icon: <PolygonIcon />, label: "Area tools" },
   date: { icon: <CalendarBlankIcon />, label: "Date" },
 } as const;
 
@@ -28,8 +28,9 @@ function ContextButton({ contextType = "area", ...props }: ContextButtonProps) {
       px="2"
       h="8"
       gap="1"
-      fontSize="sm"
+      fontSize="xs"
       fontWeight="normal"
+      aria-label={ChatContextOptions[contextType].label}
       {...props}
     >
       {ChatContextOptions[contextType].icon}

--- a/app/components/map/BasemapSelector.tsx
+++ b/app/components/map/BasemapSelector.tsx
@@ -23,7 +23,7 @@ const basemapOptions: BasemapOption[] = [
     tileUrl: "devseed/cmazl5ws500bz01scaa27dqi4",
     thumbnailUrl:
       "https://api.mapbox.com/styles/v1/devseed/cmazl5ws500bz01scaa27dqi4/static/0,0,0,0,0/200x200@2x?access_token=" +
-      process.env.NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN,
+      process.env.NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN + "&attribution=false&logo=false",
   },
   {
     id: "satellite",
@@ -31,7 +31,8 @@ const basemapOptions: BasemapOption[] = [
     tileUrl: "mapbox/satellite-v9",
     thumbnailUrl:
       "https://api.mapbox.com/styles/v1/mapbox/satellite-v9/static/0,0,0,0,0/200x200@2x?access_token=" +
-      process.env.NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN,
+      process.env.NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN +
+      "&attribution=false&logo=false",
   },
   {
     id: "dark",
@@ -39,7 +40,8 @@ const basemapOptions: BasemapOption[] = [
     tileUrl: "devseed/cm7nk8rlu01bm01qvb6pues5y",
     thumbnailUrl:
       "https://api.mapbox.com/styles/v1/devseed/cm7nk8rlu01bm01qvb6pues5y/static/0,0,0,0,0/200x200@2x?access_token=" +
-      process.env.NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN,
+      process.env.NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN +
+      "&attribution=false&logo=false",
   },
 ];
 

--- a/app/components/map/BasemapSelector.tsx
+++ b/app/components/map/BasemapSelector.tsx
@@ -23,7 +23,8 @@ const basemapOptions: BasemapOption[] = [
     tileUrl: "devseed/cmazl5ws500bz01scaa27dqi4",
     thumbnailUrl:
       "https://api.mapbox.com/styles/v1/devseed/cmazl5ws500bz01scaa27dqi4/static/0,0,0,0,0/200x200@2x?access_token=" +
-      process.env.NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN + "&attribution=false&logo=false",
+      process.env.NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN +
+      "&attribution=false&logo=false",
   },
   {
     id: "satellite",

--- a/app/sidebar.tsx
+++ b/app/sidebar.tsx
@@ -163,7 +163,7 @@ export function Sidebar() {
     <Flex
       flexDir="column"
       bg="bg.subtle"
-      w={{ base: "full", md: !sideBarVisible ? "0px" : "16rem" }}
+      w={{ base: "full", md: !sideBarVisible ? "0px" : "428px" }}
       h="100%"
       gridArea="sidebar"
       overflow="hidden"


### PR DESCRIPTION
Implementing some small, isolated changes based on feedback from design.
- Make the convo history panel use the full width, matching the chat panel at full width
- updates to chat input box:
  - Remove "Open.." on dataset/area buttons
  - reduce text size
  - add aria labels for analytics
- Remove attribution on mapbox thumbnails (basemap selector)