### PR TITLE
PZB-955: enable GADM layer as active by default on landing

### DIFF
--- a/app/components/MapAreaControls.tsx
+++ b/app/components/MapAreaControls.tsx
@@ -70,6 +70,7 @@ function MapAreaControls({
   setBasemapTiles,
 }: MapAreaControlsProps) {
   const {
+    selectAreaLayer,
     setSelectAreaLayer,
     isDrawingMode,
     startDrawing,
@@ -353,6 +354,7 @@ function MapAreaControls({
                             <Menu.Item
                               key={id}
                               value={id}
+                              disabled={id === selectAreaLayer}
                               onClick={() =>
                                 setSelectionMode({
                                   type: "Selecting",

--- a/app/components/map/layers/select-area-layer/VectorAreasLayer.tsx
+++ b/app/components/map/layers/select-area-layer/VectorAreasLayer.tsx
@@ -34,7 +34,7 @@ interface Metadata {
 }
 
 function VectorAreasLayer({ layerId }: SourceLayerProps) {
-  const { context, addContext } = useContextStore();
+  const { context, addContext, removeContext } = useContextStore();
   const { addToRegistry, addLayer, setSelectAreaLayer } = useMapStore();
   const { current: map } = useMap();
   const [hoverInfo, setHoverInfo] = useState<HoverInfo>();
@@ -175,13 +175,22 @@ function VectorAreasLayer({ layerId }: SourceLayerProps) {
 
             const idField = metadata?.layer_id_mapping?.[layerId.toLowerCase()];
 
-            // Areas stack. Skip if this src_id is already in context to avoid
-            // duplicate chips when the user clicks the same region twice.
+            // Only one vector-click AOI at a time. Skip entirely if this src_id is
+            // already the active selection (avoids remove+re-add on double-click).
+            // Custom (drawn/uploaded) areas — identified by aoiData.source === "custom"
+            // — are left untouched.
             const alreadyInContext = context.some(
               (c) =>
                 c.contextType === "area" && c.aoiData?.src_id === dynamicSrcId
             );
             if (!alreadyInContext) {
+              context
+                .filter(
+                  (c) =>
+                    c.contextType === "area" && c.aoiData?.source !== "custom"
+                )
+                .forEach((c) => removeContext(c.id));
+
               addContext({
                 contextType: "area",
                 content: aoiName,
@@ -225,6 +234,7 @@ function VectorAreasLayer({ layerId }: SourceLayerProps) {
     setSelectAreaLayer,
     metadata,
     addContext,
+    removeContext,
     context,
     addToRegistry,
     addLayer,

--- a/app/store/mapStore.ts
+++ b/app/store/mapStore.ts
@@ -49,12 +49,12 @@ const createMapSlice: StateCreator<MapState, [], [], MapSlice> = (
   get
 ) => ({
   mapRef: null,
-  selectAreaLayer: null,
+  selectAreaLayer: "GADM",
   selectionMode: undefined,
 
   reset: () => {
     set({
-      selectAreaLayer: null,
+      selectAreaLayer: "GADM",
       layers: [],
       geoJsonRegistry: [],
     });


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:
- [x] Feature

## What is the new behavior?
Landing on the app with no prior session state shows GADM active and clickable, making areas immediately selectable without any setup.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

## Demo
<img width="1008" height="558" alt="Screenshot 2026-06-08 at 22 23 07" src="https://github.com/user-attachments/assets/2d6dbb45-f998-4f7a-8a8e-2d2b8c776c71" />
