### PR TITLE
Refactor/chat panel shared

### DIFF
--- a/app/ChatPanelCompact.tsx
+++ b/app/ChatPanelCompact.tsx
@@ -181,7 +181,7 @@ function ChatPanelCompact({ onToggleSize }: ChatPanelCompactProps) {
       <Box
         px={2}
         py={0}
-        mt={2}
+        mt={1}
         borderRadius="sm"
         backdropFilter="blur(24px)"
         bg="whiteAlpha.200"

--- a/app/ChatPanelCompact.tsx
+++ b/app/ChatPanelCompact.tsx
@@ -1,17 +1,19 @@
 "use client";
 
-import { Flex, Box, Text, Link as ChLink } from "@chakra-ui/react";
-import Link from "next/link";
+import { Flex, Box } from "@chakra-ui/react";
 import { AnimatePresence, motion } from "framer-motion";
 
 import ChatInput from "./components/ChatInput";
 import ChatMessages from "./components/ChatMessages";
-import ChatStatusInfo from "./components/ChatStatusInfo";
 import ChatPanelHeader from "./ChatPanelHeader";
-import useAuthStore from "./store/authStore";
+import ChatPanelDisclaimer from "./ChatPanelDisclaimer";
+import PromptQuotaNotice from "./PromptQuotaNotice";
+import { chatPanelCardStyle } from "./chatPanelShared";
+import { usePromptQuota } from "./hooks/usePromptQuota";
 import useChatStore from "./store/chatStore";
 import { useState, useEffect, useRef, useCallback } from "react";
 
+// Intentionally narrower than the full-size panel (see FULLSIZE_PANEL_WIDTH).
 const PANEL_WIDTH = 400;
 
 // Cap the scrollable message list at ~50vh per design (~440px on a 900px-tall
@@ -24,11 +26,7 @@ const DISCLAIMER_CLEARANCE = 12; // px of breathing room below the disclaimer
 
 const cardStyle = {
   w: { base: "full", md: `${PANEL_WIDTH}px` } as const,
-  bg: "bg",
-  borderRadius: { base: 0, md: "sm" } as const,
-  borderWidth: { base: 0, md: "1px" } as const,
-  borderColor: "border.emphasized",
-  overflow: "hidden",
+  ...chatPanelCardStyle,
 };
 
 interface ChatPanelCompactProps {
@@ -36,8 +34,7 @@ interface ChatPanelCompactProps {
 }
 
 function ChatPanelCompact({ onToggleSize }: ChatPanelCompactProps) {
-  const { usedPrompts, totalPrompts } = useAuthStore();
-  const promptsExhausted = usedPrompts >= totalPrompts;
+  const { promptsExhausted } = usePromptQuota();
   const { messages } = useChatStore();
   const hasConversation = messages.some(
     (m) => m.type === "user" || m.type === "assistant"
@@ -152,48 +149,15 @@ function ChatPanelCompact({ onToggleSize }: ChatPanelCompactProps) {
           boxShadow="none"
           overflow="hidden"
         >
-          {promptsExhausted && (
-            <Box px={3} pt={3}>
-              <ChatStatusInfo type="error">
-                <Text>
-                  <strong>
-                    You&apos;ve reached today&apos;s limit of {totalPrompts}{" "}
-                    prompts.
-                  </strong>
-                  <br />
-                  Wait until tomorrow for new prompts, or{" "}
-                  <ChLink as={Link} href="/app/classic">
-                    continue without AI
-                  </ChLink>
-                  .
-                </Text>
-              </ChatStatusInfo>
-            </Box>
-          )}
+          <PromptQuotaNotice px={3} pt={3} />
           <ChatInput
             isChatDisabled={promptsExhausted}
             onAfterSend={isCollapsed ? () => setIsCollapsed(false) : undefined}
           />
         </Flex>
       </Flex>
-      {/* Frosted-glass disclaimer — sits just below the input card
-        // TODO: use chakra styles and theming for this */}
-      <Box
-        px={2}
-        py={0}
-        mt={1}
-        borderRadius="sm"
-        backdropFilter="blur(24px)"
-        bg="whiteAlpha.200"
-        fontSize="10px"
-        lineHeight="20px"
-        color="#131619"
-        opacity={0.6}
-        whiteSpace="nowrap"
-      >
-        AI makes mistakes. Verify outputs and do not share sensitive or personal
-        information.
-      </Box>
+      {/* Frosted-glass disclaimer — sits just below the input card */}
+      <ChatPanelDisclaimer variant="frosted" />
     </Flex>
   );
 }

--- a/app/ChatPanelDisclaimer.tsx
+++ b/app/ChatPanelDisclaimer.tsx
@@ -1,0 +1,49 @@
+import { Box } from "@chakra-ui/react";
+
+import { CHAT_DISCLAIMER_TEXT } from "./chatPanelShared";
+
+interface ChatPanelDisclaimerProps {
+  /**
+   * "inline" — a flush single line that sits in the panel's flex flow
+   * (full-size panel), truncated with an ellipsis if space is tight.
+   * "frosted" — a frosted-glass overlay that floats below the input card
+   * (compact panel).
+   */
+  variant: "inline" | "frosted";
+}
+
+// Shared base: same copy size, position offset and colour in both variants.
+const baseStyle = {
+  px: 2,
+  py: 0,
+  mt: 1,
+  fontSize: "10px",
+  lineHeight: "20px",
+  color: "#131619",
+  whiteSpace: "nowrap",
+} as const;
+
+const variantStyle = {
+  inline: {
+    opacity: 0.5,
+    flexShrink: 0,
+    overflow: "hidden",
+    textOverflow: "ellipsis",
+  },
+  frosted: {
+    opacity: 0.6,
+    borderRadius: "sm",
+    backdropFilter: "blur(24px)",
+    bg: "whiteAlpha.200",
+  },
+} as const;
+
+function ChatPanelDisclaimer({ variant }: ChatPanelDisclaimerProps) {
+  return (
+    <Box {...baseStyle} {...variantStyle[variant]}>
+      {CHAT_DISCLAIMER_TEXT}
+    </Box>
+  );
+}
+
+export default ChatPanelDisclaimer;

--- a/app/ChatPanelDisclaimer.tsx
+++ b/app/ChatPanelDisclaimer.tsx
@@ -12,11 +12,9 @@ interface ChatPanelDisclaimerProps {
   variant: "inline" | "frosted";
 }
 
-// Shared base: same copy size, position offset and colour in both variants.
+// Shared base: same copy size and colour in both variants; spacing/position
+// and opacity differ per variant below.
 const baseStyle = {
-  px: 2,
-  py: 0,
-  mt: 1,
   fontSize: "10px",
   lineHeight: "20px",
   color: "#131619",
@@ -25,13 +23,18 @@ const baseStyle = {
 
 const variantStyle = {
   inline: {
-    opacity: 0.5,
+    px: 3,
+    py: 1,
+    mt: -1,
     flexShrink: 0,
     overflow: "hidden",
     textOverflow: "ellipsis",
   },
   frosted: {
-    opacity: 0.6,
+    px: 2,
+    py: 0,
+    mt: 1,
+    opacity: 0.8,
     borderRadius: "sm",
     backdropFilter: "blur(24px)",
     bg: "whiteAlpha.200",

--- a/app/ChatPanelFullSize.tsx
+++ b/app/ChatPanelFullSize.tsx
@@ -1,23 +1,24 @@
 "use client";
 
-import { Flex, Box, Text, Link as ChLink } from "@chakra-ui/react";
-import Link from "next/link";
+import { Flex, Box } from "@chakra-ui/react";
 
 import ChatInput from "./components/ChatInput";
 import ChatMessages from "./components/ChatMessages";
-import ChatStatusInfo from "./components/ChatStatusInfo";
 import ChatPanelHeader from "./ChatPanelHeader";
-import useAuthStore from "./store/authStore";
+import ChatPanelDisclaimer from "./ChatPanelDisclaimer";
+import PromptQuotaNotice from "./PromptQuotaNotice";
+import { chatPanelCardStyle } from "./chatPanelShared";
+import { usePromptQuota } from "./hooks/usePromptQuota";
 
-const PANEL_WIDTH = 428;
+// Intentionally wider than the compact panel (see COMPACT_PANEL_WIDTH).
+const FULLSIZE_PANEL_WIDTH = 428;
 
 interface ChatPanelFullSizeProps {
   onToggleSize: () => void;
 }
 
 function ChatPanelFullSize({ onToggleSize }: ChatPanelFullSizeProps) {
-  const { usedPrompts, totalPrompts } = useAuthStore();
-  const promptsExhausted = usedPrompts >= totalPrompts;
+  const { promptsExhausted } = usePromptQuota();
 
   return (
     <Flex
@@ -25,12 +26,8 @@ function ChatPanelFullSize({ onToggleSize }: ChatPanelFullSizeProps) {
       flex="1 1 auto"
       minH={0}
       h="100%"
-      w={{ base: "full", md: `${PANEL_WIDTH}px` }}
-      bg="bg"
-      borderWidth={{ base: 0, md: "1px" }}
-      borderColor="border.emphasized"
-      borderRadius={{ base: 0, md: "sm" }}
-      overflow="hidden"
+      w={{ base: "full", md: `${FULLSIZE_PANEL_WIDTH}px` }}
+      {...chatPanelCardStyle}
       pointerEvents="auto"
     >
       <ChatPanelHeader
@@ -47,44 +44,12 @@ function ChatPanelFullSize({ onToggleSize }: ChatPanelFullSizeProps) {
       {/* Input area — rounded bordered box. pb matches ChatPanelCompact so the
           input box bottom lines up across compact/full-size. */}
       <Flex flexDir="column" flexShrink={0} px={3} pb={1}>
-        {promptsExhausted && (
-          <Box pb={2}>
-            <ChatStatusInfo type="error">
-              <Text>
-                <strong>
-                  You&apos;ve reached today&apos;s limit of {totalPrompts}{" "}
-                  prompts.
-                </strong>
-                <br />
-                Wait until tomorrow for new prompts, or{" "}
-                <ChLink as={Link} href="/app/classic">
-                  continue without AI
-                </ChLink>
-                .
-              </Text>
-            </ChatStatusInfo>
-          </Box>
-        )}
+        <PromptQuotaNotice pb={2} />
         <ChatInput isChatDisabled={promptsExhausted} bordered />
       </Flex>
 
       {/* Disclaimer — compact single-line at bottom */}
-      <Box
-        px={2}
-        py={0}
-        mt={1}
-        fontSize="10px"
-        lineHeight="20px"
-        color="#131619"
-        opacity={0.5}
-        flexShrink={0}
-        whiteSpace="nowrap"
-        overflow="hidden"
-        textOverflow="ellipsis"
-      >
-        AI makes mistakes. Verify outputs and do not share sensitive or
-        personal information.
-      </Box>
+      <ChatPanelDisclaimer variant="inline" />
     </Flex>
   );
 }

--- a/app/ChatPanelFullSize.tsx
+++ b/app/ChatPanelFullSize.tsx
@@ -70,8 +70,9 @@ function ChatPanelFullSize({ onToggleSize }: ChatPanelFullSizeProps) {
 
       {/* Disclaimer — compact single-line at bottom */}
       <Box
-        px={3}
-        py={1}
+        px={2}
+        py={0}
+        mt={1}
         fontSize="10px"
         lineHeight="20px"
         color="#131619"
@@ -81,7 +82,7 @@ function ChatPanelFullSize({ onToggleSize }: ChatPanelFullSizeProps) {
         overflow="hidden"
         textOverflow="ellipsis"
       >
-        AI makes mistakes. Verify outputs and do not share any sensitive or
+        AI makes mistakes. Verify outputs and do not share sensitive or
         personal information.
       </Box>
     </Flex>

--- a/app/PromptQuotaNotice.tsx
+++ b/app/PromptQuotaNotice.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { Box, BoxProps, Text, Link as ChLink } from "@chakra-ui/react";
+import Link from "next/link";
+
+import ChatStatusInfo from "./components/ChatStatusInfo";
+import { usePromptQuota } from "./hooks/usePromptQuota";
+
+/**
+ * The "you've hit today's prompt limit" banner shown above the chat input.
+ * Self-guarding: renders nothing until the quota is exhausted. Wrapper padding
+ * differs between panels, so any BoxProps passed are spread onto the wrapper.
+ */
+function PromptQuotaNotice(props: BoxProps) {
+  const { promptsExhausted, totalPrompts } = usePromptQuota();
+  if (!promptsExhausted) return null;
+
+  return (
+    <Box {...props}>
+      <ChatStatusInfo type="error">
+        <Text>
+          <strong>
+            You&apos;ve reached today&apos;s limit of {totalPrompts} prompts.
+          </strong>
+          <br />
+          Wait until tomorrow for new prompts, or{" "}
+          <ChLink as={Link} href="/app/classic">
+            continue without AI
+          </ChLink>
+          .
+        </Text>
+      </ChatStatusInfo>
+    </Box>
+  );
+}
+
+export default PromptQuotaNotice;

--- a/app/chatPanelShared.ts
+++ b/app/chatPanelShared.ts
@@ -1,0 +1,22 @@
+/**
+ * Shared chrome for the chat panel cards.
+ *
+ * Compact and full-size deliberately use DIFFERENT widths (the full-size panel
+ * is wider), so width is intentionally NOT part of this object — each panel
+ * sets its own. Everything else about the card surface is identical and lives
+ * here so the two panels can't drift.
+ */
+export const chatPanelCardStyle = {
+  bg: "bg",
+  borderRadius: { base: 0, md: "sm" } as const,
+  borderWidth: { base: 0, md: "1px" } as const,
+  borderColor: "border.emphasized",
+  overflow: "hidden",
+} as const;
+
+/**
+ * Compliance copy shown beneath the chat input in both panels. Kept in one
+ * place because the wording must never drift between layouts.
+ */
+export const CHAT_DISCLAIMER_TEXT =
+  "AI makes mistakes. Verify outputs and do not share sensitive or personal information.";

--- a/app/hooks/usePromptQuota.ts
+++ b/app/hooks/usePromptQuota.ts
@@ -1,0 +1,16 @@
+import useAuthStore from "../store/authStore";
+
+/**
+ * Derives the prompt-quota state both chat panels need: the raw counts plus
+ * whether the user has hit today's limit. Centralised so the `usedPrompts >=
+ * totalPrompts` comparison can't drift between the compact and full-size
+ * panels.
+ */
+export function usePromptQuota() {
+  const { usedPrompts, totalPrompts } = useAuthStore();
+  return {
+    usedPrompts,
+    totalPrompts,
+    promptsExhausted: usedPrompts >= totalPrompts,
+  };
+}


### PR DESCRIPTION
Extracts compact and full chat panels, disclaimers into a shared component so styles / content doesn't drift between open/closed states.

Test by:
- ensuring open and closed panel states align with the legend
- ensuring disclaimer text position is the same, with consistent positioning