### PR TITLE
Refactor/context param chips

### DIFF
--- a/app/components/legend/LayerEntry.tsx
+++ b/app/components/legend/LayerEntry.tsx
@@ -22,6 +22,7 @@ import type {
   LegendContextLayer,
   LayerActionHandler,
 } from "./types";
+import { ParamChip } from "@/app/components/ui/ParamChip";
 
 /**
  * LayerEntry component displaying details, controls, and legend swatches for a
@@ -160,38 +161,12 @@ export function LayerEntry(
             {params && params.length > 0 && (
               <Flex gap={1} flexWrap="wrap" alignItems="center">
                 {params.map((p) => (
-                  <Flex
+                  <ParamChip
                     key={p.label}
-                    alignItems="center"
-                    gap="4px"
-                    h="20px"
-                    px="6px"
-                    borderRadius="sm"
-                    border="1px solid"
-                    borderColor="#E0E2E5"
-                    fontFamily="mono"
-                    fontSize="10px"
-                    flexShrink={0}
-                  >
-                    <Text
-                      as="span"
-                      fontWeight="normal"
-                      lineHeight="16px"
-                      letterSpacing="0.5px"
-                      color="#A51EC7"
-                    >
-                      {p.label}
-                    </Text>
-                    <Text
-                      as="span"
-                      fontWeight="500"
-                      lineHeight="16px"
-                      letterSpacing="0"
-                      textAlign="center"
-                    >
-                      {p.value}
-                    </Text>
-                  </Flex>
+                    label={p.label}
+                    value={p.value}
+                    colorScheme="purple"
+                  />
                 ))}
               </Flex>
             )}

--- a/app/components/legend/Legend.tsx
+++ b/app/components/legend/Legend.tsx
@@ -12,13 +12,13 @@ import {
   StackIcon,
   CaretDownIcon,
   CaretUpIcon,
-  XIcon,
 } from "@phosphor-icons/react";
 import { Reorder, useDragControls } from "motion/react";
 
 import { LayerActionHandler, LegendLayer } from "./types";
 import type { LegendAoi } from "./useLegendHook";
 import { LayerEntry } from "./LayerEntry";
+import { ParamChip } from "@/app/components/ui/ParamChip";
 
 const ChReorderGroup = chakra(Reorder.Group);
 const ChReorderItem = chakra(Reorder.Item);
@@ -208,50 +208,17 @@ export function Legend(props: LegendProps) {
                 pl="24px"
               >
                 {aois.map((aoi) => (
-                  <Flex
+                  <ParamChip
                     key={`${aoi.contextId}-${aoi.name}`}
-                    alignItems="center"
-                    gap="4px"
-                    h="20px"
-                    px="6px"
-                    py="2px"
-                    borderRadius="6px"
-                    border="1px solid"
-                    borderColor="#E0E2E5"
-                    bg="#FFFFFF"
-                    fontFamily="mono"
-                    fontSize="10px"
-                    flexShrink={0}
-                  >
-                    <Text
-                      as="span"
-                      fontWeight="normal"
-                      lineHeight="16px"
-                      letterSpacing="0.5px"
-                      color="#4A64CB"
-                    >
-                      AREA
-                    </Text>
-                    <Text
-                      as="span"
-                      fontWeight="500"
-                      lineHeight="16px"
-                      letterSpacing="0"
-                    >
-                      {aoi.name}
-                    </Text>
-                    <IconButton
-                      variant="ghost"
-                      size="xs"
-                      p={0}
-                      minW="12px"
-                      h="12px"
-                      aria-label={`Remove ${aoi.name}`}
-                      onClick={() => onRemoveAoi?.(aoi.contextId)}
-                    >
-                      <XIcon size={10} />
-                    </IconButton>
-                  </Flex>
+                    label="AREA"
+                    value={aoi.name}
+                    colorScheme="blue"
+                    bg="white"
+                    onRemove={
+                      onRemoveAoi ? () => onRemoveAoi(aoi.contextId) : undefined
+                    }
+                    removeLabel={`Remove ${aoi.name}`}
+                  />
                 ))}
               </Flex>
             </>

--- a/app/components/legend/types.ts
+++ b/app/components/legend/types.ts
@@ -2,7 +2,7 @@ import { ReactNode } from "react";
 
 /**
  * A single read-only parameter chip shown beneath a layer title.
- * e.g. { label: "YEAR", value: "2025" } or { label: "CANOPY", value: ">= 30%" }
+ * e.g. { label: "YEAR", value: "2025" } or { label: "CANOPY", value: "> 30%" }
  */
 export interface LegendParam {
   label: string;

--- a/app/components/legend/useLegendHook.tsx
+++ b/app/components/legend/useLegendHook.tsx
@@ -17,6 +17,7 @@ import {
   DATASET_CARDS,
 } from "@/app/constants/datasets";
 import { buildYearParam, YearParam } from "@/app/utils/formatYearRange";
+import { formatCanopyThreshold } from "@/app/utils/formatCanopyThreshold";
 import type { DatasetLegendConfig } from "@/app/constants/datasets";
 import useContextStore from "@/app/store/contextStore";
 
@@ -25,9 +26,10 @@ const PARAMETER_LABELS: Record<string, string> = {
   canopy_cover: "CANOPY",
 };
 
-// Maps internal parameter keys to a formatting function that produces the value string.
+// Maps internal parameter keys to a formatting function that produces the value
+// string. Shares the canopy formatter with the insights CANOPY chip.
 const PARAMETER_FORMATTERS: Record<string, (v: unknown) => string> = {
-  canopy_cover: (v) => `>= ${v}%`,
+  canopy_cover: (v) => formatCanopyThreshold(v as number),
 };
 
 /**

--- a/app/components/legend/useLegendHook.tsx
+++ b/app/components/legend/useLegendHook.tsx
@@ -16,6 +16,7 @@ import {
   CONTEXT_LAYER_METADATA,
   DATASET_CARDS,
 } from "@/app/constants/datasets";
+import { buildYearParam, YearParam } from "@/app/utils/formatYearRange";
 import type { DatasetLegendConfig } from "@/app/constants/datasets";
 import useContextStore from "@/app/store/contextStore";
 
@@ -35,14 +36,12 @@ const PARAMETER_FORMATTERS: Record<string, (v: unknown) => string> = {
  */
 function buildParams(
   params: Record<string, unknown>,
-  dateRange?: string
+  yearParam?: YearParam
 ): LegendParam[] {
   const result: LegendParam[] = [];
 
-  if (dateRange) {
-    // Use "YEARS" for a range, "YEAR" for a single year.
-    const label = dateRange.includes("–") ? "YEARS" : "YEAR";
-    result.push({ label, value: dateRange });
+  if (yearParam) {
+    result.push(yearParam);
   }
 
   for (const [k, v] of Object.entries(params)) {
@@ -169,15 +168,8 @@ export function useLegendHook() {
 
         const { title, info, note } = relatedDataset.legend;
 
-        const dateRange = (() => {
-          if (!layer.startDate || !layer.endDate) return undefined;
-          const startYear = layer.startDate.slice(0, 4);
-          const endYear = layer.endDate.slice(0, 4);
-          return startYear === endYear
-            ? startYear
-            : `${startYear}\u2013${endYear}`;
-        })();
-        const params = buildParams(layer.parameters ?? {}, dateRange);
+        const yearParam = buildYearParam(layer.startDate, layer.endDate);
+        const params = buildParams(layer.parameters ?? {}, yearParam);
 
         entries.push({
           id: layer.id,

--- a/app/components/ui/ParamChip.tsx
+++ b/app/components/ui/ParamChip.tsx
@@ -31,6 +31,12 @@ export interface ParamChipProps {
   onRemove?: () => void;
   /** Accessible label for the remove button; defaults to `Remove {value}`. */
   removeLabel?: string;
+  /**
+   * Maximum width of the value text before it truncates with an ellipsis.
+   * Long AOI/dataset names would otherwise blow the chip out; the full value
+   * stays available via the native title tooltip. Defaults to "20ch".
+   */
+  maxValueWidth?: string;
 }
 
 /**
@@ -47,6 +53,7 @@ export function ParamChip({
   bg,
   onRemove,
   removeLabel,
+  maxValueWidth = "20ch",
 }: ParamChipProps) {
   const labelColor = LABEL_COLOR[colorScheme];
   return (
@@ -78,6 +85,9 @@ export function ParamChip({
         fontWeight="500"
         lineHeight="16px"
         color={highlightValue ? labelColor : "fg"}
+        maxW={maxValueWidth}
+        truncate
+        title={value}
       >
         {value}
       </Text>

--- a/app/components/ui/ParamChip.tsx
+++ b/app/components/ui/ParamChip.tsx
@@ -63,7 +63,7 @@ export function ParamChip({
   bg,
   onRemove,
   removeLabel,
-  maxValueWidth = "20ch",
+  maxValueWidth = "15ch",
   tooltip,
 }: ParamChipProps) {
   const labelColor = LABEL_COLOR[colorScheme];

--- a/app/components/ui/ParamChip.tsx
+++ b/app/components/ui/ParamChip.tsx
@@ -1,0 +1,101 @@
+"use client";
+import { Flex, IconButton, Text } from "@chakra-ui/react";
+import { XIcon } from "@phosphor-icons/react";
+
+export type ParamChipColorScheme = "blue" | "green" | "purple";
+
+// Label text colors mapped from the Figma spec to the nearest theme tokens.
+// The legend previously hardcoded the raw Figma hexes (#4A64CB, #A51EC7);
+// these tokens are the canonical equivalents and the single source of truth.
+//   blue   AREA            #4A64CB → primary.400 (#3361C0)
+//   green  DATA            #1AA815 → green.500   (#00A651)
+//   purple CANOPY / YEARS  #A51EC7 → purple.500  (#BA4AFF)
+const LABEL_COLOR: Record<ParamChipColorScheme, string> = {
+  blue: "primary.400",
+  green: "green.500",
+  purple: "purple.500",
+};
+
+export interface ParamChipProps {
+  label: string;
+  value: string;
+  colorScheme?: ParamChipColorScheme;
+  /** Render the value in the label color too (used for AREA chips in insights). */
+  highlightValue?: boolean;
+  /**
+   * Chip background; defaults to transparent. The legend AOI chips sit on a
+   * tinted strip and pass an opaque background so they read as distinct.
+   */
+  bg?: string;
+  /** When provided, renders a remove (×) button at the end of the chip. */
+  onRemove?: () => void;
+  /** Accessible label for the remove button; defaults to `Remove {value}`. */
+  removeLabel?: string;
+}
+
+/**
+ * Compact monospace "LABEL value" chip used to surface analysis parameters
+ * (area, dataset, canopy threshold, year range) across the insight workspace
+ * and the map legend. Visual spec: 20px tall, mono 10px, colored uppercase
+ * label + value, hairline neutral border.
+ */
+export function ParamChip({
+  label,
+  value,
+  colorScheme = "blue",
+  highlightValue = false,
+  bg,
+  onRemove,
+  removeLabel,
+}: ParamChipProps) {
+  const labelColor = LABEL_COLOR[colorScheme];
+  return (
+    <Flex
+      align="center"
+      gap={1}
+      h="20px"
+      px="6px"
+      rounded="sm"
+      border="1px solid"
+      borderColor="neutral.300"
+      bg={bg}
+      flexShrink={0}
+    >
+      <Text
+        fontFamily="mono"
+        fontSize="10px"
+        fontWeight="400"
+        lineHeight="16px"
+        letterSpacing="0.5px"
+        color={labelColor}
+        textTransform="uppercase"
+      >
+        {label}
+      </Text>
+      <Text
+        fontFamily="mono"
+        fontSize="10px"
+        fontWeight="500"
+        lineHeight="16px"
+        color={highlightValue ? labelColor : "fg"}
+      >
+        {value}
+      </Text>
+      {onRemove && (
+        <IconButton
+          variant="ghost"
+          size="xs"
+          p={0}
+          minW="12px"
+          h="12px"
+          aria-label={removeLabel ?? `Remove ${value}`}
+          onClick={onRemove}
+        >
+          <XIcon size={10} />
+        </IconButton>
+      )}
+    </Flex>
+  );
+}
+
+export default ParamChip;

--- a/app/components/ui/ParamChip.tsx
+++ b/app/components/ui/ParamChip.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { Flex, IconButton, Text } from "@chakra-ui/react";
 import { XIcon } from "@phosphor-icons/react";
+import { Tooltip } from "@/components/ui/tooltip";
 
 export type ParamChipColorScheme = "blue" | "green" | "purple";
 
@@ -33,10 +34,19 @@ export interface ParamChipProps {
   removeLabel?: string;
   /**
    * Maximum width of the value text before it truncates with an ellipsis.
-   * Long AOI/dataset names would otherwise blow the chip out; the full value
-   * stays available via the native title tooltip. Defaults to "20ch".
+   * Long AOI/dataset names would otherwise blow the chip out. Defaults to
+   * "20ch". A `ch` value also sets the truncation threshold for the tooltip
+   * (mono font ⇒ 1 char ≈ 1ch).
    */
   maxValueWidth?: string;
+  /**
+   * Full text shown in the hover tooltip. Defaults to `value`. Pass the long
+   * form here when `value` is an abbreviation (e.g. the DATA chip shows a
+   * dataset short label but tooltips the full dataset name). The tooltip only
+   * renders when it would reveal something the chip doesn't already show — a
+   * distinct full text, or a value wide enough to be truncated.
+   */
+  tooltip?: string;
 }
 
 /**
@@ -54,8 +64,18 @@ export function ParamChip({
   onRemove,
   removeLabel,
   maxValueWidth = "20ch",
+  tooltip,
 }: ParamChipProps) {
   const labelColor = LABEL_COLOR[colorScheme];
+
+  const tooltipText = tooltip ?? value;
+  // Only tooltip when it reveals something not already visible: a distinct
+  // full text, or a value wide enough to be truncated. For a `ch` maxWidth and
+  // this mono font, 1 char ≈ 1ch, so a char-count threshold is accurate.
+  const chMatch = /^(\d+(?:\.\d+)?)ch$/.exec(maxValueWidth);
+  const maxChars = chMatch ? parseFloat(chMatch[1]) : Infinity;
+  const showTooltip = tooltipText !== value || value.length > maxChars;
+
   return (
     <Flex
       align="center"
@@ -79,18 +99,19 @@ export function ParamChip({
       >
         {label}
       </Text>
-      <Text
-        fontFamily="mono"
-        fontSize="10px"
-        fontWeight="500"
-        lineHeight="16px"
-        color={highlightValue ? labelColor : "fg"}
-        maxW={maxValueWidth}
-        truncate
-        title={value}
-      >
-        {value}
-      </Text>
+      <Tooltip content={tooltipText} disabled={!showTooltip} showArrow>
+        <Text
+          fontFamily="mono"
+          fontSize="10px"
+          fontWeight="500"
+          lineHeight="16px"
+          color={highlightValue ? labelColor : "fg"}
+          maxW={maxValueWidth}
+          truncate
+        >
+          {value}
+        </Text>
+      </Tooltip>
       {onRemove && (
         <IconButton
           variant="ghost"

--- a/app/components/ui/ParamChip.tsx
+++ b/app/components/ui/ParamChip.tsx
@@ -17,6 +17,10 @@ const LABEL_COLOR: Record<ParamChipColorScheme, string> = {
   purple: "purple.500",
 };
 
+// Matches a `ch`-unit width (e.g. "15ch") so it doubles as a char-count
+// truncation threshold. Module-scoped so it isn't recompiled per render.
+const CH_UNIT_PATTERN = /^(\d+(?:\.\d+)?)ch$/;
+
 export interface ParamChipProps {
   label: string;
   value: string;
@@ -35,7 +39,7 @@ export interface ParamChipProps {
   /**
    * Maximum width of the value text before it truncates with an ellipsis.
    * Long AOI/dataset names would otherwise blow the chip out. Defaults to
-   * "20ch". A `ch` value also sets the truncation threshold for the tooltip
+   * "15ch". A `ch` value also sets the truncation threshold for the tooltip
    * (mono font ⇒ 1 char ≈ 1ch).
    */
   maxValueWidth?: string;
@@ -72,7 +76,7 @@ export function ParamChip({
   // Only tooltip when it reveals something not already visible: a distinct
   // full text, or a value wide enough to be truncated. For a `ch` maxWidth and
   // this mono font, 1 char ≈ 1ch, so a char-count threshold is accurate.
-  const chMatch = /^(\d+(?:\.\d+)?)ch$/.exec(maxValueWidth);
+  const chMatch = CH_UNIT_PATTERN.exec(maxValueWidth);
   const maxChars = chMatch ? parseFloat(chMatch[1]) : Infinity;
   const showTooltip = tooltipText !== value || value.length > maxChars;
 

--- a/app/components/widgets/AnalysisParameters.tsx
+++ b/app/components/widgets/AnalysisParameters.tsx
@@ -1,18 +1,7 @@
 "use client";
 import { Flex, Text } from "@chakra-ui/react";
-import { ParamChip } from "./analysis-params-utils";
-
-// TODO: Extract these colors to a shared util since they're used in DatasetCards too
-// Label text colors mapped from Figma spec to nearest theme tokens:
-// AREA #4A64CB → primary.400 (#3361C0)
-// DATA #1AA815 → green.500  (#00A651)
-// CANOPY #A51EC7 → purple.500 (#BA4AFF)
-// YEARS #A51EC7 → purple.500 (#BA4AFF)
-const chipLabelColor: Record<ParamChip["colorScheme"], string> = {
-  blue: "primary.400",
-  green: "green.500",
-  purple: "purple.500",
-};
+import { ParamChip } from "@/app/components/ui/ParamChip";
+import { ParamChipData } from "./analysis-params-utils";
 
 interface AnalysisParametersToggleProps {
   expanded: boolean;
@@ -45,46 +34,17 @@ export default function AnalysisParametersToggle({
 }
 
 /** Chips panel rendered below the header row when expanded */
-export function AnalysisParamsChips({ chips }: { chips: ParamChip[] }) {
+export function AnalysisParamsChips({ chips }: { chips: ParamChipData[] }) {
   return (
     <Flex gap={1.5} flexWrap="wrap">
       {chips.map((chip, idx) => (
-        <Flex
+        <ParamChip
           key={`${chip.label}-${idx}`}
-          align="center"
-          gap={1}
-          h="20px"
-          pt="2px"
-          pb="2px"
-          pr="6px"
-          pl={2}
-          rounded="sm"
-          border="1px solid"
-          borderColor="neutral.300"
-        >
-          <Text
-            fontFamily="mono"
-            fontSize="10px"
-            fontWeight="400"
-            lineHeight="16px"
-            letterSpacing="0.5px"
-            color={chipLabelColor[chip.colorScheme]}
-            textTransform="uppercase"
-          >
-            {chip.label}
-          </Text>
-          <Text
-            fontFamily="mono"
-            fontSize="10px"
-            fontWeight="500"
-            lineHeight="16px"
-            color={
-              chip.label === "AREA" ? chipLabelColor[chip.colorScheme] : "fg"
-            }
-          >
-            {chip.value}
-          </Text>
-        </Flex>
+          label={chip.label}
+          value={chip.value}
+          colorScheme={chip.colorScheme}
+          highlightValue={chip.label === "AREA"}
+        />
       ))}
     </Flex>
   );

--- a/app/components/widgets/AnalysisParameters.tsx
+++ b/app/components/widgets/AnalysisParameters.tsx
@@ -44,6 +44,7 @@ export function AnalysisParamsChips({ chips }: { chips: ParamChipData[] }) {
           value={chip.value}
           colorScheme={chip.colorScheme}
           highlightValue={chip.label === "AREA"}
+          tooltip={chip.tooltip}
         />
       ))}
     </Flex>

--- a/app/components/widgets/AnalysisParameters.tsx
+++ b/app/components/widgets/AnalysisParameters.tsx
@@ -43,7 +43,7 @@ export function AnalysisParamsChips({ chips }: { chips: ParamChipData[] }) {
           label={chip.label}
           value={chip.value}
           colorScheme={chip.colorScheme}
-          highlightValue={chip.label === "AREA"}
+          highlightValue={chip.highlightValue}
           tooltip={chip.tooltip}
         />
       ))}

--- a/app/components/widgets/__tests__/analysis-params-utils.test.ts
+++ b/app/components/widgets/__tests__/analysis-params-utils.test.ts
@@ -32,7 +32,7 @@ describe("buildChips", () => {
     expect(chips.filter((c) => c.label === "AREA").map((c) => c.value)).toEqual(
       ["Pará, Brazil", "Acre, Brazil"]
     );
-    expect(chips.find((c) => c.label === "CANOPY")?.value).toBe("≥ 30%");
+    expect(chips.find((c) => c.label === "CANOPY")?.value).toBe("> 30%");
     expect(chips.find((c) => c.label === "YEARS")?.value).toBe("2020–23");
   });
 });

--- a/app/components/widgets/__tests__/analysis-params-utils.test.ts
+++ b/app/components/widgets/__tests__/analysis-params-utils.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import { buildChips } from "../analysis-params-utils";
+
+describe("buildChips", () => {
+  it("uses the short label for a dataset that defines one", () => {
+    const chips = buildChips({
+      dataset: "Global natural/semi-natural grassland extent",
+    });
+    const data = chips.find((c) => c.label === "DATA");
+    expect(data?.value).toBe("Grasslands");
+  });
+
+  it("falls back to the full name when no short label is defined", () => {
+    const chips = buildChips({ dataset: "Tree cover loss" });
+    const data = chips.find((c) => c.label === "DATA");
+    expect(data?.value).toBe("Tree cover loss");
+  });
+
+  it("leaves an unknown dataset name unchanged", () => {
+    const chips = buildChips({ dataset: "Some custom layer" });
+    const data = chips.find((c) => c.label === "DATA");
+    expect(data?.value).toBe("Some custom layer");
+  });
+
+  it("builds one AREA chip per area plus canopy and year chips", () => {
+    const chips = buildChips({
+      areas: ["Pará, Brazil", "Acre, Brazil"],
+      canopyThreshold: 30,
+      startYear: 2020,
+      endYear: 2023,
+    });
+    expect(chips.filter((c) => c.label === "AREA").map((c) => c.value)).toEqual(
+      ["Pará, Brazil", "Acre, Brazil"]
+    );
+    expect(chips.find((c) => c.label === "CANOPY")?.value).toBe("≥ 30%");
+    expect(chips.find((c) => c.label === "YEARS")?.value).toBe("2020–2023");
+  });
+});

--- a/app/components/widgets/__tests__/analysis-params-utils.test.ts
+++ b/app/components/widgets/__tests__/analysis-params-utils.test.ts
@@ -33,6 +33,6 @@ describe("buildChips", () => {
       ["Pará, Brazil", "Acre, Brazil"]
     );
     expect(chips.find((c) => c.label === "CANOPY")?.value).toBe("≥ 30%");
-    expect(chips.find((c) => c.label === "YEARS")?.value).toBe("2020–2023");
+    expect(chips.find((c) => c.label === "YEARS")?.value).toBe("2020–23");
   });
 });

--- a/app/components/widgets/analysis-params-utils.ts
+++ b/app/components/widgets/analysis-params-utils.ts
@@ -1,13 +1,14 @@
 import { AnalysisParams } from "@/app/types/chat";
+import { ParamChipColorScheme } from "@/app/components/ui/ParamChip";
 
-export interface ParamChip {
+export interface ParamChipData {
   label: string;
   value: string;
-  colorScheme: "blue" | "green" | "purple";
+  colorScheme: ParamChipColorScheme;
 }
 
-export function buildChips(params: AnalysisParams): ParamChip[] {
-  const chips: ParamChip[] = [];
+export function buildChips(params: AnalysisParams): ParamChipData[] {
+  const chips: ParamChipData[] = [];
 
   // Area chips — one per AOI
   if (params.areas?.length) {

--- a/app/components/widgets/analysis-params-utils.ts
+++ b/app/components/widgets/analysis-params-utils.ts
@@ -6,6 +6,8 @@ export interface ParamChipData {
   label: string;
   value: string;
   colorScheme: ParamChipColorScheme;
+  /** Full text for the hover tooltip when `value` is an abbreviation. */
+  tooltip?: string;
 }
 
 export function buildChips(params: AnalysisParams): ParamChipData[] {
@@ -18,12 +20,13 @@ export function buildChips(params: AnalysisParams): ParamChipData[] {
     }
   }
 
-  // Dataset chip — use the short label where one is defined for the dataset
+  // Dataset chip — show the short label, tooltip the full dataset name
   if (params.dataset) {
     chips.push({
       label: "DATA",
       value: shortDatasetName(params.dataset),
       colorScheme: "green",
+      tooltip: params.dataset,
     });
   }
 

--- a/app/components/widgets/analysis-params-utils.ts
+++ b/app/components/widgets/analysis-params-utils.ts
@@ -9,15 +9,22 @@ export interface ParamChipData {
   colorScheme: ParamChipColorScheme;
   /** Full text for the hover tooltip when `value` is an abbreviation. */
   tooltip?: string;
+  /** Render the value in the label colour too (AREA chips). */
+  highlightValue?: boolean;
 }
 
 export function buildChips(params: AnalysisParams): ParamChipData[] {
   const chips: ParamChipData[] = [];
 
-  // Area chips — one per AOI
+  // Area chips — one per AOI (value coloured like the label)
   if (params.areas?.length) {
     for (const area of params.areas) {
-      chips.push({ label: "AREA", value: area, colorScheme: "blue" });
+      chips.push({
+        label: "AREA",
+        value: area,
+        colorScheme: "blue",
+        highlightValue: true,
+      });
     }
   }
 

--- a/app/components/widgets/analysis-params-utils.ts
+++ b/app/components/widgets/analysis-params-utils.ts
@@ -2,6 +2,7 @@ import { AnalysisParams } from "@/app/types/chat";
 import { ParamChipColorScheme } from "@/app/components/ui/ParamChip";
 import { shortDatasetName } from "@/app/constants/datasets";
 import { buildYearParam } from "@/app/utils/formatYearRange";
+import { formatCanopyThreshold } from "@/app/utils/formatCanopyThreshold";
 
 export interface ParamChipData {
   label: string;
@@ -42,7 +43,7 @@ export function buildChips(params: AnalysisParams): ParamChipData[] {
   if (params.canopyThreshold != null) {
     chips.push({
       label: "CANOPY",
-      value: `≥ ${params.canopyThreshold}%`,
+      value: formatCanopyThreshold(params.canopyThreshold),
       colorScheme: "purple",
     });
   }

--- a/app/components/widgets/analysis-params-utils.ts
+++ b/app/components/widgets/analysis-params-utils.ts
@@ -1,6 +1,7 @@
 import { AnalysisParams } from "@/app/types/chat";
 import { ParamChipColorScheme } from "@/app/components/ui/ParamChip";
 import { shortDatasetName } from "@/app/constants/datasets";
+import { buildYearParam } from "@/app/utils/formatYearRange";
 
 export interface ParamChipData {
   label: string;
@@ -39,13 +40,10 @@ export function buildChips(params: AnalysisParams): ParamChipData[] {
     });
   }
 
-  // Year range chip
-  if (params.startYear != null && params.endYear != null) {
-    chips.push({
-      label: "YEARS",
-      value: `${params.startYear}–${params.endYear}`,
-      colorScheme: "purple",
-    });
+  // Year chip — shared with the legend so labelling/format stay identical
+  const yearParam = buildYearParam(params.startYear, params.endYear);
+  if (yearParam) {
+    chips.push({ ...yearParam, colorScheme: "purple" });
   }
 
   return chips;

--- a/app/components/widgets/analysis-params-utils.ts
+++ b/app/components/widgets/analysis-params-utils.ts
@@ -1,5 +1,6 @@
 import { AnalysisParams } from "@/app/types/chat";
 import { ParamChipColorScheme } from "@/app/components/ui/ParamChip";
+import { shortDatasetName } from "@/app/constants/datasets";
 
 export interface ParamChipData {
   label: string;
@@ -17,9 +18,13 @@ export function buildChips(params: AnalysisParams): ParamChipData[] {
     }
   }
 
-  // Dataset chip
+  // Dataset chip — use the short label where one is defined for the dataset
   if (params.dataset) {
-    chips.push({ label: "DATA", value: params.dataset, colorScheme: "green" });
+    chips.push({
+      label: "DATA",
+      value: shortDatasetName(params.dataset),
+      colorScheme: "green",
+    });
   }
 
   // Canopy threshold chip (only if present — omit for non-tree-cover datasets)

--- a/app/constants/datasets.ts
+++ b/app/constants/datasets.ts
@@ -21,6 +21,11 @@ export type DatasetLegendConfig = {
 export type DatasetCardConfig = {
   dataset_id: number;
   dataset_name: string;
+  /**
+   * Short label used in compact UI such as analysis-parameter chips, where the
+   * full dataset_name is too long. Omit when the full name is already short.
+   */
+  shortName?: string;
   description: string;
   img?: string;
   tile_url?: string;
@@ -90,6 +95,7 @@ export const DATASET_CARDS: (DatasetCardConfig & { img?: string })[] = [
   {
     dataset_id: 0,
     dataset_name: "Global all ecosystem disturbance alerts (DIST-ALERT)",
+    shortName: "DIST-ALERT",
     data_layer: "Global all ecosystem disturbance alerts (DIST-ALERT)",
     context_layer: null as string | null,
     img: "/dataset_card_dist_alerts.webp",
@@ -113,6 +119,7 @@ export const DATASET_CARDS: (DatasetCardConfig & { img?: string })[] = [
   {
     dataset_id: 1,
     dataset_name: "Global land cover",
+    shortName: "Land cover",
     context_layer: null as string | null,
     img: "/dataset_card_land_cover.webp",
     cadence: "annual",
@@ -144,6 +151,7 @@ export const DATASET_CARDS: (DatasetCardConfig & { img?: string })[] = [
   {
     dataset_id: 2,
     dataset_name: "Global natural/semi-natural grassland extent",
+    shortName: "Grasslands",
     context_layer: null as string | null,
     img: "/dataset_card_grasslands.webp",
     cadence: "annual",
@@ -166,6 +174,7 @@ export const DATASET_CARDS: (DatasetCardConfig & { img?: string })[] = [
   {
     dataset_id: 3,
     dataset_name: "SBTN Natural Lands Map",
+    shortName: "Natural lands",
     context_layer: null as string | null,
     img: "/dataset_card_natural_lands.webp",
     cadence: "2020",
@@ -226,6 +235,7 @@ export const DATASET_CARDS: (DatasetCardConfig & { img?: string })[] = [
   {
     dataset_id: 8,
     dataset_name: "Tree cover loss by dominant driver",
+    shortName: "TCL by driver",
     data_layer: "Tree cover loss by dominant driver",
     context_layer: null,
     threshold: 30,
@@ -308,6 +318,7 @@ export const DATASET_CARDS: (DatasetCardConfig & { img?: string })[] = [
   {
     dataset_id: 10,
     dataset_name: "Tree cover loss due to fires",
+    shortName: "TCL from fires",
     data_layer: "Tree cover loss due to fires",
     context_layer: null,
     threshold: 30,
@@ -339,6 +350,7 @@ export const DATASET_CARDS: (DatasetCardConfig & { img?: string })[] = [
   {
     dataset_id: 6,
     dataset_name: "Forest greenhouse gas net flux (2001-2025)",
+    shortName: "GHG net flux",
     data_layer: "Forest greenhouse gas net flux",
     context_layer: null,
     threshold: 30,
@@ -468,3 +480,22 @@ export const DATASETS: DatasetInfo[] = DATASET_CARDS.map(
 export const DATASET_BY_ID: Record<number, DatasetInfo> = Object.fromEntries(
   DATASETS.map((d) => [d.dataset_id, d])
 );
+
+// Full dataset_name -> short label, for the datasets that define one. Keyed by
+// name (not id) because the only handle available at chip-build time is the
+// name string (dataset.dataset_name or a layer's layerName).
+export const DATASET_SHORTNAME_BY_NAME: Record<string, string> =
+  Object.fromEntries(
+    DATASET_CARDS.filter((c) => c.shortName).map((c) => [
+      c.dataset_name,
+      c.shortName as string,
+    ])
+  );
+
+/**
+ * Returns the short label for a dataset name when one is defined, otherwise the
+ * original name unchanged. Long unmapped names still truncate at the chip.
+ */
+export function shortDatasetName(name: string): string {
+  return DATASET_SHORTNAME_BY_NAME[name] ?? name;
+}

--- a/app/constants/datasets.ts
+++ b/app/constants/datasets.ts
@@ -484,13 +484,12 @@ export const DATASET_BY_ID: Record<number, DatasetInfo> = Object.fromEntries(
 // Full dataset_name -> short label, for the datasets that define one. Keyed by
 // name (not id) because the only handle available at chip-build time is the
 // name string (dataset.dataset_name or a layer's layerName).
-export const DATASET_SHORTNAME_BY_NAME: Record<string, string> =
-  Object.fromEntries(
-    DATASET_CARDS.filter((c) => c.shortName).map((c) => [
-      c.dataset_name,
-      c.shortName as string,
-    ])
-  );
+const DATASET_SHORTNAME_BY_NAME: Record<string, string> = Object.fromEntries(
+  DATASET_CARDS.filter((c) => c.shortName).map((c) => [
+    c.dataset_name,
+    c.shortName as string,
+  ])
+);
 
 /**
  * Returns the short label for a dataset name when one is defined, otherwise the

--- a/app/store/chat-tools/pickAoi.ts
+++ b/app/store/chat-tools/pickAoi.ts
@@ -16,7 +16,7 @@ const GLOBAL_LAYER_ID = "Global Layer";
 const GLOBAL_LAYER_NAME = "Global Layer";
 
 function isGlobalQuery(name: string): boolean {
-  return name.toLowerCase() === "all countries in the world";
+  return name.toLowerCase() === "all countries";
 }
 
 /**

--- a/app/utils/__tests__/formatCanopyThreshold.test.ts
+++ b/app/utils/__tests__/formatCanopyThreshold.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from "vitest";
+import { formatCanopyThreshold } from "../formatCanopyThreshold";
+
+describe("formatCanopyThreshold", () => {
+  it("formats a numeric threshold as a > percentage", () => {
+    expect(formatCanopyThreshold(30)).toBe("> 30%");
+  });
+
+  it("accepts a string threshold", () => {
+    expect(formatCanopyThreshold("75")).toBe("> 75%");
+  });
+});

--- a/app/utils/__tests__/formatYearRange.test.ts
+++ b/app/utils/__tests__/formatYearRange.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { buildYearParam } from "../formatYearRange";
+
+describe("buildYearParam", () => {
+  it("collapses equal bounds to a single YEAR", () => {
+    expect(buildYearParam(2020, 2020)).toEqual({
+      label: "YEAR",
+      value: "2020",
+    });
+  });
+
+  it("formats differing bounds as a YEARS range with a 2-digit end year", () => {
+    expect(buildYearParam(2020, 2023)).toEqual({
+      label: "YEARS",
+      value: "2020–23",
+    });
+  });
+
+  it("parses the year from ISO date strings", () => {
+    expect(buildYearParam("2001-01-01", "2025-12-31")).toEqual({
+      label: "YEARS",
+      value: "2001–25",
+    });
+  });
+
+  it("returns undefined when a bound is missing", () => {
+    expect(buildYearParam(2020, undefined)).toBeUndefined();
+    expect(buildYearParam(null, 2023)).toBeUndefined();
+  });
+
+  it("returns undefined when a bound is unparseable", () => {
+    expect(buildYearParam("not-a-date", "2023")).toBeUndefined();
+  });
+});

--- a/app/utils/formatCanopyThreshold.ts
+++ b/app/utils/formatCanopyThreshold.ts
@@ -1,0 +1,8 @@
+/**
+ * Shared CANOPY threshold formatting for analysis-parameter chips. Used by both
+ * the insight workspace (AnalysisParamsChips) and the map legend (LayerEntry) so
+ * the two render identically.
+ */
+export function formatCanopyThreshold(value: number | string): string {
+  return `> ${value}%`;
+}

--- a/app/utils/formatYearRange.ts
+++ b/app/utils/formatYearRange.ts
@@ -11,16 +11,14 @@ export interface YearParam {
   value: string;
 }
 
-/** Extract a 4-digit year from a year number or a date-ish string. */
+/** Extract a 4-digit year from a year number or an ISO date string. */
 function toYear(value: number | string): number | null {
   if (typeof value === "number") {
     return Number.isFinite(value) ? value : null;
   }
-  // ISO dates start "YYYY-…"; use that prefix directly, else fall back to Date.
+  // Callers pass either year numbers or ISO dates ("YYYY-…"); read the prefix.
   const prefix = value.slice(0, 4);
-  if (/^\d{4}$/.test(prefix)) return Number(prefix);
-  const year = new Date(value).getUTCFullYear();
-  return Number.isNaN(year) ? null : year;
+  return /^\d{4}$/.test(prefix) ? Number(prefix) : null;
 }
 
 /**

--- a/app/utils/formatYearRange.ts
+++ b/app/utils/formatYearRange.ts
@@ -1,0 +1,46 @@
+/**
+ * Shared year-range formatting for analysis-parameter chips. Both the insight
+ * workspace (AnalysisParamsChips) and the map legend (LayerEntry) surface the
+ * same "YEAR(S)" chip; this keeps their parsing and labelling identical.
+ */
+
+const EN_DASH = "–";
+
+export interface YearParam {
+  label: "YEAR" | "YEARS";
+  value: string;
+}
+
+/** Extract a 4-digit year from a year number or a date-ish string. */
+function toYear(value: number | string): number | null {
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? value : null;
+  }
+  // ISO dates start "YYYY-…"; use that prefix directly, else fall back to Date.
+  const prefix = value.slice(0, 4);
+  if (/^\d{4}$/.test(prefix)) return Number(prefix);
+  const year = new Date(value).getUTCFullYear();
+  return Number.isNaN(year) ? null : year;
+}
+
+/**
+ * Builds the year chip from a start/end pair given as year numbers or date
+ * strings. Equal bounds collapse to a single "YEAR" (e.g. "2020"); differing
+ * bounds become a compact "YEARS" range with a 2-digit end year (e.g.
+ * "2020–23"). Returns undefined when either bound is missing or unparseable.
+ */
+export function buildYearParam(
+  start: number | string | null | undefined,
+  end: number | string | null | undefined
+): YearParam | undefined {
+  if (start == null || end == null) return undefined;
+  const startYear = toYear(start);
+  const endYear = toYear(end);
+  if (startYear == null || endYear == null) return undefined;
+  if (startYear === endYear) {
+    return { label: "YEAR", value: String(startYear) };
+  }
+  // Compact end year to its last two digits: 2020–2023 → "2020–23".
+  const endShort = String(endYear).slice(-2);
+  return { label: "YEARS", value: `${startYear}${EN_DASH}${endShort}` };
+}


### PR DESCRIPTION
Makes param chips a shared component across Insights and Legends (leaving context chips in the chat out for now, unclear if we will continue with these long term) in addition to:
- applying truncation to long names
- using mapped short names for datasets e.g. `Global Natural/Semi-natural grasslands --> Grasslands` with tooltips for full names
- Unify canopy threshold parsing and use `>` (same as GFW)
- truncate years from `20XX-20YY` to `20XX-YY` share parsing across components

<img width="410" height="66" alt="Screenshot 2026-06-09 at 12 26 41" src="https://github.com/user-attachments/assets/94a9e02f-4f1f-4203-87a0-709b66875a54" />
