### PR TITLE
[PZB-956][MVP] Users can analyse an area by clicking  on the analyse nudge without typing

### DIFF
--- a/app/app/(chat)/layout.tsx
+++ b/app/app/(chat)/layout.tsx
@@ -22,6 +22,7 @@ import { useSearchParams } from "next/navigation";
 import DraggableBottomSheet from "@/app/components/BottomSheet";
 import { ListIcon } from "@phosphor-icons/react";
 import useSidebarStore from "@/app/store/sidebarStore";
+import { AnalysisCtaTrigger } from "@/app/lib/analysis/AnalysisCtaTrigger";
 
 export default function DashboardLayout({
   children,
@@ -163,6 +164,7 @@ export default function DashboardLayout({
     >
       <UploadAreaDialog />
       <WhatsNewModal />
+      <AnalysisCtaTrigger />
 
       {!isMobile && <PageHeader />}
       {isMobile ? MobileLayout : DesktopLayout}

--- a/app/components/AnalyseNudge.tsx
+++ b/app/components/AnalyseNudge.tsx
@@ -1,0 +1,58 @@
+"use client";
+import { useState } from "react";
+import { Button, Flex, Text } from "@chakra-ui/react";
+import { CheckIcon } from "@phosphor-icons/react";
+import { AnalyseSuggestion } from "@/app/types/chat";
+import { runAnalysis } from "@/app/lib/analysis/runAnalysis";
+
+export default function AnalyseNudge({
+  suggestion,
+}: {
+  suggestion: AnalyseSuggestion;
+}) {
+  const [accepted, setAccepted] = useState(false);
+
+  const handleAnalyse = () => {
+    if (accepted) return;
+    setAccepted(true);
+    runAnalysis(suggestion);
+  };
+
+  return (
+    <Flex
+      direction="column"
+      gap={3}
+      w="full"
+      px={3}
+      py={2}
+      bg="bg.panel"
+      border="1px solid"
+      borderColor={accepted ? "primary.500" : "primary.emphasized"}
+      borderRadius="lg"
+    >
+      <Flex direction="column" gap={1}>
+        <Text fontSize="xs" fontWeight="semibold" lineHeight="16px">
+          {suggestion.areaName}
+        </Text>
+        <Text fontSize="xs" color="fg.muted" lineHeight="16px">
+          Run an analysis of {suggestion.datasetName} for this area?
+        </Text>
+      </Flex>
+      <Button
+        size="xs"
+        colorPalette="primary"
+        alignSelf="flex-start"
+        onClick={handleAnalyse}
+        disabled={accepted}
+      >
+        {accepted ? (
+          <>
+            <CheckIcon weight="bold" /> Analysing
+          </>
+        ) : (
+          "Analyse"
+        )}
+      </Button>
+    </Flex>
+  );
+}

--- a/app/components/AnalyseNudge.tsx
+++ b/app/components/AnalyseNudge.tsx
@@ -1,20 +1,24 @@
 "use client";
-import { useState } from "react";
 import { Button, Flex, Text } from "@chakra-ui/react";
 import { CheckIcon } from "@phosphor-icons/react";
 import { AnalyseSuggestion } from "@/app/types/chat";
+import useChatStore from "@/app/store/chatStore";
 import { runAnalysis } from "@/app/lib/analysis/runAnalysis";
 
 export default function AnalyseNudge({
+  messageId,
   suggestion,
 }: {
+  messageId: string;
   suggestion: AnalyseSuggestion;
 }) {
-  const [accepted, setAccepted] = useState(false);
+  // Accepted state lives on the message so the card survives re-mounts and
+  // accepted nudges persist in the thread when a new selection is made.
+  const accepted = suggestion.accepted ?? false;
 
   const handleAnalyse = () => {
     if (accepted) return;
-    setAccepted(true);
+    useChatStore.getState().acceptAnalyseNudge(messageId);
     runAnalysis(suggestion);
   };
 

--- a/app/components/InsightWorkspace.tsx
+++ b/app/components/InsightWorkspace.tsx
@@ -6,8 +6,10 @@ import {
   CaretUpIcon,
   ArrowArcLeftIcon,
   ArrowArcRightIcon,
+  SpinnerGapIcon,
 } from "@phosphor-icons/react";
 import useInsightStore from "@/app/store/insightStore";
+import useChatStore from "@/app/store/chatStore";
 import WidgetMessage from "./WidgetMessage";
 import { Tooltip } from "./ui/tooltip";
 import { WidgetIconComponent } from "@/app/utils/widgetIcons";
@@ -44,6 +46,7 @@ const aiDisclaimerTooltip = (
 
 export default function InsightWorkspace() {
   const { insights } = useInsightStore();
+  const isLoading = useChatStore((state) => state.isLoading);
   const [currentIndex, setCurrentIndex] = useState(0);
   const [isCollapsed, setIsCollapsed] = useState(false);
   const [paramsExpanded, setParamsExpanded] = useState(false);
@@ -135,23 +138,48 @@ export default function InsightWorkspace() {
             </Tooltip>
           </Text>
         </Flex>
-        <IconButton
-          size="2xs"
-          variant="ghost"
-          h="16px"
-          minW="16px"
-          w="16px"
-          color="#656E7B"
-          aria-label={isCollapsed ? "Expand insight" : "Collapse insight"}
-          flexShrink={0}
-          onClick={() => setIsCollapsed((v) => !v)}
-        >
-          {isCollapsed ? (
-            <CaretDownIcon size={12} weight="bold" />
-          ) : (
-            <CaretUpIcon size={12} weight="bold" />
+        <Flex align="center" gap="8px" flexShrink={0}>
+          {isLoading && (
+            <Flex align="center" gap="4px">
+              <Box
+                animation="spin 1s infinite"
+                animationTimingFunction="steps(8, end)"
+              >
+                <SpinnerGapIcon
+                  size={12}
+                  color="var(--chakra-colors-fg-muted)"
+                />
+              </Box>
+              <Text
+                fontSize="10px"
+                fontFamily="mono"
+                lineHeight="16px"
+                letterSpacing="0.03em"
+                color="fg.muted"
+                whiteSpace="nowrap"
+              >
+                INSIGHTS LOADING
+              </Text>
+            </Flex>
           )}
-        </IconButton>
+          <IconButton
+            size="2xs"
+            variant="ghost"
+            h="16px"
+            minW="16px"
+            w="16px"
+            color="#656E7B"
+            aria-label={isCollapsed ? "Expand insight" : "Collapse insight"}
+            flexShrink={0}
+            onClick={() => setIsCollapsed((v) => !v)}
+          >
+            {isCollapsed ? (
+              <CaretDownIcon size={12} weight="bold" />
+            ) : (
+              <CaretUpIcon size={12} weight="bold" />
+            )}
+          </IconButton>
+        </Flex>
       </Flex>
 
       {!isCollapsed && (

--- a/app/components/MessageBubble.tsx
+++ b/app/components/MessageBubble.tsx
@@ -35,6 +35,7 @@ import { toaster } from "./ui/toaster";
 import { apiFetch } from "@/app/lib/api-client";
 import CopySelectionTooltip from "./CopySelectionTooltip";
 import DatasetNudge from "./DatasetNudge";
+import AnalyseNudge from "./AnalyseNudge";
 
 interface MessageBubbleProps {
   message: ChatMessage;
@@ -201,6 +202,14 @@ function MessageBubble({
     return (
       <Box my={2}>
         <DatasetNudge datasets={message.suggestedDatasets} />
+      </Box>
+    );
+  }
+
+  if (message.type === "analyse-nudge" && message.analyseSuggestion) {
+    return (
+      <Box my={2}>
+        <AnalyseNudge suggestion={message.analyseSuggestion} />
       </Box>
     );
   }

--- a/app/components/MessageBubble.tsx
+++ b/app/components/MessageBubble.tsx
@@ -209,7 +209,10 @@ function MessageBubble({
   if (message.type === "analyse-nudge" && message.analyseSuggestion) {
     return (
       <Box my={2}>
-        <AnalyseNudge suggestion={message.analyseSuggestion} />
+        <AnalyseNudge
+          messageId={message.id}
+          suggestion={message.analyseSuggestion}
+        />
       </Box>
     );
   }

--- a/app/components/map/layers/select-area-layer/VectorAreasLayer.tsx
+++ b/app/components/map/layers/select-area-layer/VectorAreasLayer.tsx
@@ -16,7 +16,6 @@ import useContextStore from "@/app/store/contextStore";
 import useMapStore from "@/app/store/mapStore";
 
 import { useFeatureFlag } from "@/app/hooks/useFeatureFlag";
-import { showAnalysisCta } from "@/app/lib/analysis/showAnalysisCta";
 
 import {
   getAoiName,
@@ -215,16 +214,16 @@ function VectorAreasLayer({ layerId }: SourceLayerProps) {
 
             // Analysis feature — hidden behind ?ff=analysis; GADM only.
             // Purely additive: with the flag off, behavior is unchanged.
+            // AnalysisCtaTrigger reacts to this selection and surfaces the
+            // analyse nudge once a dataset is also active.
             if (layerId === "GADM" && metadata && isAnalysisEnabled) {
-              const selection = toAreaSelection(
-                layerId,
-                (featureProps ?? {}) as Record<string, unknown>,
-                metadata
+              setAnalysis(
+                toAreaSelection(
+                  layerId,
+                  (featureProps ?? {}) as Record<string, unknown>,
+                  metadata
+                )
               );
-              setAnalysis(selection);
-              // Surfaces the analyse nudge in the chat stream when a dataset
-              // is active; without one, the selection alone is kept.
-              showAnalysisCta(selection);
             }
           }
         }

--- a/app/components/map/layers/select-area-layer/VectorAreasLayer.tsx
+++ b/app/components/map/layers/select-area-layer/VectorAreasLayer.tsx
@@ -216,14 +216,18 @@ function VectorAreasLayer({ layerId }: SourceLayerProps) {
             // Purely additive: with the flag off, behavior is unchanged.
             // AnalysisCtaTrigger reacts to this selection and surfaces the
             // analyse nudge once a dataset is also active.
-            if (layerId === "GADM" && metadata && isAnalysisEnabled) {
-              setAnalysis(
-                toAreaSelection(
-                  layerId,
-                  (featureProps ?? {}) as Record<string, unknown>,
-                  metadata
-                )
-              );
+            if (isAnalysisEnabled) {
+              if (layerId === "GADM" && metadata) {
+                setAnalysis(
+                  toAreaSelection(
+                    layerId,
+                    (featureProps ?? {}) as Record<string, unknown>,
+                    metadata
+                  )
+                );
+              } else {
+                useMapStore.getState().clearAnalysis();
+              }
             }
           }
         }

--- a/app/components/map/layers/select-area-layer/VectorAreasLayer.tsx
+++ b/app/components/map/layers/select-area-layer/VectorAreasLayer.tsx
@@ -1,18 +1,6 @@
 import { useEffect, useState } from "react";
 import { Layer, MapMouseEvent, Source, useMap } from "react-map-gl/maplibre";
 import { union } from "@turf/union";
-import "../../../../theme/popup.css";
-
-import { LayerId, selectLayerOptions } from "../../../../types/map";
-import useContextStore from "../../../../store/contextStore";
-import useMapStore from "../../../../store/mapStore";
-import { API_CONFIG } from "../../../../config/api";
-import {
-  getAoiName,
-  getSrcId,
-  getSubtype,
-  singularizeDatasetName,
-} from "../../../../utils/areaHelpers";
 import {
   Feature,
   FeatureCollection,
@@ -20,8 +8,26 @@ import {
   MultiPolygon,
   Polygon,
 } from "geojson";
-import AreaTooltip, { HoverInfo } from "../../../ui/AreaTooltip";
+
+import { LayerId, selectLayerOptions } from "@/app/types/map";
+import { API_CONFIG } from "@/app/config/api";
+
+import useContextStore from "@/app/store/contextStore";
+import useMapStore from "@/app/store/mapStore";
+
+import { useFeatureFlag } from "@/app/hooks/useFeatureFlag";
+
+import {
+  getAoiName,
+  getSrcId,
+  getSubtype,
+  singularizeDatasetName,
+  toAreaSelection,
+} from "@/app/utils/areaHelpers";
+
+import AreaTooltip, { HoverInfo } from "@/app/components/ui/AreaTooltip";
 import { selectAreaFillPaint, selectAreaLinePaint } from "./mapStyles";
+import "@/app/theme/popup.css";
 
 interface SourceLayerProps {
   layerId: LayerId;
@@ -35,7 +41,9 @@ interface Metadata {
 
 function VectorAreasLayer({ layerId }: SourceLayerProps) {
   const { context, addContext, removeContext } = useContextStore();
-  const { addToRegistry, addLayer, setSelectAreaLayer } = useMapStore();
+  const { addToRegistry, addLayer, setSelectAreaLayer, setAnalysis } =
+    useMapStore();
+  const isAnalysisEnabled = useFeatureFlag("analysis");
   const { current: map } = useMap();
   const [hoverInfo, setHoverInfo] = useState<HoverInfo>();
   const [metadata, setMetadata] = useState<Metadata | null>(null);
@@ -203,6 +211,19 @@ function VectorAreasLayer({ layerId }: SourceLayerProps) {
                 },
               });
             }
+
+            // Analysis feature — hidden behind ?ff=analysis; GADM only.
+            // Purely additive: with the flag off, behavior is unchanged.
+            if (layerId === "GADM" && metadata && isAnalysisEnabled) {
+              setAnalysis(
+                toAreaSelection(
+                  layerId,
+                  (featureProps ?? {}) as Record<string, unknown>,
+                  metadata
+                ),
+                { lng: e.lngLat.lng, lat: e.lngLat.lat }
+              );
+            }
           }
         }
       };
@@ -240,6 +261,7 @@ function VectorAreasLayer({ layerId }: SourceLayerProps) {
     addLayer,
     layerId,
     url,
+    isAnalysisEnabled,
   ]);
 
   return (

--- a/app/components/map/layers/select-area-layer/VectorAreasLayer.tsx
+++ b/app/components/map/layers/select-area-layer/VectorAreasLayer.tsx
@@ -16,6 +16,7 @@ import useContextStore from "@/app/store/contextStore";
 import useMapStore from "@/app/store/mapStore";
 
 import { useFeatureFlag } from "@/app/hooks/useFeatureFlag";
+import { showAnalysisCta } from "@/app/lib/analysis/showAnalysisCta";
 
 import {
   getAoiName,
@@ -215,14 +216,15 @@ function VectorAreasLayer({ layerId }: SourceLayerProps) {
             // Analysis feature — hidden behind ?ff=analysis; GADM only.
             // Purely additive: with the flag off, behavior is unchanged.
             if (layerId === "GADM" && metadata && isAnalysisEnabled) {
-              setAnalysis(
-                toAreaSelection(
-                  layerId,
-                  (featureProps ?? {}) as Record<string, unknown>,
-                  metadata
-                ),
-                { lng: e.lngLat.lng, lat: e.lngLat.lat }
+              const selection = toAreaSelection(
+                layerId,
+                (featureProps ?? {}) as Record<string, unknown>,
+                metadata
               );
+              setAnalysis(selection);
+              // Surfaces the analyse nudge in the chat stream when a dataset
+              // is active; without one, the selection alone is kept.
+              showAnalysisCta(selection);
             }
           }
         }
@@ -262,6 +264,7 @@ function VectorAreasLayer({ layerId }: SourceLayerProps) {
     layerId,
     url,
     isAnalysisEnabled,
+    setAnalysis,
   ]);
 
   return (

--- a/app/hooks/useFeatureFlag.ts
+++ b/app/hooks/useFeatureFlag.ts
@@ -1,0 +1,9 @@
+import { useState } from "react";
+import { isFeatureEnabled } from "@/app/lib/feature-flags";
+
+export function useFeatureFlag(flag: string): boolean {
+  const [enabled] = useState(() =>
+    isFeatureEnabled(new URLSearchParams(window.location.search), flag)
+  );
+  return enabled;
+}

--- a/app/hooks/useFeatureFlag.ts
+++ b/app/hooks/useFeatureFlag.ts
@@ -3,7 +3,12 @@ import { isFeatureEnabled } from "@/app/lib/feature-flags";
 
 export function useFeatureFlag(flag: string): boolean {
   const [enabled] = useState(() =>
-    isFeatureEnabled(new URLSearchParams(window.location.search), flag)
+    // Flags are read from the URL, which only exists client-side; during SSR
+    // every flag is off. Callers must not branch server-rendered DOM on the
+    // flag (hydration mismatch) — render-null or client-only components only.
+    typeof window === "undefined"
+      ? false
+      : isFeatureEnabled(new URLSearchParams(window.location.search), flag)
   );
   return enabled;
 }

--- a/app/lib/__tests__/feature-flags.test.ts
+++ b/app/lib/__tests__/feature-flags.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from "vitest";
+import { isFeatureEnabled } from "../feature-flags";
+
+const params = (query: string) => new URLSearchParams(query);
+
+describe("isFeatureEnabled", () => {
+  it("is false when no ff param is present", () => {
+    expect(isFeatureEnabled(params(""), "analysis")).toBe(false);
+  });
+
+  it("is true when the flag is the sole ff value", () => {
+    expect(isFeatureEnabled(params("ff=analysis"), "analysis")).toBe(true);
+  });
+
+  it("is true when the flag is among comma-separated ff values", () => {
+    expect(isFeatureEnabled(params("ff=foo,analysis,bar"), "analysis")).toBe(
+      true
+    );
+  });
+
+  it("ignores surrounding whitespace", () => {
+    expect(isFeatureEnabled(params("ff=foo, analysis "), "analysis")).toBe(
+      true
+    );
+  });
+
+  it("is false when the flag is absent from ff", () => {
+    expect(isFeatureEnabled(params("ff=foo,bar"), "analysis")).toBe(false);
+  });
+});

--- a/app/lib/analysis/AnalysisCtaTrigger.tsx
+++ b/app/lib/analysis/AnalysisCtaTrigger.tsx
@@ -1,0 +1,26 @@
+"use client";
+import { useEffect } from "react";
+import useMapStore from "@/app/store/mapStore";
+import useContextStore from "@/app/store/contextStore";
+import { useFeatureFlag } from "@/app/hooks/useFeatureFlag";
+import { showAnalysisCta } from "./showAnalysisCta";
+
+/**
+ * Render-null watcher implementing the CTA gate reactively: the analyse nudge
+ * surfaces whenever an analysis selection and an active dataset coexist,
+ * regardless of which was set first. Mounted once in the (chat) layout;
+ * showAnalysisCta is idempotent, so re-runs on unrelated context changes are
+ * harmless.
+ */
+export function AnalysisCtaTrigger() {
+  const enabled = useFeatureFlag("analysis");
+  const analysisSelection = useMapStore((state) => state.analysisSelection);
+  const context = useContextStore((state) => state.context);
+
+  useEffect(() => {
+    if (!enabled || !analysisSelection) return;
+    showAnalysisCta(analysisSelection);
+  }, [enabled, analysisSelection, context]);
+
+  return null;
+}

--- a/app/lib/analysis/__tests__/buildAnalysisPrompt.test.ts
+++ b/app/lib/analysis/__tests__/buildAnalysisPrompt.test.ts
@@ -1,0 +1,13 @@
+import { describe, it, expect } from "vitest";
+import { buildAnalysisPrompt } from "../buildAnalysisPrompt";
+
+describe("buildAnalysisPrompt", () => {
+  it("references both the dataset and the area", () => {
+    const prompt = buildAnalysisPrompt({
+      areaName: "Pará, Brazil",
+      datasetId: 1,
+      datasetName: "Tree cover loss",
+    });
+    expect(prompt).toBe("Analyse Tree cover loss in Pará, Brazil.");
+  });
+});

--- a/app/lib/analysis/__tests__/runAnalysis.test.ts
+++ b/app/lib/analysis/__tests__/runAnalysis.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+// The store import chain reaches the Chakra toaster (.tsx), which the node
+// test environment can't parse — stub the module boundary.
+vi.mock("@/app/components/ui/toaster", () => ({
+  toaster: { create: vi.fn() },
+  Toaster: () => null,
+}));
+
+import { runAnalysis } from "../runAnalysis";
+import useChatStore from "@/app/store/chatStore";
+import useMapStore from "@/app/store/mapStore";
+
+const suggestion = {
+  areaName: "Pará, Brazil",
+  datasetId: 4,
+  datasetName: "Tree cover loss",
+};
+
+describe("runAnalysis", () => {
+  const originalSendMessage = useChatStore.getState().sendMessage;
+  const sendMessage = vi.fn().mockResolvedValue({ isNew: true, id: "t-1" });
+
+  beforeEach(() => {
+    sendMessage.mockClear();
+    useChatStore.setState({ sendMessage });
+    useMapStore
+      .getState()
+      .setAnalysis({ name: "Pará, Brazil", source: "gadm" });
+  });
+
+  afterEach(() => {
+    useChatStore.setState({ sendMessage: originalSendMessage });
+    useMapStore.getState().clearAnalysis();
+  });
+
+  it("sends the structured prompt through the generative pipeline", () => {
+    runAnalysis(suggestion);
+
+    expect(sendMessage).toHaveBeenCalledTimes(1);
+    expect(sendMessage).toHaveBeenCalledWith(
+      "Analyse Tree cover loss in Pará, Brazil.",
+      "query"
+    );
+  });
+
+  it("clears the analysis selection once the analysis is triggered", () => {
+    runAnalysis(suggestion);
+    expect(useMapStore.getState().analysisSelection).toBeNull();
+  });
+});

--- a/app/lib/analysis/__tests__/showAnalysisCta.test.ts
+++ b/app/lib/analysis/__tests__/showAnalysisCta.test.ts
@@ -81,6 +81,49 @@ describe("showAnalysisCta", () => {
     expect(nudges[0].analyseSuggestion?.areaName).toBe("Acre, Brazil");
   });
 
+  it("is idempotent for an identical pending nudge (reactive trigger re-runs)", () => {
+    seedContext([layerContext()]);
+
+    showAnalysisCta(selection);
+    const firstId = analyseNudges()[0].id;
+
+    expect(showAnalysisCta(selection)).toBe(true);
+
+    const nudges = analyseNudges();
+    expect(nudges).toHaveLength(1);
+    expect(nudges[0].id).toBe(firstId);
+  });
+
+  it("keeps accepted nudges in history when a new selection arrives", () => {
+    seedContext([layerContext()]);
+
+    showAnalysisCta(selection);
+    useChatStore.getState().acceptAnalyseNudge(analyseNudges()[0].id);
+
+    showAnalysisCta({ name: "Acre, Brazil", source: "gadm" });
+
+    const nudges = analyseNudges();
+    expect(nudges).toHaveLength(2);
+    expect(nudges[0].analyseSuggestion).toMatchObject({
+      areaName: "Pará, Brazil",
+      accepted: true,
+    });
+    expect(nudges[1].analyseSuggestion?.areaName).toBe("Acre, Brazil");
+  });
+
+  it("re-offers the same area after the previous nudge was accepted", () => {
+    seedContext([layerContext()]);
+
+    showAnalysisCta(selection);
+    useChatStore.getState().acceptAnalyseNudge(analyseNudges()[0].id);
+
+    expect(showAnalysisCta(selection)).toBe(true);
+
+    const nudges = analyseNudges();
+    expect(nudges).toHaveLength(2);
+    expect(nudges[1].analyseSuggestion?.accepted).toBeUndefined();
+  });
+
   it("does nothing when no dataset is active (analysis stays gated)", () => {
     expect(showAnalysisCta(selection)).toBe(false);
     expect(analyseNudges()).toHaveLength(0);

--- a/app/lib/analysis/__tests__/showAnalysisCta.test.ts
+++ b/app/lib/analysis/__tests__/showAnalysisCta.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// The store import chain reaches the Chakra toaster (.tsx), which the node
+// test environment can't parse — stub the module boundary.
+vi.mock("@/app/components/ui/toaster", () => ({
+  toaster: { create: vi.fn() },
+  Toaster: () => null,
+}));
+
+import { showAnalysisCta } from "../showAnalysisCta";
+import useChatStore from "@/app/store/chatStore";
+import useContextStore from "@/app/store/contextStore";
+import type { ContextItem } from "@/app/store/contextStore";
+import type { AnalysisSelection } from "@/app/store/selectAnalysisSlice";
+
+const selection: AnalysisSelection = {
+  name: "Pará, Brazil",
+  source: "gadm",
+  srcId: "BRA.14_1",
+  subtype: "adm1",
+};
+
+// Tree cover loss in the dataset catalogue (DATASET_BY_ID)
+const TCL_ID = 4;
+
+const layerContext = (overrides: Partial<ContextItem> = {}): ContextItem => ({
+  id: "layer-1",
+  contextType: "layer",
+  content: "Tree cover loss",
+  datasetId: TCL_ID,
+  ...overrides,
+});
+
+// Seed context state directly: addContext has map-layer side effects that are
+// irrelevant to CTA gating.
+const seedContext = (items: ContextItem[]) =>
+  useContextStore.setState({ context: items });
+
+const analyseNudges = () =>
+  useChatStore.getState().messages.filter((m) => m.type === "analyse-nudge");
+
+describe("showAnalysisCta", () => {
+  beforeEach(() => {
+    useChatStore.getState().reset();
+    useContextStore.getState().reset();
+  });
+
+  it("injects an analyse-nudge when a dataset is active", () => {
+    seedContext([layerContext()]);
+
+    expect(showAnalysisCta(selection)).toBe(true);
+
+    const nudges = analyseNudges();
+    expect(nudges).toHaveLength(1);
+    expect(nudges[0].analyseSuggestion).toEqual({
+      areaName: "Pará, Brazil",
+      datasetId: TCL_ID,
+      datasetName: "Tree cover loss",
+    });
+  });
+
+  it("appends the nudge as the last message", () => {
+    seedContext([layerContext()]);
+    useChatStore
+      .getState()
+      .addMessage({ type: "assistant", message: "Some narrative" });
+
+    showAnalysisCta(selection);
+
+    expect(useChatStore.getState().messages.at(-1)?.type).toBe("analyse-nudge");
+  });
+
+  it("keeps a single live nudge: a new selection replaces the previous one", () => {
+    seedContext([layerContext()]);
+
+    showAnalysisCta(selection);
+    showAnalysisCta({ name: "Acre, Brazil", source: "gadm" });
+
+    const nudges = analyseNudges();
+    expect(nudges).toHaveLength(1);
+    expect(nudges[0].analyseSuggestion?.areaName).toBe("Acre, Brazil");
+  });
+
+  it("does nothing when no dataset is active (analysis stays gated)", () => {
+    expect(showAnalysisCta(selection)).toBe(false);
+    expect(analyseNudges()).toHaveLength(0);
+  });
+
+  it("ignores non-layer context when looking for an active dataset", () => {
+    seedContext([
+      {
+        id: "area-1",
+        contextType: "area",
+        content: "Pará, Brazil",
+        aoiData: { name: "Pará, Brazil" },
+      },
+    ]);
+
+    expect(showAnalysisCta(selection)).toBe(false);
+  });
+
+  it("does nothing for a selection without a name", () => {
+    seedContext([layerContext()]);
+    expect(showAnalysisCta({ name: "", source: "gadm" })).toBe(false);
+    expect(analyseNudges()).toHaveLength(0);
+  });
+
+  it("falls back to the layer display name for datasets outside the catalogue", () => {
+    seedContext([
+      layerContext({ datasetId: 99999, layerName: "Custom layer" }),
+    ]);
+
+    expect(showAnalysisCta(selection)).toBe(true);
+    expect(analyseNudges()[0].analyseSuggestion?.datasetName).toBe(
+      "Custom layer"
+    );
+  });
+});

--- a/app/lib/analysis/buildAnalysisPrompt.ts
+++ b/app/lib/analysis/buildAnalysisPrompt.ts
@@ -1,0 +1,11 @@
+import type { AnalyseSuggestion } from "@/app/types/chat";
+
+/**
+ * Builds the structured prompt injected into the agent when the user accepts
+ * the analyse CTA. The AOI and dataset are also carried via ui_context (built
+ * by chatStore.sendMessage from contextStore), so the prompt only needs to be
+ * a clear, human-readable instruction.
+ */
+export function buildAnalysisPrompt(suggestion: AnalyseSuggestion): string {
+  return `Analyse ${suggestion.datasetName} in ${suggestion.areaName}.`;
+}

--- a/app/lib/analysis/runAnalysis.ts
+++ b/app/lib/analysis/runAnalysis.ts
@@ -1,0 +1,19 @@
+import useChatStore from "@/app/store/chatStore";
+import useMapStore from "@/app/store/mapStore";
+import type { AnalyseSuggestion } from "@/app/types/chat";
+import { buildAnalysisPrompt } from "./buildAnalysisPrompt";
+
+/**
+ * Runs the analysis for an accepted analyse CTA.
+ *
+ * MVP route is generative: inject a structured prompt into the agent via the
+ * existing chat pipeline (AOI + dataset travel in ui_context, already in
+ * contextStore). A future enhancement may serve a curated default from the
+ * analytics API instead — that swap should be contained to this module.
+ */
+export function runAnalysis(suggestion: AnalyseSuggestion): void {
+  useMapStore.getState().clearAnalysis();
+  void useChatStore
+    .getState()
+    .sendMessage(buildAnalysisPrompt(suggestion), "query");
+}

--- a/app/lib/analysis/showAnalysisCta.ts
+++ b/app/lib/analysis/showAnalysisCta.ts
@@ -29,6 +29,20 @@ export function showAnalysisCta(selection: AnalysisSelection): boolean {
     DATASET_BY_ID[datasetId]?.dataset_name ?? datasetContext.layerName;
   if (!datasetName) return false;
 
+  // Idempotent for the live pending nudge: the reactive trigger re-runs on
+  // every context change, and an identical re-upsert would churn the card.
+  const pending = useChatStore
+    .getState()
+    .messages.find(
+      (m) => m.type === "analyse-nudge" && !m.analyseSuggestion?.accepted
+    );
+  if (
+    pending?.analyseSuggestion?.areaName === selection.name &&
+    pending.analyseSuggestion.datasetId === datasetId
+  ) {
+    return true;
+  }
+
   useChatStore.getState().upsertAnalyseNudge({
     areaName: selection.name,
     datasetId,

--- a/app/lib/analysis/showAnalysisCta.ts
+++ b/app/lib/analysis/showAnalysisCta.ts
@@ -1,0 +1,38 @@
+import useChatStore from "@/app/store/chatStore";
+import useContextStore from "@/app/store/contextStore";
+import { DATASET_BY_ID } from "@/app/constants/datasets";
+import type { AnalysisSelection } from "@/app/store/selectAnalysisSlice";
+
+/**
+ * Surfaces the analyse CTA for an area selection. Analysis is intentional:
+ * the CTA only appears when a dataset is active alongside the selected area.
+ *
+ * MVP surface is a nudge message in the chat stream; a future enhancement may
+ * swap this for a map popup — that change should be contained to this module.
+ *
+ * Returns whether a CTA was surfaced.
+ */
+export function showAnalysisCta(selection: AnalysisSelection): boolean {
+  if (!selection.name) return false;
+
+  const datasetContext = useContextStore
+    .getState()
+    .context.find(
+      (ctx) => ctx.contextType === "layer" && typeof ctx.datasetId === "number"
+    );
+  if (!datasetContext) return false;
+
+  const datasetId = datasetContext.datasetId!;
+  // Prefer the canonical catalogue name — it matches what sendMessage puts in
+  // ui_context.dataset_selected — and fall back to the layer's display name.
+  const datasetName =
+    DATASET_BY_ID[datasetId]?.dataset_name ?? datasetContext.layerName;
+  if (!datasetName) return false;
+
+  useChatStore.getState().upsertAnalyseNudge({
+    areaName: selection.name,
+    datasetId,
+    datasetName,
+  });
+  return true;
+}

--- a/app/lib/feature-flags.ts
+++ b/app/lib/feature-flags.ts
@@ -1,0 +1,18 @@
+/**
+ * Hidden-feature gate. Flags are opt-in via a single comma-separated URL param,
+ * e.g. `?ff=analysis` or `?ff=analysis,other`. Reusable across features so each
+ * new hidden feature shares one convention.
+ */
+const FLAGS_PARAM = "ff";
+
+export function isFeatureEnabled(
+  params: URLSearchParams,
+  flag: string
+): boolean {
+  const raw = params.get(FLAGS_PARAM);
+  if (!raw) return false;
+  return raw
+    .split(",")
+    .map((value) => value.trim())
+    .includes(flag);
+}

--- a/app/store/__tests__/chatStore.test.ts
+++ b/app/store/__tests__/chatStore.test.ts
@@ -57,4 +57,55 @@ describe("chatStore.upsertAnalyseNudge", () => {
     useChatStore.getState().reset();
     expect(analyseNudges()).toHaveLength(0);
   });
+
+  it("preserves accepted nudges and only replaces the pending one", () => {
+    useChatStore.getState().upsertAnalyseNudge(suggestion("Pará, Brazil"));
+    const accepted = analyseNudges()[0];
+    useChatStore.getState().acceptAnalyseNudge(accepted.id);
+
+    useChatStore.getState().upsertAnalyseNudge(suggestion("Acre, Brazil"));
+    useChatStore.getState().upsertAnalyseNudge(suggestion("Amazonas, Brazil"));
+
+    const nudges = analyseNudges();
+    expect(nudges).toHaveLength(2);
+    expect(nudges[0].analyseSuggestion).toMatchObject({
+      areaName: "Pará, Brazil",
+      accepted: true,
+    });
+    expect(nudges[1].analyseSuggestion?.areaName).toBe("Amazonas, Brazil");
+    expect(nudges[1].analyseSuggestion?.accepted).toBeUndefined();
+  });
+});
+
+describe("chatStore.acceptAnalyseNudge", () => {
+  beforeEach(() => {
+    useChatStore.getState().reset();
+  });
+
+  it("marks the targeted nudge as accepted", () => {
+    useChatStore.getState().upsertAnalyseNudge(suggestion("Pará, Brazil"));
+    const nudge = analyseNudges()[0];
+
+    useChatStore.getState().acceptAnalyseNudge(nudge.id);
+
+    expect(analyseNudges()[0].analyseSuggestion?.accepted).toBe(true);
+  });
+
+  it("leaves other messages untouched", () => {
+    useChatStore
+      .getState()
+      .addMessage({ type: "assistant", message: "Narrative" });
+    useChatStore.getState().upsertAnalyseNudge(suggestion("Pará, Brazil"));
+
+    useChatStore.getState().acceptAnalyseNudge("not-a-real-id");
+
+    expect(analyseNudges()[0].analyseSuggestion?.accepted).toBeUndefined();
+    expect(
+      useChatStore
+        .getState()
+        .messages.some(
+          (m) => m.type === "assistant" && m.message === "Narrative"
+        )
+    ).toBe(true);
+  });
 });

--- a/app/store/__tests__/chatStore.test.ts
+++ b/app/store/__tests__/chatStore.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// The store import chain reaches the Chakra toaster (.tsx), which the node
+// test environment can't parse — stub the module boundary.
+vi.mock("@/app/components/ui/toaster", () => ({
+  toaster: { create: vi.fn() },
+  Toaster: () => null,
+}));
+
+import useChatStore from "../chatStore";
+import type { AnalyseSuggestion } from "@/app/types/chat";
+
+const suggestion = (areaName: string): AnalyseSuggestion => ({
+  areaName,
+  datasetId: 4,
+  datasetName: "Tree cover loss",
+});
+
+const analyseNudges = () =>
+  useChatStore.getState().messages.filter((m) => m.type === "analyse-nudge");
+
+describe("chatStore.upsertAnalyseNudge", () => {
+  beforeEach(() => {
+    useChatStore.getState().reset();
+  });
+
+  it("appends an analyse-nudge message carrying the suggestion", () => {
+    useChatStore.getState().upsertAnalyseNudge(suggestion("Pará, Brazil"));
+
+    const nudges = analyseNudges();
+    expect(nudges).toHaveLength(1);
+    expect(nudges[0].analyseSuggestion?.areaName).toBe("Pará, Brazil");
+    expect(useChatStore.getState().messages.at(-1)?.type).toBe("analyse-nudge");
+  });
+
+  it("replaces a previous nudge instead of stacking, preserving other messages", () => {
+    useChatStore.getState().upsertAnalyseNudge(suggestion("Pará, Brazil"));
+    useChatStore
+      .getState()
+      .addMessage({ type: "assistant", message: "Narrative" });
+    useChatStore.getState().upsertAnalyseNudge(suggestion("Acre, Brazil"));
+
+    const nudges = analyseNudges();
+    expect(nudges).toHaveLength(1);
+    expect(nudges[0].analyseSuggestion?.areaName).toBe("Acre, Brazil");
+    expect(
+      useChatStore
+        .getState()
+        .messages.some(
+          (m) => m.type === "assistant" && m.message === "Narrative"
+        )
+    ).toBe(true);
+  });
+
+  it("is cleared by reset() along with the rest of the thread", () => {
+    useChatStore.getState().upsertAnalyseNudge(suggestion("Pará, Brazil"));
+    useChatStore.getState().reset();
+    expect(analyseNudges()).toHaveLength(0);
+  });
+});

--- a/app/store/__tests__/selectAnalysisSlice.test.ts
+++ b/app/store/__tests__/selectAnalysisSlice.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// The store import chain reaches the Chakra toaster (.tsx), which the node
+// test environment can't parse — stub the module boundary.
+vi.mock("@/app/components/ui/toaster", () => ({
+  toaster: { create: vi.fn() },
+  Toaster: () => null,
+}));
+
+import useMapStore from "../mapStore";
+import type { AnalysisSelection } from "../selectAnalysisSlice";
+
+const selection: AnalysisSelection = {
+  name: "Pará, Brazil",
+  source: "gadm",
+  srcId: "BRA.14_1",
+  subtype: "adm1",
+};
+
+describe("selectAnalysisSlice", () => {
+  beforeEach(() => {
+    useMapStore.getState().clearAnalysis();
+  });
+
+  it("starts with no selection", () => {
+    expect(useMapStore.getState().analysisSelection).toBeNull();
+  });
+
+  it("setAnalysis stores the selection", () => {
+    useMapStore.getState().setAnalysis(selection);
+    expect(useMapStore.getState().analysisSelection).toEqual(selection);
+  });
+
+  it("setAnalysis replaces a previous selection (one at a time)", () => {
+    useMapStore.getState().setAnalysis(selection);
+    useMapStore
+      .getState()
+      .setAnalysis({ name: "Acre, Brazil", source: "gadm" });
+    expect(useMapStore.getState().analysisSelection?.name).toBe("Acre, Brazil");
+  });
+
+  it("setAnalysis accepts a selection without srcId/subtype", () => {
+    useMapStore.getState().setAnalysis({ name: "Brazil", source: "gadm" });
+    const stored = useMapStore.getState().analysisSelection;
+    expect(stored?.srcId).toBeUndefined();
+    expect(stored?.subtype).toBeUndefined();
+  });
+
+  it("clearAnalysis resets the selection", () => {
+    useMapStore.getState().setAnalysis(selection);
+    useMapStore.getState().clearAnalysis();
+    expect(useMapStore.getState().analysisSelection).toBeNull();
+  });
+});

--- a/app/store/__tests__/selectAnalysisSlice.test.ts
+++ b/app/store/__tests__/selectAnalysisSlice.test.ts
@@ -51,4 +51,10 @@ describe("selectAnalysisSlice", () => {
     useMapStore.getState().clearAnalysis();
     expect(useMapStore.getState().analysisSelection).toBeNull();
   });
+
+  it("mapStore.reset() clears the selection (new thread)", () => {
+    useMapStore.getState().setAnalysis(selection);
+    useMapStore.getState().reset();
+    expect(useMapStore.getState().analysisSelection).toBeNull();
+  });
 });

--- a/app/store/chatStore.ts
+++ b/app/store/chatStore.ts
@@ -280,16 +280,21 @@ const useChatStore = create<ChatState & ChatActions>((set, get) => ({
   // any pending nudge instead of stacking. Accepted nudges persist in the
   // thread as a record of the analyses the user ran.
   upsertAnalyseNudge: (suggestion) => {
-    set((state) => ({
-      messages: state.messages.filter(
-        (m) => m.type !== "analyse-nudge" || m.analyseSuggestion?.accepted
-      ),
-    }));
-    get().addMessage({
+    const newMessage: ChatMessage = {
+      id: Date.now().toString() + "-" + Math.random().toString(36).slice(2, 11),
       type: "analyse-nudge",
       message: "",
       analyseSuggestion: suggestion,
-    });
+      timestamp: new Date().toISOString(),
+    };
+    set((state) => ({
+      messages: [
+        ...state.messages.filter(
+          (m) => m.type !== "analyse-nudge" || m.analyseSuggestion?.accepted
+        ),
+        newMessage,
+      ],
+    }));
   },
 
   acceptAnalyseNudge: (messageId) => {

--- a/app/store/chatStore.ts
+++ b/app/store/chatStore.ts
@@ -50,6 +50,7 @@ interface ChatActions {
     message: Omit<ChatMessage, "id" | "timestamp"> & { timestamp?: string }
   ) => void;
   upsertAnalyseNudge: (suggestion: AnalyseSuggestion) => void;
+  acceptAnalyseNudge: (messageId: string) => void;
   sendMessage: (
     message: string,
     queryType?: QueryType
@@ -275,17 +276,33 @@ const useChatStore = create<ChatState & ChatActions>((set, get) => ({
   },
 
   // The analyse nudge is client-side only (never replayed from thread
-  // history): at most one is live at a time, so a new selection replaces any
-  // previous nudge instead of stacking.
+  // history): at most one is pending at a time, so a new selection replaces
+  // any pending nudge instead of stacking. Accepted nudges persist in the
+  // thread as a record of the analyses the user ran.
   upsertAnalyseNudge: (suggestion) => {
     set((state) => ({
-      messages: state.messages.filter((m) => m.type !== "analyse-nudge"),
+      messages: state.messages.filter(
+        (m) => m.type !== "analyse-nudge" || m.analyseSuggestion?.accepted
+      ),
     }));
     get().addMessage({
       type: "analyse-nudge",
       message: "",
       analyseSuggestion: suggestion,
     });
+  },
+
+  acceptAnalyseNudge: (messageId) => {
+    set((state) => ({
+      messages: state.messages.map((m) =>
+        m.id === messageId && m.analyseSuggestion
+          ? {
+              ...m,
+              analyseSuggestion: { ...m.analyseSuggestion, accepted: true },
+            }
+          : m
+      ),
+    }));
   },
 
   generateNewThread: () => {

--- a/app/store/chatStore.ts
+++ b/app/store/chatStore.ts
@@ -13,6 +13,7 @@ import {
   UiContext,
   ToolStepData,
   SuggestedDataset,
+  AnalyseSuggestion,
 } from "@/app/types/chat";
 import useContextStore from "./contextStore";
 import { readDataStream } from "@/app/lib/read-data-stream";
@@ -48,6 +49,7 @@ interface ChatActions {
   addMessage: (
     message: Omit<ChatMessage, "id" | "timestamp"> & { timestamp?: string }
   ) => void;
+  upsertAnalyseNudge: (suggestion: AnalyseSuggestion) => void;
   sendMessage: (
     message: string,
     queryType?: QueryType
@@ -270,6 +272,20 @@ const useChatStore = create<ChatState & ChatActions>((set, get) => ({
     set((state) => ({
       messages: [...state.messages, newMessage],
     }));
+  },
+
+  // The analyse nudge is client-side only (never replayed from thread
+  // history): at most one is live at a time, so a new selection replaces any
+  // previous nudge instead of stacking.
+  upsertAnalyseNudge: (suggestion) => {
+    set((state) => ({
+      messages: state.messages.filter((m) => m.type !== "analyse-nudge"),
+    }));
+    get().addMessage({
+      type: "analyse-nudge",
+      message: "",
+      analyseSuggestion: suggestion,
+    });
   },
 
   generateNewThread: () => {

--- a/app/store/mapStore.ts
+++ b/app/store/mapStore.ts
@@ -5,6 +5,10 @@ import center from "@turf/center";
 import { LayerId } from "../types/map";
 import { DrawAreaSlice, createDrawAreaSlice } from "./drawAreaSlice";
 import { UploadAreaSlice, createUploadAreaSlice } from "./uploadAreaSlice";
+import {
+  SelectAnalysisSlice,
+  createSelectAnalysisSlice,
+} from "./selectAnalysisSlice";
 import { StateCreator } from "zustand";
 import { showError } from "@/app/hooks/useErrorHandler";
 import {
@@ -42,7 +46,8 @@ interface MapSlice {
 export type MapState = MapSlice &
   DrawAreaSlice &
   UploadAreaSlice &
-  LayerManagerSlice;
+  LayerManagerSlice &
+  SelectAnalysisSlice;
 
 const createMapSlice: StateCreator<MapState, [], [], MapSlice> = (
   set,
@@ -202,6 +207,7 @@ const useMapStore = create<MapState>()((...a) => ({
   ...createDrawAreaSlice(...a),
   ...createUploadAreaSlice(...a),
   ...createLayerManagerSlice(...a),
+  ...createSelectAnalysisSlice(...a),
 }));
 
 export default useMapStore;

--- a/app/store/mapStore.ts
+++ b/app/store/mapStore.ts
@@ -62,6 +62,9 @@ const createMapSlice: StateCreator<MapState, [], [], MapSlice> = (
       selectAreaLayer: "GADM",
       layers: [],
       geoJsonRegistry: [],
+      // Clear the analysis selection so a new thread (which reseeds the
+      // default dataset) doesn't resurrect a nudge from the previous one.
+      analysisSelection: null,
     });
     get().clearSelectionMode();
 

--- a/app/store/selectAnalysisSlice.ts
+++ b/app/store/selectAnalysisSlice.ts
@@ -1,0 +1,40 @@
+import { StateCreator } from "zustand";
+import type { MapState } from "./mapStore";
+
+export interface LngLat {
+  lng: number;
+  lat: number;
+}
+
+export interface AnalysisSelection {
+  name: string;
+  source: string;
+  // Undefined is possible: the source feature may not carry an id/subtype.
+  srcId?: string;
+  subtype?: string;
+}
+
+export interface SelectAnalysisSlice {
+  /** The area selected for analysis, or null when nothing is selected. */
+  selection: AnalysisSelection | null;
+  /** Where to anchor the CTA popup (the clicked point). */
+  lngLat: LngLat | null;
+  setAnalysis: (selection: AnalysisSelection, lngLat: LngLat) => void;
+  clearAnalysis: () => void;
+}
+
+/**
+ * Ephemeral UI state for the analysis CTA — deliberately separate from the
+ * chat-context store. Holds only the current selection + anchor.
+ */
+export const createSelectAnalysisSlice: StateCreator<
+  MapState,
+  [],
+  [],
+  SelectAnalysisSlice
+> = (set) => ({
+  selection: null,
+  lngLat: null,
+  setAnalysis: (selection, lngLat) => set({ selection, lngLat }),
+  clearAnalysis: () => set({ selection: null, lngLat: null }),
+});

--- a/app/store/selectAnalysisSlice.ts
+++ b/app/store/selectAnalysisSlice.ts
@@ -1,11 +1,6 @@
 import { StateCreator } from "zustand";
 import type { MapState } from "./mapStore";
 
-export interface LngLat {
-  lng: number;
-  lat: number;
-}
-
 export interface AnalysisSelection {
   name: string;
   source: string;
@@ -17,15 +12,13 @@ export interface AnalysisSelection {
 export interface SelectAnalysisSlice {
   /** The area selected for analysis, or null when nothing is selected. */
   analysisSelection: AnalysisSelection | null;
-  /** Where to anchor the CTA popup (the clicked point). */
-  lngLat: LngLat | null;
-  setAnalysis: (selection: AnalysisSelection, lngLat: LngLat) => void;
+  setAnalysis: (selection: AnalysisSelection) => void;
   clearAnalysis: () => void;
 }
 
 /**
  * Ephemeral UI state for the analysis CTA — deliberately separate from the
- * chat-context store. Holds only the current selection + anchor.
+ * chat-context store. Holds only the current selection (one at a time).
  */
 export const createSelectAnalysisSlice: StateCreator<
   MapState,
@@ -34,8 +27,6 @@ export const createSelectAnalysisSlice: StateCreator<
   SelectAnalysisSlice
 > = (set) => ({
   analysisSelection: null,
-  lngLat: null,
-  setAnalysis: (selection, lngLat) =>
-    set({ analysisSelection: selection, lngLat }),
-  clearAnalysis: () => set({ analysisSelection: null, lngLat: null }),
+  setAnalysis: (selection) => set({ analysisSelection: selection }),
+  clearAnalysis: () => set({ analysisSelection: null }),
 });

--- a/app/store/selectAnalysisSlice.ts
+++ b/app/store/selectAnalysisSlice.ts
@@ -16,7 +16,7 @@ export interface AnalysisSelection {
 
 export interface SelectAnalysisSlice {
   /** The area selected for analysis, or null when nothing is selected. */
-  selection: AnalysisSelection | null;
+  analysisSelection: AnalysisSelection | null;
   /** Where to anchor the CTA popup (the clicked point). */
   lngLat: LngLat | null;
   setAnalysis: (selection: AnalysisSelection, lngLat: LngLat) => void;
@@ -33,8 +33,9 @@ export const createSelectAnalysisSlice: StateCreator<
   [],
   SelectAnalysisSlice
 > = (set) => ({
-  selection: null,
+  analysisSelection: null,
   lngLat: null,
-  setAnalysis: (selection, lngLat) => set({ selection, lngLat }),
-  clearAnalysis: () => set({ selection: null, lngLat: null }),
+  setAnalysis: (selection, lngLat) =>
+    set({ analysisSelection: selection, lngLat }),
+  clearAnalysis: () => set({ analysisSelection: null, lngLat: null }),
 });

--- a/app/types/chat.ts
+++ b/app/types/chat.ts
@@ -177,6 +177,9 @@ export interface AnalyseSuggestion {
   areaName: string;
   datasetId: number;
   datasetName: string;
+  // Set once the user clicks Analyse: accepted nudges persist in the thread
+  // as a record of the run, while pending ones are replaced by new selections.
+  accepted?: boolean;
 }
 
 export interface SuggestedDataset {

--- a/app/types/chat.ts
+++ b/app/types/chat.ts
@@ -24,12 +24,14 @@ export interface ChatMessage {
     | "area-card"
     | "error"
     | "warning"
-    | "dataset-nudge";
+    | "dataset-nudge"
+    | "analyse-nudge";
   message: string;
   timestamp: string;
   widgets?: InsightWidget[]; // For widget messages
   aoiSelection?: AOISelection; // For area-card messages
   suggestedDatasets?: SuggestedDataset[]; // For dataset-nudge messages
+  analyseSuggestion?: AnalyseSuggestion; // For analyse-nudge messages
   context?: ContextItem[];
   traceId?: string;
   toolSteps?: ToolStepData[]; // For user messages - reasoning steps taken to respond
@@ -166,6 +168,15 @@ export interface DatasetContextLayer {
 export interface DatasetParameter {
   name: string;
   values: unknown[];
+}
+
+// Payload of an analyse-nudge message: a snapshot of the area + dataset the
+// CTA was created for, taken at injection time so the card stays stable even
+// if the live context changes afterwards.
+export interface AnalyseSuggestion {
+  areaName: string;
+  datasetId: number;
+  datasetName: string;
 }
 
 export interface SuggestedDataset {

--- a/app/utils/areaHelpers.ts
+++ b/app/utils/areaHelpers.ts
@@ -1,4 +1,5 @@
-import { LayerId, LayerName } from "../types/map";
+import { LayerId, LayerName, selectLayerOptions } from "@/app/types/map";
+import type { AnalysisSelection } from "@/app/store/selectAnalysisSlice";
 
 interface FeatureProperties {
   [key: string]: unknown;
@@ -74,4 +75,32 @@ export function getSubtype(
   if (metadata.subregion_to_subtype_mapping?.[layerKey]) {
     return metadata.subregion_to_subtype_mapping[layerKey];
   }
+}
+
+/** Metadata the backend supplies for resolving ids/subtypes per layer. */
+export interface SelectionMetadata {
+  layer_id_mapping: Record<string, string>;
+  gadm_subtype_mapping?: Record<string, string>;
+  subregion_to_subtype_mapping?: Record<string, string>;
+}
+
+/**
+ * Driving-side anti-corruption layer: turns a clicked map feature's properties
+ * into a store `selectAnalysisSlice`, mirroring the extraction that lives inline in
+ * `VectorAreasLayer` today (name / src id / subtype / source).
+ */
+export function toAreaSelection(
+  layerId: LayerId,
+  properties: Record<string, unknown>,
+  metadata: SelectionMetadata
+): AnalysisSelection {
+  const config = selectLayerOptions.find((option) => option.id === layerId);
+  const nameKeys = config?.nameKeys ?? [];
+
+  return {
+    name: getAoiName(nameKeys, properties as Record<string, string>),
+    source: layerId.toLowerCase(),
+    srcId: getSrcId(layerId, properties, metadata),
+    subtype: getSubtype(layerId, properties, metadata),
+  };
 }

--- a/declarations.d.ts
+++ b/declarations.d.ts
@@ -1,0 +1,1 @@
+declare module "*.css";


### PR DESCRIPTION
## Pull request type

- [X] Feature


## What is the current behavior?
- The only way to get an insight in GNW today is to type a prompt. That's a meaningful friction point: users who are browsing the map and spot something interesting have to switch modes, formulate a question, and wait for generation. There's no direct path from "I see something on the map" to "tell me about this area".

- Issue Number: [[PZB-956]](https://gfw.atlassian.net/browse/PZB-956)


## What is the new behavior?
**When** I'm exploring the map and want to understand what's happening in a specific area, **I want** to click to select it and hit an Analyze CTA, **so that** I get an insight for the active dataset without having to formulate or type a prompt.



## Does this introduce a breaking change?

- [ ] Yes
- [X] No



## Demo

<img width="1510" height="910" alt="Screenshot 2026-06-12 at 14 23 39" src="https://github.com/user-attachments/assets/d96678c8-af15-4acf-bd9f-9c6535762185" />


[PZB-956]: https://gfw.atlassian.net/browse/PZB-956?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ