### PR TITLE
Make pane flush to new header

### DIFF
--- a/app/components/InsightProvenanceDrawer.tsx
+++ b/app/components/InsightProvenanceDrawer.tsx
@@ -238,9 +238,9 @@ export default function InsightProvenanceDrawer({
       placement="end"
     >
       <Portal>
-        <Drawer.Backdrop zIndex={1000} top={{ md: 12 }} />
-        <Drawer.Positioner zIndex={1200} top={{ md: 12 }}>
-          <Drawer.Content bg="neutral.200" maxH="calc(100vh - 3rem)">
+        <Drawer.Backdrop zIndex={1000} top={{ md: 10 }} />
+        <Drawer.Positioner zIndex={1200} top={{ md: 10 }}>
+          <Drawer.Content bg="neutral.200" maxH="calc(100vh - 40px)">
             <Drawer.Header
               display="flex"
               justifyContent="space-between"


### PR DESCRIPTION
Fixes gap in `View how this was generated` pane (see below)

### Before
<img width="1280" height="795" alt="image" src="https://github.com/user-attachments/assets/8c69f1a2-0342-475a-bcd8-a04d8717c661" />

### After
<img width="1920" height="991" alt="Screenshot 2026-06-11 at 13 30 09" src="https://github.com/user-attachments/assets/6851af8a-3e68-4f78-a88a-78b7b613a491" />
