### PR TITLE
Feature/pzb 949 map boundary casing

### DIFF
--- a/app/components/Map.tsx
+++ b/app/components/Map.tsx
@@ -17,6 +17,7 @@ import useMapStore from "@/app/store/mapStore";
 import useContextStore from "@/app/store/contextStore";
 import { useShallow } from "zustand/react/shallow";
 import MapAreaControls from "./MapAreaControls";
+import { basemapOptions } from "./map/BasemapSelector";
 import DynamicTileLayers, {
   RASTER_TOP_SENTINEL_ID,
 } from "./map/layers/DynamicTileLayers";
@@ -43,6 +44,8 @@ function Map({ disableMapAreaControls }: { disableMapAreaControls?: boolean }) {
     registerPrimaryForestProtocol();
   }, []);
   const { layers, handleLayerAction, aois, handleRemoveAoi } = useLegendHook();
+  const basemapTheme =
+    basemapOptions.find((o) => o.tileUrl === basemapTiles)?.theme ?? "light";
   const hasInsights = useInsightStore((s) => s.insights.length > 0);
   const areas = useContextStore(
     useShallow((s) => s.context.filter((c) => c.contextType === "area"))
@@ -209,8 +212,8 @@ function Map({ disableMapAreaControls }: { disableMapAreaControls?: boolean }) {
           <Layer id={RASTER_TOP_SENTINEL_ID} type="line" paint={{}} />
         </Source>
         <DynamicTileLayers />
-        <VectorTileLayers areas={areas} />
-        <GeoJsonLayers areas={areas} />
+        <VectorTileLayers areas={areas} basemapTheme={basemapTheme} />
+        <GeoJsonLayers areas={areas} basemapTheme={basemapTheme} />
         <SelectAreaLayer />
 
         {!disableMapAreaControls && (

--- a/app/components/map/BasemapSelector.tsx
+++ b/app/components/map/BasemapSelector.tsx
@@ -9,17 +9,21 @@ import {
 } from "@chakra-ui/react";
 import { CheckIcon, MapTrifoldIcon } from "@phosphor-icons/react";
 
+export type BasemapTheme = "light" | "dark";
+
 export interface BasemapOption {
   id: string;
   name: string;
   tileUrl: string;
   thumbnailUrl: string;
+  theme: BasemapTheme;
 }
 
-const basemapOptions: BasemapOption[] = [
+export const basemapOptions: BasemapOption[] = [
   {
     id: "light",
     name: "Light",
+    theme: "light",
     tileUrl: "devseed/cmazl5ws500bz01scaa27dqi4",
     thumbnailUrl:
       "https://api.mapbox.com/styles/v1/devseed/cmazl5ws500bz01scaa27dqi4/static/0,0,0,0,0/200x200@2x?access_token=" +
@@ -29,6 +33,7 @@ const basemapOptions: BasemapOption[] = [
   {
     id: "satellite",
     name: "Satellite",
+    theme: "dark",
     tileUrl: "mapbox/satellite-v9",
     thumbnailUrl:
       "https://api.mapbox.com/styles/v1/mapbox/satellite-v9/static/0,0,0,0,0/200x200@2x?access_token=" +
@@ -38,6 +43,7 @@ const basemapOptions: BasemapOption[] = [
   {
     id: "dark",
     name: "Dark",
+    theme: "dark",
     tileUrl: "devseed/cm7nk8rlu01bm01qvb6pues5y",
     thumbnailUrl:
       "https://api.mapbox.com/styles/v1/devseed/cm7nk8rlu01bm01qvb6pues5y/static/0,0,0,0,0/200x200@2x?access_token=" +

--- a/app/components/map/layers/GeoJsonLayers.tsx
+++ b/app/components/map/layers/GeoJsonLayers.tsx
@@ -15,6 +15,7 @@ import {
   GeoJsonEntry,
   FeatureRef,
 } from "@/app/store/layerManagerSlice";
+import { BasemapTheme } from "../BasemapSelector";
 import bbox from "@turf/bbox";
 import { unionAoiBboxes } from "@/app/utils/bboxUtils";
 
@@ -108,13 +109,15 @@ interface GeoJsonLayerGroupProps {
   layer: ManagedLayer;
   entries: GeoJsonEntry[];
   areas: ContextItem[];
+  basemapTheme: BasemapTheme;
 }
 
 interface GeoJsonLayersProps {
   areas: ContextItem[];
+  basemapTheme: BasemapTheme;
 }
 
-export default function GeoJsonLayers({ areas }: GeoJsonLayersProps) {
+export default function GeoJsonLayers({ areas, basemapTheme }: GeoJsonLayersProps) {
   const layers = useMapStore((s) => s.layers);
   const geoJsonRegistry = useMapStore((s) => s.geoJsonRegistry);
   const geoJsonLayers = layers.filter((l) => l.type === "geojson");
@@ -133,6 +136,7 @@ export default function GeoJsonLayers({ areas }: GeoJsonLayersProps) {
             layer={layer}
             entries={entries}
             areas={areas}
+            basemapTheme={basemapTheme}
           />
         );
       })}
@@ -142,7 +146,12 @@ export default function GeoJsonLayers({ areas }: GeoJsonLayersProps) {
 
 // If the group is a single area, render a single label and polygon
 // If the group is a multi-area selection, render a bbox polygon and a label for the selection name
-function GeoJsonLayerGroup({ layer, entries, areas }: GeoJsonLayerGroupProps) {
+function GeoJsonLayerGroup({
+  layer,
+  entries,
+  areas,
+  basemapTheme,
+}: GeoJsonLayerGroupProps) {
   const { addContext, removeContext } = useContextStore();
   const { isHovered, setHoverState } = useHoverState();
   // Context matching — use layer.selectionName for groups, or first entry name for singles
@@ -156,11 +165,18 @@ function GeoJsonLayerGroup({ layer, entries, areas }: GeoJsonLayerGroupProps) {
   const lineOpacity = !layer.visible ? 0 : isInContext ? 1 : 0.5;
 
   const isMultiArea = !!layer.selectionName;
-  const fillColor = isInContext
-    ? isMultiArea
-      ? "#8EA4E8"
-      : "#0A3785"
+
+  // On dark basemaps (dark, satellite) boundaries use white lines + blue casing
+  // to maximise contrast. On light basemaps the colours are inverted.
+  const casingColor = basemapTheme === "dark" ? "#0049aa" : "#FFFFFF";
+  const mainLineColor = isInContext
+    ? basemapTheme === "dark"
+      ? "#FFFFFF"
+      : isMultiArea
+        ? "#8EA4E8"
+        : "#0A3785"
     : "#666E7B";
+
   const handleRemoveFromContext = () => {
     if (areaInContext) removeContext(areaInContext.id);
   };
@@ -216,6 +232,7 @@ function GeoJsonLayerGroup({ layer, entries, areas }: GeoJsonLayerGroupProps) {
       {entries.map((entry) => {
         const sourceId = `geojson-source-${groupId}-${entry.ref.source}-${entry.ref.name}`;
         const fillLayerId = `geojson-fill-${groupId}-${entry.ref.source}-${entry.ref.name}`;
+        const casingLayerId = `geojson-line-${groupId}-${entry.ref.source}-${entry.ref.name}-casing`;
         const lineLayerId = `geojson-line-${groupId}-${entry.ref.source}-${entry.ref.name}-solid`;
         return (
           <Source
@@ -228,7 +245,32 @@ function GeoJsonLayerGroup({ layer, entries, areas }: GeoJsonLayerGroupProps) {
             <MapLayer
               id={fillLayerId}
               type="fill"
-              paint={{ "fill-color": fillColor, "fill-opacity": 0 }}
+              paint={{ "fill-color": mainLineColor, "fill-opacity": 0 }}
+              filter={[
+                "any",
+                ["==", ["geometry-type"], "Polygon"],
+                ["==", ["geometry-type"], "MultiPolygon"],
+              ]}
+            />
+            {/* Casing layer (wider, contrasting colour) rendered below the main line */}
+            <MapLayer
+              id={casingLayerId}
+              type="line"
+              paint={{
+                "line-color": casingColor,
+                "line-width": [
+                  "interpolate",
+                  ["linear"],
+                  ["zoom"],
+                  2,
+                  3.3,
+                  10,
+                  6.7,
+                  14,
+                  10,
+                ],
+                "line-opacity": lineOpacity,
+              }}
               filter={[
                 "any",
                 ["==", ["geometry-type"], "Polygon"],
@@ -239,22 +281,18 @@ function GeoJsonLayerGroup({ layer, entries, areas }: GeoJsonLayerGroupProps) {
               id={lineLayerId}
               type="line"
               paint={{
-                "line-color": fillColor,
-                "line-width": isMultiArea
-                  ? 1.5
-                  : [
-                      "interpolate",
-                      ["linear"],
-                      ["zoom"],
-                      3,
-                      0.5,
-                      6,
-                      1,
-                      10,
-                      2,
-                      14,
-                      3,
-                    ],
+                "line-color": mainLineColor,
+                "line-width": [
+                  "interpolate",
+                  ["linear"],
+                  ["zoom"],
+                  2,
+                  1,
+                  10,
+                  2,
+                  14,
+                  3,
+                ],
                 "line-opacity": lineOpacity,
               }}
               filter={[
@@ -278,7 +316,7 @@ function GeoJsonLayerGroup({ layer, entries, areas }: GeoJsonLayerGroupProps) {
             id={`bbox-line-${groupId}-dashed`}
             type="line"
             paint={{
-              "line-color": fillColor,
+              "line-color": mainLineColor,
               "line-width": 1.5,
               "line-dasharray": [2, 1],
               "line-opacity": isHovered || isInContext ? 0 : 0.75 * lineOpacity,
@@ -288,7 +326,7 @@ function GeoJsonLayerGroup({ layer, entries, areas }: GeoJsonLayerGroupProps) {
             id={`bbox-line-${groupId}-solid`}
             type="line"
             paint={{
-              "line-color": fillColor,
+              "line-color": mainLineColor,
               "line-width": 1.5,
               "line-opacity": isHovered || isInContext ? 0.75 * lineOpacity : 0,
             }}

--- a/app/components/map/layers/GeoJsonLayers.tsx
+++ b/app/components/map/layers/GeoJsonLayers.tsx
@@ -171,13 +171,13 @@ function GeoJsonLayerGroup({
 
   // On dark basemaps (dark, satellite) boundaries use white lines + blue casing
   // to maximise contrast. On light basemaps the colours are inverted.
-  const casingColor = basemapTheme === "dark" ? "#0049aa" : "#FFFFFF";
+  const casingColor = basemapTheme === "dark" ? "#172B7A" : "#FFFFFF";
   const mainLineColor = isInContext
     ? basemapTheme === "dark"
       ? "#FFFFFF"
       : isMultiArea
         ? "#8EA4E8"
-        : "#0A3785"
+        : "#172B7A"
     : "#666E7B";
 
   const handleRemoveFromContext = () => {
@@ -265,12 +265,12 @@ function GeoJsonLayerGroup({
                   "interpolate",
                   ["linear"],
                   ["zoom"],
-                  2,
-                  3.3,
+                  3,
+                  3.5,
+                  6,
+                  7,
                   10,
-                  6.7,
-                  14,
-                  10,
+                  11,
                 ],
                 "line-opacity": lineOpacity,
               }}
@@ -289,12 +289,12 @@ function GeoJsonLayerGroup({
                   "interpolate",
                   ["linear"],
                   ["zoom"],
-                  2,
+                  3,
                   1,
+                  6,
+                  1.5,
                   10,
                   2,
-                  14,
-                  3,
                 ],
                 "line-opacity": lineOpacity,
               }}

--- a/app/components/map/layers/GeoJsonLayers.tsx
+++ b/app/components/map/layers/GeoJsonLayers.tsx
@@ -117,7 +117,10 @@ interface GeoJsonLayersProps {
   basemapTheme: BasemapTheme;
 }
 
-export default function GeoJsonLayers({ areas, basemapTheme }: GeoJsonLayersProps) {
+export default function GeoJsonLayers({
+  areas,
+  basemapTheme,
+}: GeoJsonLayersProps) {
   const layers = useMapStore((s) => s.layers);
   const geoJsonRegistry = useMapStore((s) => s.geoJsonRegistry);
   const geoJsonLayers = layers.filter((l) => l.type === "geojson");

--- a/app/components/map/layers/VectorTileLayers.tsx
+++ b/app/components/map/layers/VectorTileLayers.tsx
@@ -37,12 +37,11 @@ function VectorTileLayers({ areas, basemapTheme }: VectorTileLayersProps) {
           (a) => a.aoiSelection?.name === layer.name || a.content === layer.name
         );
 
-        const lineColor =
-          isInContext
-            ? basemapTheme === "dark"
-              ? "#FFFFFF"
-              : "#8EA4E8"
-            : "#666E7B";
+        const lineColor = isInContext
+          ? basemapTheme === "dark"
+            ? "#FFFFFF"
+            : "#8EA4E8"
+          : "#666E7B";
         const casingColor = basemapTheme === "dark" ? "#0049aa" : "#FFFFFF";
         const lineOpacity = !layer.visible ? 0 : isInContext ? 1 : 0.5;
         const opacity = layer.opacity ?? 1;

--- a/app/components/map/layers/VectorTileLayers.tsx
+++ b/app/components/map/layers/VectorTileLayers.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { useMemo, useState, useEffect } from "react";
 import { Layer, Source } from "react-map-gl/maplibre";
 import useMapStore from "@/app/store/mapStore";
 import type { Layer as ManagedLayer } from "@/app/store/layerManagerSlice";
@@ -17,6 +17,9 @@ interface VectorTileLayersProps {
  */
 function VectorTileLayers({ areas, basemapTheme }: VectorTileLayersProps) {
   const allLayers = useMapStore((s) => s.layers);
+  const mapRef = useMapStore((s) => s.mapRef);
+  const [hoveredLayerId, setHoveredLayerId] = useState<string | null>(null);
+
   const vectorLayers = useMemo(
     () =>
       allLayers.filter(
@@ -25,6 +28,29 @@ function VectorTileLayers({ areas, basemapTheme }: VectorTileLayersProps) {
       ),
     [allLayers]
   );
+
+  useEffect(() => {
+    const map = mapRef?.getMap();
+    if (!map) return;
+
+    const cleanups: Array<() => void> = [];
+
+    for (const layer of vectorLayers) {
+      const fillId = `vector-tile-fill-${layer.id}`;
+      const enter = () => setHoveredLayerId(layer.id);
+      const leave = () =>
+        setHoveredLayerId((prev) => (prev === layer.id ? null : prev));
+
+      map.on("mouseenter", fillId, enter);
+      map.on("mouseleave", fillId, leave);
+      cleanups.push(() => {
+        map.off("mouseenter", fillId, enter);
+        map.off("mouseleave", fillId, leave);
+      });
+    }
+
+    return () => cleanups.forEach((c) => c());
+  }, [mapRef, vectorLayers]);
 
   return (
     <>
@@ -36,6 +62,7 @@ function VectorTileLayers({ areas, basemapTheme }: VectorTileLayersProps) {
         const isInContext = areas.some(
           (a) => a.aoiSelection?.name === layer.name || a.content === layer.name
         );
+        const isHovered = hoveredLayerId === layer.id;
 
         const lineColor = isInContext
           ? basemapTheme === "dark"
@@ -53,14 +80,17 @@ function VectorTileLayers({ areas, basemapTheme }: VectorTileLayersProps) {
             type="vector"
             tiles={[layer.tileUrl]}
           >
-            {/* Subtle fill to make features selectable visually */}
             <Layer
               id={fillLayerId}
               type="fill"
               source-layer={layer.sourceLayer}
               paint={{
-                "fill-color": lineColor,
-                "fill-opacity": isInContext ? 0.06 * opacity : 0,
+                "fill-color": "#172B7A",
+                "fill-opacity": isHovered
+                  ? 0.1 * opacity
+                  : isInContext
+                    ? 0.06 * opacity
+                    : 0,
               }}
             />
             {/* Casing layer (wider, contrasting colour) rendered below the main line */}

--- a/app/components/map/layers/VectorTileLayers.tsx
+++ b/app/components/map/layers/VectorTileLayers.tsx
@@ -3,9 +3,11 @@ import { Layer, Source } from "react-map-gl/maplibre";
 import useMapStore from "@/app/store/mapStore";
 import type { Layer as ManagedLayer } from "@/app/store/layerManagerSlice";
 import type { ContextItem } from "@/app/store/contextStore";
+import type { BasemapTheme } from "../BasemapSelector";
 
 interface VectorTileLayersProps {
   areas: ContextItem[];
+  basemapTheme: BasemapTheme;
 }
 
 /**
@@ -13,7 +15,7 @@ interface VectorTileLayersProps {
  * Applies context-aware styling: blue when the layer is the active area
  * context, gray otherwise — consistent with GeoJsonLayers.
  */
-function VectorTileLayers({ areas }: VectorTileLayersProps) {
+function VectorTileLayers({ areas, basemapTheme }: VectorTileLayersProps) {
   const allLayers = useMapStore((s) => s.layers);
   const vectorLayers = useMemo(
     () =>
@@ -35,7 +37,13 @@ function VectorTileLayers({ areas }: VectorTileLayersProps) {
           (a) => a.aoiSelection?.name === layer.name || a.content === layer.name
         );
 
-        const lineColor = isInContext ? "#8EA4E8" : "#666E7B";
+        const lineColor =
+          isInContext
+            ? basemapTheme === "dark"
+              ? "#FFFFFF"
+              : "#8EA4E8"
+            : "#666E7B";
+        const casingColor = basemapTheme === "dark" ? "#0049aa" : "#FFFFFF";
         const lineOpacity = !layer.visible ? 0 : isInContext ? 1 : 0.5;
         const opacity = layer.opacity ?? 1;
 
@@ -54,6 +62,17 @@ function VectorTileLayers({ areas }: VectorTileLayersProps) {
               paint={{
                 "fill-color": lineColor,
                 "fill-opacity": isInContext ? 0.06 * opacity : 0,
+              }}
+            />
+            {/* Casing layer (wider, contrasting colour) rendered below the main line */}
+            <Layer
+              id={`${lineLayerId}-casing`}
+              type="line"
+              source-layer={layer.sourceLayer}
+              paint={{
+                "line-color": casingColor,
+                "line-width": 5,
+                "line-opacity": lineOpacity * opacity,
               }}
             />
             <Layer

--- a/app/components/map/layers/VectorTileLayers.tsx
+++ b/app/components/map/layers/VectorTileLayers.tsx
@@ -1,4 +1,4 @@
-import { useMemo, useState, useEffect } from "react";
+import { useMemo } from "react";
 import { Layer, Source } from "react-map-gl/maplibre";
 import useMapStore from "@/app/store/mapStore";
 import type { Layer as ManagedLayer } from "@/app/store/layerManagerSlice";
@@ -17,9 +17,6 @@ interface VectorTileLayersProps {
  */
 function VectorTileLayers({ areas, basemapTheme }: VectorTileLayersProps) {
   const allLayers = useMapStore((s) => s.layers);
-  const mapRef = useMapStore((s) => s.mapRef);
-  const [hoveredLayerId, setHoveredLayerId] = useState<string | null>(null);
-
   const vectorLayers = useMemo(
     () =>
       allLayers.filter(
@@ -28,29 +25,6 @@ function VectorTileLayers({ areas, basemapTheme }: VectorTileLayersProps) {
       ),
     [allLayers]
   );
-
-  useEffect(() => {
-    const map = mapRef?.getMap();
-    if (!map) return;
-
-    const cleanups: Array<() => void> = [];
-
-    for (const layer of vectorLayers) {
-      const fillId = `vector-tile-fill-${layer.id}`;
-      const enter = () => setHoveredLayerId(layer.id);
-      const leave = () =>
-        setHoveredLayerId((prev) => (prev === layer.id ? null : prev));
-
-      map.on("mouseenter", fillId, enter);
-      map.on("mouseleave", fillId, leave);
-      cleanups.push(() => {
-        map.off("mouseenter", fillId, enter);
-        map.off("mouseleave", fillId, leave);
-      });
-    }
-
-    return () => cleanups.forEach((c) => c());
-  }, [mapRef, vectorLayers]);
 
   return (
     <>
@@ -62,7 +36,6 @@ function VectorTileLayers({ areas, basemapTheme }: VectorTileLayersProps) {
         const isInContext = areas.some(
           (a) => a.aoiSelection?.name === layer.name || a.content === layer.name
         );
-        const isHovered = hoveredLayerId === layer.id;
 
         const lineColor = isInContext
           ? basemapTheme === "dark"
@@ -80,17 +53,14 @@ function VectorTileLayers({ areas, basemapTheme }: VectorTileLayersProps) {
             type="vector"
             tiles={[layer.tileUrl]}
           >
+            {/* Subtle fill to make features selectable visually */}
             <Layer
               id={fillLayerId}
               type="fill"
               source-layer={layer.sourceLayer}
               paint={{
-                "fill-color": "#172B7A",
-                "fill-opacity": isHovered
-                  ? 0.1 * opacity
-                  : isInContext
-                    ? 0.06 * opacity
-                    : 0,
+                "fill-color": lineColor,
+                "fill-opacity": isInContext ? 0.06 * opacity : 0,
               }}
             />
             {/* Casing layer (wider, contrasting colour) rendered below the main line */}

--- a/app/components/map/layers/select-area-layer/mapStyles.ts
+++ b/app/components/map/layers/select-area-layer/mapStyles.ts
@@ -4,13 +4,13 @@ import {
 } from "react-map-gl/maplibre";
 
 export const selectAreaFillPaint: FillLayerSpecification["paint"] = {
-  "fill-color": "#4B88D8",
+  "fill-color": "#172B7A",
   "fill-opacity": [
     "case",
     ["boolean", ["feature-state", "hover"], false],
-    0.48,
+    0.1,
     ["boolean", ["feature-state", "selected"], false],
-    0.08,
+    0.01,
     0,
   ],
 };


### PR DESCRIPTION
Adds per-basemap casing to boundaries for single and multi-area selections.

Basemaps now defined by theme: 'light' or 'dark'

| Type | Before | After |
| - | - | - |
| Light |  <img width="985" height="904" alt="Screenshot 2026-06-11 at 16 10 17" src="https://github.com/user-attachments/assets/65a66474-b00a-445e-951c-8f3cc54a208c" /> <img width="979" height="899" alt="Screenshot 2026-06-11 at 16 12 28" src="https://github.com/user-attachments/assets/83ee540b-1bea-4071-a750-d4635792827a" /> | <img width="994" height="906" alt="Screenshot 2026-06-11 at 16 09 49" src="https://github.com/user-attachments/assets/91d32c00-2c02-4dd1-8555-eb6f89b3c35f" /> <img width="979" height="895" alt="Screenshot 2026-06-11 at 16 12 37" src="https://github.com/user-attachments/assets/992212e4-9fd6-499f-a021-70742984caa3" /> |
| Dark  |  <img width="978" height="897" alt="Screenshot 2026-06-11 at 16 11 11" src="https://github.com/user-attachments/assets/11610da4-98c2-42a6-af36-38f85ce4be7b" /> <img width="998" height="907" alt="Screenshot 2026-06-11 at 16 11 42" src="https://github.com/user-attachments/assets/25ec865b-d48b-4595-9689-4f45b390ac7c" /> |  <img width="985" height="904" alt="Screenshot 2026-06-11 at 16 10 55" src="https://github.com/user-attachments/assets/aa0662f8-f609-4f49-9606-ac1611dbfde4" /> <img width="985" height="904" alt="Screenshot 2026-06-11 at 16 12 05" src="https://github.com/user-attachments/assets/a34fd908-0ebf-4416-9283-817cda81a477" /> |
