### PR TITLE
Insight component accessibility audit

### DIFF
--- a/app/chart-debug/ChartDebugPanel.tsx
+++ b/app/chart-debug/ChartDebugPanel.tsx
@@ -268,12 +268,17 @@ const DRIVER_PIE = [
   { driver: "Unknown", area_ha: 180000 },
 ];
 
+// Deterministic pseudo-random so SSR and client render the same fixture
+// values (Math.random() here caused hydration mismatches).
+const pseudoRandom = (i: number, salt: number) =>
+  ((i * 9301 + salt * 49297) % 233280) / 233280;
+
 // Large table for pagination testing
 const LARGE_TABLE_DATA = Array.from({ length: 50 }, (_, i) => ({
   rank: i + 1,
   province: `Province ${String.fromCharCode(65 + (i % 26))}${i >= 26 ? "2" : ""}`,
-  area_ha: Math.round(50000 - i * 800 + Math.random() * 200),
-  change_pct: +(-2 - Math.random() * 8).toFixed(1),
+  area_ha: Math.round(50000 - i * 800 + pseudoRandom(i, 1) * 200),
+  change_pct: +(-2 - pseudoRandom(i, 2) * 8).toFixed(1),
 }));
 
 // Multi-series line for dash-pattern testing
@@ -306,14 +311,28 @@ const WIDE_TABLE_DATA = Array.from({ length: 12 }, (_, i) => ({
     "Paraguay",
     "Mexico",
   ][i],
-  tree_loss_2018_ha: Math.round(4000000 - i * 350000 + Math.random() * 50000),
-  tree_loss_2019_ha: Math.round(3800000 - i * 320000 + Math.random() * 50000),
-  tree_loss_2020_ha: Math.round(3600000 - i * 300000 + Math.random() * 50000),
-  tree_loss_2021_ha: Math.round(3400000 - i * 280000 + Math.random() * 50000),
-  tree_loss_2022_ha: Math.round(3200000 - i * 260000 + Math.random() * 50000),
-  tree_loss_2023_ha: Math.round(3000000 - i * 240000 + Math.random() * 50000),
-  primary_loss_ha: Math.round(1500000 - i * 120000 + Math.random() * 30000),
-  pct_global: +(25 - i * 2.2 + Math.random()).toFixed(1),
+  tree_loss_2018_ha: Math.round(
+    4000000 - i * 350000 + pseudoRandom(i, 3) * 50000
+  ),
+  tree_loss_2019_ha: Math.round(
+    3800000 - i * 320000 + pseudoRandom(i, 4) * 50000
+  ),
+  tree_loss_2020_ha: Math.round(
+    3600000 - i * 300000 + pseudoRandom(i, 5) * 50000
+  ),
+  tree_loss_2021_ha: Math.round(
+    3400000 - i * 280000 + pseudoRandom(i, 6) * 50000
+  ),
+  tree_loss_2022_ha: Math.round(
+    3200000 - i * 260000 + pseudoRandom(i, 7) * 50000
+  ),
+  tree_loss_2023_ha: Math.round(
+    3000000 - i * 240000 + pseudoRandom(i, 8) * 50000
+  ),
+  primary_loss_ha: Math.round(
+    1500000 - i * 120000 + pseudoRandom(i, 9) * 30000
+  ),
+  pct_global: +(25 - i * 2.2 + pseudoRandom(i, 10)).toFixed(1),
 }));
 
 // Long category names for label testing
@@ -1028,8 +1047,7 @@ export default function ChartDebugPanel() {
 
         <Separator my={8} />
         <Text fontSize="xs" color="fg.subtle" textAlign="center">
-          {FIXTURES.length} fixtures · showing {filtered.length} · rendered at{" "}
-          {new Date().toLocaleTimeString()}
+          {FIXTURES.length} fixtures · showing {filtered.length}
         </Text>
       </Container>
     </Box>

--- a/app/components/InsightProvenanceDrawer.tsx
+++ b/app/components/InsightProvenanceDrawer.tsx
@@ -28,6 +28,10 @@ import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 import { vs } from "react-syntax-highlighter/dist/esm/styles/prism";
 import { fetchExternalData } from "@/app/actions/fetch-data";
 import { Tooltip } from "@/app/components/ui/tooltip";
+import {
+  buildProvenanceMarkdown,
+  provenanceFilename,
+} from "@/app/utils/provenanceRecord";
 import JSZip from "jszip";
 import Image from "next/image";
 
@@ -117,7 +121,7 @@ function extractDataUrls(code: string): string[] {
 
 // --- Components ---
 
-function CodeBlockViewer({ code }: { code: string }) {
+function CodeBlockViewer({ code, step }: { code: string; step?: number }) {
   const { copy, copied } = useClipboard({ value: code });
   const [downloading, setDownloading] = useState(false);
 
@@ -174,6 +178,11 @@ function CodeBlockViewer({ code }: { code: string }) {
           <Image src="/python-logo.svg" alt="Python" width={14} height={14} />
           <Text fontSize="xs" color="neutral.600">
             Code
+            {step !== undefined && (
+              <Text as="span" color="neutral.500" fontFamily="mono" ml={1}>
+                · step {step}
+              </Text>
+            )}
           </Text>
         </Flex>
         <Flex gap={2}>
@@ -230,6 +239,21 @@ export default function InsightProvenanceDrawer({
 }: InsightProvenanceDrawerProps) {
   const parts = generation?.codeact_parts || [];
 
+  const handleDownloadRecord = () => {
+    const markdown = buildProvenanceMarkdown({
+      title,
+      parts: parts.map((part) => ({
+        type: part.type,
+        content: safeBase64Decode(part.content),
+      })),
+      sourceUrls: generation?.source_urls,
+    });
+    const blob = new Blob([markdown], {
+      type: "text/markdown;charset=utf-8;",
+    });
+    triggerDownload(blob, provenanceFilename(title));
+  };
+
   return (
     <Drawer.Root
       open={isOpen}
@@ -248,23 +272,55 @@ export default function InsightProvenanceDrawer({
               pt={5}
               pb={3}
             >
-              <Heading size="sm" m={0} maxW="calc(100% - 80px)">
-                {title ? `${title}` : "How this was generated"}
-              </Heading>
-              <Drawer.CloseTrigger asChild>
-                <Button
-                  size="xs"
-                  variant="outline"
-                  color="neutral.600"
-                  borderColor="neutral.300"
-                  bg="white"
-                  h={6}
-                  rounded="sm"
+              <Box maxW="calc(100% - 160px)">
+                <Heading size="sm" m={0}>
+                  {title ? `${title}` : "How this was generated"}
+                </Heading>
+                <Text
+                  fontSize="10px"
+                  fontFamily="mono"
+                  letterSpacing="0.03em"
+                  color="neutral.500"
+                  mt={1}
                 >
-                  <X />
-                  Close
-                </Button>
-              </Drawer.CloseTrigger>
+                  GENERATION RECORD · AI-ASSISTED ANALYSIS
+                </Text>
+              </Box>
+              <Flex gap={2}>
+                {parts.length > 0 && (
+                  <Tooltip content="Download this record as Markdown for archiving or audit">
+                    <Button
+                      size="xs"
+                      variant="outline"
+                      color="neutral.600"
+                      borderColor="neutral.300"
+                      bg="white"
+                      h={6}
+                      rounded="sm"
+                      onClick={handleDownloadRecord}
+                    >
+                      <DownloadSimple />
+                      Save record
+                    </Button>
+                  </Tooltip>
+                )}
+                {/* position=static overrides the drawer recipe's absolute
+                    top-right placement so Close sits inline next to Save */}
+                <Drawer.CloseTrigger asChild position="static">
+                  <Button
+                    size="xs"
+                    variant="outline"
+                    color="neutral.600"
+                    borderColor="neutral.300"
+                    bg="white"
+                    h={6}
+                    rounded="sm"
+                  >
+                    <X />
+                    Close
+                  </Button>
+                </Drawer.CloseTrigger>
+              </Flex>
             </Drawer.Header>
             <Drawer.Body bg="neutral.200" pt={0}>
               {parts.length === 0 ? (
@@ -341,7 +397,7 @@ export default function InsightProvenanceDrawer({
                             </Box>
                           )}
                           {part.type === "code_block" && (
-                            <CodeBlockViewer code={content} />
+                            <CodeBlockViewer code={content} step={i + 1} />
                           )}
                           {part.type === "execution_output" && (
                             <Box
@@ -363,6 +419,14 @@ export default function InsightProvenanceDrawer({
                                   <Terminal size={14} />
                                   <Text fontSize="xs" color="neutral.600">
                                     Execution output
+                                    <Text
+                                      as="span"
+                                      color="neutral.500"
+                                      fontFamily="mono"
+                                      ml={1}
+                                    >
+                                      · step {i + 1}
+                                    </Text>
                                   </Text>
                                 </Flex>
                                 <Flex gap={2}>
@@ -407,18 +471,28 @@ export default function InsightProvenanceDrawer({
                         <Heading size="xs" mb={2}>
                           Sources
                         </Heading>
-                        <Flex direction="column" gap={1}>
+                        <Flex direction="column" gap={1} as="ol" pl={0} m={0}>
                           {generation.source_urls.map((url, idx) => (
-                            <Link
-                              key={idx}
-                              fontSize="xs"
-                              color="blue.600"
-                              href={url}
-                              target="_blank"
-                              rel="noopener noreferrer"
-                            >
-                              {url}
-                            </Link>
+                            <Flex as="li" key={idx} gap={2} align="baseline">
+                              <Text
+                                fontSize="xs"
+                                fontFamily="mono"
+                                color="neutral.500"
+                                flexShrink={0}
+                              >
+                                {idx + 1}.
+                              </Text>
+                              <Link
+                                fontSize="xs"
+                                color="blue.600"
+                                href={url}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                wordBreak="break-all"
+                              >
+                                {url}
+                              </Link>
+                            </Flex>
                           ))}
                         </Flex>
                       </Box>

--- a/app/components/InsightWorkspace.tsx
+++ b/app/components/InsightWorkspace.tsx
@@ -56,7 +56,8 @@ export default function InsightWorkspace() {
   if (total === 0) return null;
 
   // currentIndex 0 = newest, total-1 = oldest
-  const widget = insights[total - 1 - currentIndex];
+  const widgetIndex = total - 1 - currentIndex;
+  const widget = insights[widgetIndex];
   const chips = widget.analysisParams ? buildChips(widget.analysisParams) : [];
   const hasChips = chips.length > 0;
   // currentIndex 0 = newest (shown as "1 of N"). The Left/Prev arrow
@@ -64,6 +65,20 @@ export default function InsightWorkspace() {
   const canGoPrev = currentIndex > 0;
   const canGoNext = currentIndex < total - 1;
   const HeaderIcon = WidgetIconComponent[widget.type];
+
+  // Arrow keys page through insights while focus is anywhere in the card,
+  // mirroring the prev/next buttons. Charts/menus don't consume arrows, so
+  // this doesn't conflict with inner widgets.
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (total <= 1) return;
+    if (e.key === "ArrowLeft" && canGoPrev) {
+      e.preventDefault();
+      setCurrentIndex((i) => i - 1);
+    } else if (e.key === "ArrowRight" && canGoNext) {
+      e.preventDefault();
+      setCurrentIndex((i) => i + 1);
+    }
+  };
 
   return (
     /* Card is the scroll container: grows to content, scrolls when flex-shrunk */
@@ -79,6 +94,7 @@ export default function InsightWorkspace() {
       pointerEvents="all"
       display="flex"
       flexDirection="column"
+      onKeyDown={handleKeyDown}
     >
       {/* Header — sticky so it never scrolls away */}
       <Flex
@@ -156,43 +172,56 @@ export default function InsightWorkspace() {
 
       {!isCollapsed && (
         <>
-          {/* Title row */}
-          <Flex
-            px={4}
-            py={1}
-            justify="space-between"
-            align="flex-start"
-            borderBottom="1px solid"
-            borderColor="#DDE2F5"
+          {/* Keyed on the active insight so switching re-runs the entry
+              animation; the media query keeps it off under reduced motion. */}
+          <Box
+            key={widget.id ?? widgetIndex}
+            css={{
+              "@media (prefers-reduced-motion: no-preference)": {
+                animationName: "fadeSlideIn",
+                animationDuration: "240ms",
+                animationTimingFunction: "ease-out",
+              },
+            }}
           >
-            <Heading
-              size="sm"
-              fontWeight="semibold"
-              color="primary.fg"
-              flex={1}
-              mr={2}
-              mb={0}
+            {/* Title row */}
+            <Flex
+              px={4}
+              py={1}
+              justify="space-between"
+              align="flex-start"
+              borderBottom="1px solid"
+              borderColor="#DDE2F5"
             >
-              {widget.title}
-            </Heading>
-            {hasChips && (
-              <AnalysisParametersToggle
-                expanded={paramsExpanded}
-                onToggle={() => setParamsExpanded((v) => !v)}
-              />
+              <Heading
+                size="sm"
+                fontWeight="semibold"
+                color="primary.fg"
+                flex={1}
+                mr={2}
+                mb={0}
+              >
+                {widget.title}
+              </Heading>
+              {hasChips && (
+                <AnalysisParametersToggle
+                  expanded={paramsExpanded}
+                  onToggle={() => setParamsExpanded((v) => !v)}
+                />
+              )}
+            </Flex>
+
+            {/* Params chips section */}
+            {hasChips && paramsExpanded && (
+              <Box px={4} py={2} borderBottom="1px solid" borderColor="#DDE2F5">
+                <AnalysisParamsChips chips={chips} />
+              </Box>
             )}
-          </Flex>
 
-          {/* Params chips section */}
-          {hasChips && paramsExpanded && (
-            <Box px={4} py={2} borderBottom="1px solid" borderColor="#DDE2F5">
-              <AnalysisParamsChips chips={chips} />
+            {/* Inner chart card */}
+            <Box px={2} py={2}>
+              <WidgetMessage widget={widget} inWorkspace />
             </Box>
-          )}
-
-          {/* Inner chart card */}
-          <Box px={2} py={2}>
-            <WidgetMessage widget={widget} inWorkspace />
           </Box>
 
           {/* Navigation footer — sticky so it never scrolls away */}
@@ -209,31 +238,40 @@ export default function InsightWorkspace() {
               justify="space-between"
               align="center"
             >
-              <IconButton
-                size="xs"
-                variant="ghost"
-                border="1px solid"
-                borderColor="border.emphasized"
-                aria-label="Previous insight"
-                disabled={!canGoPrev}
-                onClick={() => setCurrentIndex((i) => i - 1)}
+              <Tooltip content="Previous insight (←)" openDelay={400}>
+                <IconButton
+                  size="xs"
+                  variant="ghost"
+                  border="1px solid"
+                  borderColor="border.emphasized"
+                  aria-label="Previous insight"
+                  disabled={!canGoPrev}
+                  onClick={() => setCurrentIndex((i) => i - 1)}
+                >
+                  <ArrowArcLeftIcon size={14} />
+                </IconButton>
+              </Tooltip>
+              <Text
+                fontSize="xs"
+                color="neutral.500"
+                aria-live="polite"
+                css={{ fontVariantNumeric: "tabular-nums" }}
               >
-                <ArrowArcLeftIcon size={14} />
-              </IconButton>
-              <Text fontSize="xs" color="neutral.500">
                 {currentIndex + 1} of {total} available analyses
               </Text>
-              <IconButton
-                size="xs"
-                variant="ghost"
-                border="1px solid"
-                borderColor="border.emphasized"
-                aria-label="Next insight"
-                disabled={!canGoNext}
-                onClick={() => setCurrentIndex((i) => i + 1)}
-              >
-                <ArrowArcRightIcon size={14} />
-              </IconButton>
+              <Tooltip content="Next insight (→)" openDelay={400}>
+                <IconButton
+                  size="xs"
+                  variant="ghost"
+                  border="1px solid"
+                  borderColor="border.emphasized"
+                  aria-label="Next insight"
+                  disabled={!canGoNext}
+                  onClick={() => setCurrentIndex((i) => i + 1)}
+                >
+                  <ArrowArcRightIcon size={14} />
+                </IconButton>
+              </Tooltip>
             </Flex>
           )}
         </>

--- a/app/components/WidgetMessage.tsx
+++ b/app/components/WidgetMessage.tsx
@@ -1,19 +1,23 @@
 "use client";
-import { useState } from "react";
+import { useRef, useState } from "react";
 import {
   Box,
   Heading,
   Flex,
   Button,
   Dialog,
+  Menu,
   Portal,
   CloseButton,
+  Text,
   useDisclosure,
 } from "@chakra-ui/react";
 import {
   MicroscopeIcon as Microscope,
   ArrowsOutIcon,
   DownloadSimpleIcon,
+  FileCsvIcon,
+  ImageIcon,
   TableIcon,
   ChartBarIcon,
   CaretDownIcon,
@@ -21,16 +25,41 @@ import {
 import { InsightWidget, DatasetInfo } from "@/app/types/chat";
 import TableWidget from "./widgets/TableWidget";
 import DatasetCardWidget from "./widgets/DatasetCardWidget";
-import ChartWidget from "./widgets/ChartWidget";
+import ChartWidget, { AXIS_FIT_TYPES } from "./widgets/ChartWidget";
 import { WidgetIcons } from "../utils/widgetIcons";
 import InsightProvenanceDrawer from "./InsightProvenanceDrawer";
 import VisualizationDisclaimer from "./VisualizationDisclaimer";
 import WidgetErrorBoundary from "./widgets/WidgetErrorBoundary";
 import ScrollableTableWrapper from "./widgets/ScrollableTableWrapper";
+import { AnalysisParamsChips } from "./widgets/AnalysisParameters";
+import { buildChips } from "./widgets/analysis-params-utils";
+import { exportChartImage } from "@/app/utils/exportChartImage";
+import { toaster } from "@/app/components/ui/toaster";
 
 interface WidgetMessageProps {
   widget: InsightWidget;
   inWorkspace?: boolean;
+}
+
+/** Y-axis with the classic break squiggle — icon for the fit-axis toggle. */
+function AxisBreakIcon({ size = 14 }: { size?: number }) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 14 14"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      aria-hidden="true"
+    >
+      <path d="M7 1.5v3.5" />
+      <path d="M4.5 7.5l5-2" />
+      <path d="M4.5 10l5-2" />
+      <path d="M7 11v1.5" />
+    </svg>
+  );
 }
 
 export default function WidgetMessage({
@@ -38,6 +67,9 @@ export default function WidgetMessage({
   inWorkspace,
 }: WidgetMessageProps) {
   const [showAsTable, setShowAsTable] = useState(false);
+  const [fitYAxis, setFitYAxis] = useState(false);
+  const [exportingImage, setExportingImage] = useState(false);
+  const chartRef = useRef<HTMLDivElement>(null);
   const { open, onOpen, onClose } = useDisclosure();
   const {
     open: expanded,
@@ -50,6 +82,25 @@ export default function WidgetMessage({
 
   const handleOpen = () => {
     onOpen();
+  };
+
+  const handleDownloadImage = async () => {
+    if (!chartRef.current || exportingImage) return;
+    setExportingImage(true);
+    try {
+      await exportChartImage(chartRef.current, widget.title);
+    } catch (error) {
+      console.error("Chart image export failed:", error);
+      toaster.create({
+        title: "Image export failed",
+        description:
+          "The chart couldn't be saved as an image. You can still download the data as CSV.",
+        type: "error",
+        duration: 4000,
+      });
+    } finally {
+      setExportingImage(false);
+    }
   };
 
   const handleDownloadCsv = () => {
@@ -94,6 +145,10 @@ export default function WidgetMessage({
   const isChartType = chartTypes.includes(widget.type);
   const hasData = Array.isArray(widget.data) && widget.data.length > 0;
   const showDisclaimer = (isChartType || widget.type === "table") && hasData;
+  const supportsAxisFit = AXIS_FIT_TYPES.has(widget.type);
+  const fullscreenChips = widget.analysisParams
+    ? buildChips(widget.analysisParams)
+    : [];
   return (
     <Box
       rounded="md"
@@ -127,6 +182,8 @@ export default function WidgetMessage({
               borderColor="border.emphasized"
               rounded="md"
               overflow="hidden"
+              role="group"
+              aria-label="Visualization format"
             >
               <Button
                 size="xs"
@@ -136,6 +193,7 @@ export default function WidgetMessage({
                 h={6}
                 rounded="none"
                 fontWeight="medium"
+                aria-pressed={!showAsTable}
               >
                 <ChartBarIcon size={14} />
                 Chart
@@ -148,11 +206,30 @@ export default function WidgetMessage({
                 h={6}
                 rounded="none"
                 fontWeight="medium"
+                aria-pressed={showAsTable}
               >
                 <TableIcon size={14} />
                 Table
               </Button>
             </Flex>
+          )}
+          {/* Fit y-axis to data — only for types where a non-zero baseline
+              is honest (line/area/scatter; bar lengths encode magnitude) */}
+          {isChartType && hasData && supportsAxisFit && !showAsTable && (
+            <Button
+              size="xs"
+              variant={fitYAxis ? "solid" : "outline"}
+              colorPalette={fitYAxis ? "primary" : undefined}
+              onClick={() => setFitYAxis((v) => !v)}
+              h={6}
+              rounded="sm"
+              color={fitYAxis ? undefined : "neutral.500"}
+              aria-pressed={fitYAxis}
+              title="Rescale the y-axis to the data range instead of starting at zero"
+            >
+              <AxisBreakIcon />
+              Fit y-axis
+            </Button>
           )}
           {/* Show full-screen */}
           {isChartType && hasData && (
@@ -171,7 +248,9 @@ export default function WidgetMessage({
         </Flex>
         {isChartType && !showAsTable && (
           <WidgetErrorBoundary fallbackTitle="Unable to render chart">
-            <ChartWidget widget={widget} />
+            <Box ref={chartRef}>
+              <ChartWidget widget={widget} fitYAxis={fitYAxis} />
+            </Box>
           </WidgetErrorBoundary>
         )}
         {isChartType && showAsTable && Array.isArray(widget.data) && (
@@ -225,18 +304,38 @@ export default function WidgetMessage({
                 View how this was generated
               </Button>
             )}
-            <Button
-              size="xs"
-              variant="outline"
-              onClick={handleDownloadCsv}
-              h={6}
-              rounded="sm"
-              color="neutral.500"
-            >
-              <DownloadSimpleIcon size={14} />
-              Download
-              <CaretDownIcon size={12} />
-            </Button>
+            <Menu.Root positioning={{ placement: "bottom-start" }}>
+              <Menu.Trigger asChild>
+                <Button
+                  size="xs"
+                  variant="outline"
+                  h={6}
+                  rounded="sm"
+                  color="neutral.500"
+                  loading={exportingImage}
+                >
+                  <DownloadSimpleIcon size={14} />
+                  Download
+                  <CaretDownIcon size={12} />
+                </Button>
+              </Menu.Trigger>
+              <Portal>
+                <Menu.Positioner>
+                  <Menu.Content minW="180px" zIndex={1400}>
+                    <Menu.Item value="csv" onClick={handleDownloadCsv}>
+                      <FileCsvIcon size={14} />
+                      Data (CSV)
+                    </Menu.Item>
+                    {isChartType && !showAsTable && (
+                      <Menu.Item value="png" onClick={handleDownloadImage}>
+                        <ImageIcon size={14} />
+                        Chart image (PNG)
+                      </Menu.Item>
+                    )}
+                  </Menu.Content>
+                </Menu.Positioner>
+              </Portal>
+            </Menu.Root>
           </Flex>
         )}
         {showDisclaimer && !inWorkspace && <VisualizationDisclaimer />}
@@ -273,10 +372,72 @@ export default function WidgetMessage({
                     <CloseButton size="sm" />
                   </Dialog.CloseTrigger>
                 </Dialog.Header>
-                <Dialog.Body px={0} pb={0}>
-                  <WidgetErrorBoundary fallbackTitle="Unable to render chart">
-                    <ChartWidget widget={widget} expanded />
-                  </WidgetErrorBoundary>
+                <Dialog.Body
+                  px={0}
+                  pb={0}
+                  display="flex"
+                  flexDirection={{ base: "column", md: "row" }}
+                  gap={6}
+                  minH={0}
+                  overflow="auto"
+                >
+                  <Box flex="1" minW={0}>
+                    <WidgetErrorBoundary fallbackTitle="Unable to render chart">
+                      <ChartWidget
+                        widget={widget}
+                        expanded
+                        fitYAxis={fitYAxis}
+                      />
+                    </WidgetErrorBoundary>
+                  </Box>
+                  {(widget.description ||
+                    fullscreenChips.length > 0 ||
+                    widget.datasetName) && (
+                    <Flex
+                      direction="column"
+                      gap={4}
+                      w={{ base: "100%", md: "300px" }}
+                      flexShrink={0}
+                      borderLeftWidth={{ base: 0, md: "1px" }}
+                      borderTopWidth={{ base: "1px", md: 0 }}
+                      borderColor="border"
+                      pl={{ base: 0, md: 5 }}
+                      pt={{ base: 4, md: 1 }}
+                      overflowY="auto"
+                    >
+                      {widget.description && (
+                        <Box>
+                          <Heading size="xs" mb={1}>
+                            About this insight
+                          </Heading>
+                          <Text fontSize="sm" color="fg.muted">
+                            {widget.description}
+                          </Text>
+                        </Box>
+                      )}
+                      {fullscreenChips.length > 0 && (
+                        <Box>
+                          <Heading size="xs" mb={2}>
+                            Analysis parameters
+                          </Heading>
+                          <AnalysisParamsChips chips={fullscreenChips} />
+                        </Box>
+                      )}
+                      {widget.datasetName && (
+                        <Box>
+                          <Heading size="xs" mb={1}>
+                            Dataset
+                          </Heading>
+                          <Text fontSize="sm" color="fg.muted">
+                            {widget.datasetName}
+                          </Text>
+                        </Box>
+                      )}
+                      <Box mt="auto">
+                        <VisualizationDisclaimer />
+                      </Box>
+                    </Flex>
+                  )}
                 </Dialog.Body>
               </Dialog.Content>
             </Dialog.Positioner>

--- a/app/components/widgets/ChartWidget.tsx
+++ b/app/components/widgets/ChartWidget.tsx
@@ -16,17 +16,21 @@ import {
   CartesianGrid,
   Label,
   Legend,
+  ReferenceLine,
   Tooltip,
   XAxis,
   YAxis,
+  usePlotArea,
 } from "recharts";
 import formatChartData, {
   formatYAxisLabel,
   formatXAxisLabel,
+  formatTooltipValue,
   toAxisLabel,
 } from "@/app/utils/formatCharts";
 import { InsightWidget } from "@/app/types/chat";
 import { STROKE_DASH_PATTERNS } from "@/app/utils/ChartColors";
+import usePrefersReducedMotion from "@/app/hooks/usePrefersReducedMotion";
 
 type ChartType =
   | "bar"
@@ -43,6 +47,8 @@ const TICK_MARGIN = 6; // gap between tick text and axis line
 const TITLE_BAND = 22; // reserved column: title (~14px) + breathing room
 const TICK_ANGLE_RAD = (35 * Math.PI) / 180;
 const MAX_X_TICKS = 12; // density target before we thin tick labels
+const ANIMATION_MS = 650; // entry animation; disabled under reduced motion
+const MAX_LINE_DOTS = 14; // beyond this, per-point dots become noise
 
 // Chart wrapper components
 type ChartWrapperComponent =
@@ -65,6 +71,32 @@ const chartWrappers: Record<ChartType, ChartWrapperComponent> = {
 interface ChartWidgetProps {
   widget: InsightWidget;
   expanded?: boolean;
+  /**
+   * Rescale the y-axis to the data range instead of anchoring at zero.
+   * Useful for flat series; offered only for line/area/scatter — truncated
+   * axes misrepresent bar charts, whose lengths encode magnitude.
+   */
+  fitYAxis?: boolean;
+}
+
+/** Chart types where a fit-to-data y-axis is honest and useful. */
+export const AXIS_FIT_TYPES: ReadonlySet<string> = new Set([
+  "line",
+  "area",
+  "scatter",
+]);
+
+/**
+ * Floor the y-domain to a round number just below the data minimum, so a
+ * fitted axis starts at e.g. 35,000 rather than 35,612. Explicit numbers are
+ * needed because recharts' "auto" minimum stays pinned to the 0 baseline
+ * that Area items feed into the domain.
+ */
+function niceFloor(min: number, max: number): number {
+  if (!Number.isFinite(min) || min <= 0) return min;
+  const range = max - min || Math.abs(min) || 1;
+  const step = Math.pow(10, Math.floor(Math.log10(range)));
+  return Math.floor(min / step) * step;
 }
 interface CustomTooltipProps {
   active?: boolean;
@@ -78,8 +110,7 @@ interface CustomTooltipProps {
 const CustomScatterTooltip = ({ active, payload }: CustomTooltipProps) => {
   if (active && payload && payload.length >= 2) {
     const dataPoint = payload[0].payload;
-    const xAxisPayload = payload[0];
-    const yAxisPayload = payload[1];
+    const axisPayloads = [payload[0], payload[1]];
 
     return (
       <Box
@@ -96,37 +127,22 @@ const CustomScatterTooltip = ({ active, payload }: CustomTooltipProps) => {
             {String(dataPoint.name)}
           </Heading>
         )}
-        <Flex
-          justifyContent="space-between"
-          fontSize="xs"
-          fontWeight="normal"
-          color="fg.muted"
-        >
-          <Text as="span" mr={4}>
-            {xAxisPayload.name}
-          </Text>
-          <Text fontFamily="mono" textAlign="right">
-            {xAxisPayload.name === "year"
-              ? xAxisPayload.value
-              : Number(xAxisPayload.value).toLocaleString()}
-          </Text>
-        </Flex>
-        <Flex
-          justifyContent="space-between"
-          fontSize="xs"
-          fontWeight="normal"
-          color="fg.muted"
-        >
-          <Text as="span" mr={4}>
-            {yAxisPayload.name}
-          </Text>
-          <Text fontFamily="mono" textAlign="right">
-            {/* FIX: Correctly reference the y-axis payload value */}
-            {yAxisPayload.name === "year"
-              ? yAxisPayload.value
-              : Number(yAxisPayload.value).toLocaleString()}
-          </Text>
-        </Flex>
+        {axisPayloads.map((axisPayload, idx) => (
+          <Flex
+            key={idx}
+            justifyContent="space-between"
+            fontSize="xs"
+            fontWeight="normal"
+            color="fg.muted"
+          >
+            <Text as="span" mr={4}>
+              {toAxisLabel(axisPayload.name)}
+            </Text>
+            <Text fontFamily="mono" textAlign="right">
+              {formatTooltipValue(axisPayload.value, axisPayload.name)}
+            </Text>
+          </Flex>
+        ))}
       </Box>
     );
   }
@@ -136,40 +152,108 @@ const CustomScatterTooltip = ({ active, payload }: CustomTooltipProps) => {
 
 interface CustomPieLegendProps {
   series: { name?: string | number; color?: string }[];
+  /** Share of total per slice name, formatted (e.g. "26%"). */
+  shares?: Map<string, string>;
 }
 
-const CustomPieLegend = ({ series }: CustomPieLegendProps) => {
+const CustomPieLegend = ({ series, shares }: CustomPieLegendProps) => {
   if (!series) return null;
 
   return (
     <Flex direction="column" gap={1} as="ul" listStyleType="none" m={0} p={0}>
       {series
         .filter((entry) => entry.name && entry.color)
-        .map((entry, index) => (
-          <Flex as="li" key={`item-${index}`} align="center" gap={1.5}>
-            <Box
-              w={2.5}
-              h={2.5}
-              bg={entry.color}
-              border="1px solid"
-              borderColor="neutral.400"
-              rounded="sm"
-              flexShrink={0}
-            />
-            <Text
-              fontSize="2xs"
-              color="neutral.500"
-              overflow="hidden"
-              textOverflow="ellipsis"
-              whiteSpace="nowrap"
-            >
-              {String(entry.name)}
-            </Text>
-          </Flex>
-        ))}
+        .map((entry, index) => {
+          const share = shares?.get(String(entry.name));
+          return (
+            <Flex as="li" key={`item-${index}`} align="center" gap={1.5}>
+              <Box
+                w={2.5}
+                h={2.5}
+                bg={entry.color}
+                border="1px solid"
+                borderColor="neutral.400"
+                rounded="sm"
+                flexShrink={0}
+              />
+              <Text
+                fontSize="2xs"
+                color="neutral.500"
+                overflow="hidden"
+                textOverflow="ellipsis"
+                whiteSpace="nowrap"
+                flex="1"
+              >
+                {String(entry.name)}
+              </Text>
+              {share && (
+                <Text
+                  fontSize="2xs"
+                  color="fg.muted"
+                  fontFamily="mono"
+                  flexShrink={0}
+                  css={{ fontVariantNumeric: "tabular-nums" }}
+                >
+                  {share}
+                </Text>
+              )}
+            </Flex>
+          );
+        })}
     </Flex>
   );
 };
+
+/** "26%" for most slices, "<1%" for slivers — keeps the legend scannable. */
+function formatShare(value: number, total: number): string | undefined {
+  if (!total || total <= 0 || !Number.isFinite(value)) return undefined;
+  const pct = (value / total) * 100;
+  if (pct > 0 && pct < 1) return "<1%";
+  return `${Math.round(pct)}%`;
+}
+
+/**
+ * Donut centre total. Rendered as a <Pie> child so it sits in the chart's
+ * SVG; reads the plot area from recharts context because the pie (default
+ * cx/cy of 50%) is centred there. Recharts 3 doesn't hand <Label content>
+ * renderers a viewBox, so a context-reading component is the reliable path.
+ */
+function DonutCenterLabel({
+  total,
+  axisKey,
+  expanded = false,
+}: {
+  total: number;
+  axisKey?: string;
+  expanded?: boolean;
+}) {
+  const plotArea = usePlotArea();
+  if (!plotArea || total <= 0) return null;
+  const cx = plotArea.x + plotArea.width / 2;
+  const cy = plotArea.y + plotArea.height / 2;
+  return (
+    <text x={cx} y={cy} textAnchor="middle" dominantBaseline="central">
+      <tspan
+        x={cx}
+        dy="-0.3em"
+        fontSize={expanded ? "22" : "14"}
+        fontWeight="600"
+        fill="var(--chakra-colors-fg)"
+      >
+        {formatYAxisLabel(total, axisKey)}
+      </tspan>
+      <tspan
+        x={cx}
+        dy="1.5em"
+        fontSize={expanded ? "12" : "9"}
+        letterSpacing="0.05em"
+        fill="var(--chakra-colors-fg-muted)"
+      >
+        TOTAL
+      </tspan>
+    </text>
+  );
+}
 
 interface CustomPieTooltipWithTotalProps extends CustomTooltipProps {
   total?: number;
@@ -204,7 +288,7 @@ const CustomPieTooltip = ({
             {dataPoint.name}
           </Text>
           <Text fontFamily="mono" textAlign="right">
-            {value.toLocaleString()}
+            {formatTooltipValue(value)}
             {pct !== null && (
               <Text as="span" color="fg.subtle" ml={1}>
                 ({pct}%)
@@ -218,9 +302,28 @@ const CustomPieTooltip = ({
   return null;
 };
 
+function ChartFallback({ message }: { message: string }) {
+  return (
+    <Flex
+      align="center"
+      justify="center"
+      minH="120px"
+      border="1px dashed"
+      borderColor="border"
+      borderRadius="md"
+      p={4}
+    >
+      <Text fontSize="sm" color="fg.muted">
+        {message}
+      </Text>
+    </Flex>
+  );
+}
+
 export default function ChartWidget({
   widget,
   expanded = false,
+  fitYAxis = false,
 }: ChartWidgetProps) {
   const { data, xAxis, yAxis, type, seriesFields } = widget;
   const ChartTypeWrapper = chartWrappers[type as ChartType];
@@ -240,48 +343,52 @@ export default function ChartWidget({
     [data, type, xAxis, yAxis, widget.datasetName, seriesFields]
   );
 
-  const chart = useChart({ data: formattedData, series });
+  // Humanize series labels that are raw column keys (snake_case or the
+  // y-axis key) — tooltip and legend then show "Tree cover loss (ha)"
+  // instead of "tree_cover_loss_ha". Category-valued series names like
+  // "DR Congo" are left untouched. dataKeys still use the raw `name`.
+  const labelledSeries = useMemo(
+    () =>
+      series.map((s) =>
+        s.name === yAxis || s.name.includes("_")
+          ? { ...s, label: toAxisLabel(s.name) }
+          : s
+      ),
+    [series, yAxis]
+  );
+
+  const chart = useChart({ data: formattedData, series: labelledSeries });
+  const prefersReducedMotion = usePrefersReducedMotion();
+  const animate = !prefersReducedMotion;
 
   const pieTotal = useMemo(() => {
     if (type !== "pie" || !yAxis) return 0;
     return formattedData.reduce((sum, d) => sum + (Number(d[yAxis]) || 0), 0);
   }, [type, yAxis, formattedData]);
 
+  const pieShares = useMemo(() => {
+    if (type !== "pie" || !yAxis || !xAxis || pieTotal <= 0) return undefined;
+    const shares = new Map<string, string>();
+    for (const row of formattedData) {
+      const share = formatShare(Number(row[yAxis]), pieTotal);
+      if (share) shares.set(String(row[xAxis]), share);
+    }
+    return shares;
+  }, [type, xAxis, yAxis, formattedData, pieTotal]);
+
   if (!xAxis || (type === "scatter" && !yAxis)) {
-    return (
-      <Flex
-        align="center"
-        justify="center"
-        minH="120px"
-        border="1px dashed"
-        borderColor="border"
-        borderRadius="md"
-        p={4}
-      >
-        <Text fontSize="sm" color="fg.muted">
-          Chart is missing axis configuration.
-        </Text>
-      </Flex>
-    );
+    return <ChartFallback message="Chart is missing axis configuration." />;
   }
 
   if (!ChartTypeWrapper || formattedData.length === 0 || series.length === 0) {
     return (
-      <Flex
-        align="center"
-        justify="center"
-        minH="120px"
-        border="1px dashed"
-        borderColor="border"
-        borderRadius="md"
-        p={4}
-      >
-        <Text fontSize="sm" color="fg.muted">
-          {!ChartTypeWrapper
+      <ChartFallback
+        message={
+          !ChartTypeWrapper
             ? `Unsupported chart type: "${type}"`
-            : "No data available for this chart."}
-        </Text>
-      </Flex>
+            : "No data available for this chart."
+        }
+      />
     );
   }
 
@@ -310,10 +417,15 @@ export default function ChartWidget({
   }
 
   // Sized from the longest formatted tick so titles hug the ticks regardless
-  // of content — fixed sizes leave dead bands or cause overlap.
+  // of content — fixed sizes leave dead bands or cause overlap. The same pass
+  // detects negative values (e.g. GHG net-flux sinks) so the Y domain can
+  // extend below zero instead of clipping those bars.
   const yKeys = type === "scatter" ? [yAxis] : series.map((s) => s.name);
   let longestXTickChars = 0;
   let longestYTickChars = 0;
+  let hasNegativeValues = false;
+  let dataMinValue = Infinity;
+  let dataMaxValue = -Infinity;
   for (const row of formattedData) {
     const xFormatted =
       type === "scatter"
@@ -324,6 +436,9 @@ export default function ChartWidget({
     for (const k of yKeys) {
       const v = Number(row[k]);
       if (!Number.isFinite(v)) continue;
+      if (v < 0) hasNegativeValues = true;
+      dataMinValue = Math.min(dataMinValue, v);
+      dataMaxValue = Math.max(dataMaxValue, v);
       longestYTickChars = Math.max(
         longestYTickChars,
         formatYAxisLabel(v, yAxis).length
@@ -344,6 +459,12 @@ export default function ChartWidget({
     longestYTickChars * CHAR_PX + TICK_MARGIN + TITLE_BAND
   );
 
+  const animationProps = {
+    isAnimationActive: animate,
+    animationDuration: ANIMATION_MS,
+    animationEasing: "ease-out" as const,
+  };
+
   const renderChartItems = () => {
     switch (type) {
       case "pie": {
@@ -352,9 +473,9 @@ export default function ChartWidget({
             data={chart.data}
             nameKey={chart.key(xAxis)}
             dataKey={chart.key(yAxis)}
-            innerRadius={35}
-            outerRadius={75}
-            isAnimationActive={false}
+            innerRadius={expanded ? "42%" : 35}
+            outerRadius={expanded ? "80%" : 75}
+            {...animationProps}
             startAngle={90}
             endAngle={-270}
           >
@@ -366,6 +487,11 @@ export default function ChartWidget({
                 stroke="var(--chakra-colors-bg)"
               />
             ))}
+            <DonutCenterLabel
+              total={pieTotal}
+              axisKey={yAxis}
+              expanded={expanded}
+            />
           </Pie>
         );
       }
@@ -376,11 +502,14 @@ export default function ChartWidget({
             name={item.name?.toString()}
             data={chart.data} // Scatter plots often use the full dataset
             fill={chart.color(item.color)}
-            isAnimationActive={false}
+            {...animationProps}
           />
         ));
       }
       case "line": {
+        // Per-point dots clutter long series; keep them for short ones and
+        // always show an emphasized dot on hover.
+        const showDots = formattedData.length <= MAX_LINE_DOTS;
         return chart.series.map((item, idx) => (
           <Line
             key={item.name}
@@ -392,7 +521,13 @@ export default function ChartWidget({
             strokeDasharray={
               STROKE_DASH_PATTERNS[idx % STROKE_DASH_PATTERNS.length]
             }
-            isAnimationActive={false}
+            dot={showDots ? { r: 2.5, strokeWidth: 1 } : false}
+            activeDot={{
+              r: 4.5,
+              strokeWidth: 2,
+              stroke: "var(--chakra-colors-bg)",
+            }}
+            {...animationProps}
           />
         ));
       }
@@ -411,13 +546,24 @@ export default function ChartWidget({
             strokeDasharray={
               STROKE_DASH_PATTERNS[idx % STROKE_DASH_PATTERNS.length]
             }
-            isAnimationActive={false}
+            activeDot={{
+              r: 4.5,
+              strokeWidth: 2,
+              stroke: "var(--chakra-colors-bg)",
+            }}
+            {...animationProps}
           />
         ));
       }
       case "bar":
       case "grouped-bar":
       case "stacked-bar": {
+        // Rounded tops read well on upward bars only — skip for stacked
+        // segments and for divergent charts where bars also point down.
+        const barRadius: [number, number, number, number] | undefined =
+          type !== "stacked-bar" && !hasNegativeValues
+            ? [3, 3, 0, 0]
+            : undefined;
         return chart.series.map((item) => (
           <Bar
             key={item.name}
@@ -425,7 +571,8 @@ export default function ChartWidget({
             dataKey={chart.key(item.name)}
             stackId={type === "stacked-bar" ? "a" : undefined}
             fill={chart.color(item.color)}
-            isAnimationActive={false}
+            radius={barRadius}
+            {...animationProps}
           >
             {typeof formattedData[0]?._barColor === "string" &&
               formattedData.map((entry, index) => (
@@ -439,24 +586,50 @@ export default function ChartWidget({
     }
   };
 
-  const chartLabel =
-    `${type} chart: ${widget.title || ""}. ${widget.description || ""}`.trim();
+  const pointsSummary =
+    type === "pie"
+      ? `${formattedData.length} slices`
+      : `${formattedData.length} data points`;
+  const chartLabel = [
+    `${type} chart: ${widget.title || ""}.`,
+    `${pointsSummary}.`,
+    widget.description || "",
+  ]
+    .join(" ")
+    .trim();
 
   return (
-    <Box role="img" aria-label={chartLabel} tabIndex={0}>
+    <Box
+      role="img"
+      aria-label={chartLabel}
+      tabIndex={0}
+      borderRadius="sm"
+      _focusVisible={{
+        outline: "2px solid",
+        outlineColor: "primary.focusRing",
+        outlineOffset: "2px",
+      }}
+    >
       <Chart.Root
         maxH={expanded ? "75vh" : type === "pie" ? "190px" : "280px"}
         chart={chart}
         overflow="hidden"
       >
-        <ChartTypeWrapper data={chart.data}>
+        <ChartTypeWrapper
+          data={chart.data}
+          // Anchor area fills to the data minimum when fitting, so the 0
+          // baseline stops forcing the y-domain down to zero.
+          {...(type === "area" && fitYAxis
+            ? { baseValue: "dataMin" as const }
+            : {})}
+        >
           {type !== "pie" && (
             <CartesianGrid strokeDasharray="3 3" vertical={false} />
           )}
           <Legend
             content={
               type === "pie" ? (
-                <CustomPieLegend series={chart.series} />
+                <CustomPieLegend series={chart.series} shares={pieShares} />
               ) : (
                 <Chart.Legend />
               )
@@ -526,7 +699,20 @@ export default function ChartWidget({
                 }
                 axisLine={false}
                 tickLine={false}
-                domain={[0, "auto"]}
+                // Default: floor at 0 for all-positive data, but extend below
+                // zero for divergent datasets (e.g. GHG net flux sinks) so
+                // negative bars aren't clipped. "Fit y-axis" rescales to the
+                // data range for flat line/area/scatter series.
+                domain={
+                  fitYAxis &&
+                  AXIS_FIT_TYPES.has(type) &&
+                  Number.isFinite(dataMinValue)
+                    ? [niceFloor(dataMinValue, dataMaxValue), "auto"]
+                    : [(dataMin: number) => Math.min(0, dataMin), "auto"]
+                }
+                // Without this, recharts re-expands a fitted domain to cover
+                // the 0 baseline that area fills contribute.
+                allowDataOverflow={fitYAxis && AXIS_FIT_TYPES.has(type)}
                 fontSize={TICK_FONT_PX}
               >
                 {yAxis && (
@@ -543,6 +729,13 @@ export default function ChartWidget({
                   />
                 )}
               </YAxis>
+              {hasNegativeValues && (
+                <ReferenceLine
+                  y={0}
+                  stroke="var(--chakra-colors-neutral-400)"
+                  strokeWidth={1}
+                />
+              )}
             </>
           )}
           <Tooltip
@@ -555,7 +748,11 @@ export default function ChartWidget({
               ) : type === "pie" ? (
                 <CustomPieTooltip total={pieTotal} />
               ) : (
-                <Chart.Tooltip />
+                <Chart.Tooltip
+                  formatter={(value) =>
+                    formatTooltipValue(value, chart.key(yAxis))
+                  }
+                />
               )
             }
           />

--- a/app/components/widgets/TableWidget.tsx
+++ b/app/components/widgets/TableWidget.tsx
@@ -1,8 +1,20 @@
 "use client";
 import { useMemo, useState } from "react";
 import { toSentenceCase } from "@/app/utils/formatText";
-import { Badge, Box, Button, Flex, Table, Text } from "@chakra-ui/react";
-import { CaretUpIcon, CaretDownIcon } from "@phosphor-icons/react";
+import {
+  Badge,
+  Box,
+  Button,
+  chakra,
+  Flex,
+  Table,
+  Text,
+} from "@chakra-ui/react";
+import {
+  CaretUpIcon,
+  CaretDownIcon,
+  CaretUpDownIcon,
+} from "@phosphor-icons/react";
 
 const PAGE_SIZE = 10;
 
@@ -38,6 +50,14 @@ export default function TableWidget({ data, caption }: TableWidgetProps) {
   if (!data || data.length === 0) return null;
 
   const headers = Object.keys(data[0]);
+
+  // Right-align a column when every non-null value in it is numeric, so
+  // magnitudes line up digit-for-digit (paired with tabular-nums below).
+  const numericColumns = new Set(
+    headers.filter((key) =>
+      data.every((row) => row[key] == null || typeof row[key] === "number")
+    )
+  );
 
   // Helper function to format numeric values
   const formatValue = (
@@ -99,9 +119,7 @@ export default function TableWidget({ data, caption }: TableWidgetProps) {
                 fontWeight="normal"
                 whiteSpace="pre"
                 scope="col"
-                cursor="pointer"
-                _hover={{ color: "fg" }}
-                onClick={() => handleSort(key)}
+                textAlign={numericColumns.has(key) ? "end" : undefined}
                 aria-sort={
                   sortKey === key
                     ? sortDir === "asc"
@@ -110,15 +128,36 @@ export default function TableWidget({ data, caption }: TableWidgetProps) {
                     : "none"
                 }
               >
-                <Flex align="center" gap={1} display="inline-flex">
+                <chakra.button
+                  type="button"
+                  display="inline-flex"
+                  alignItems="center"
+                  gap={1}
+                  cursor="pointer"
+                  color="inherit"
+                  onClick={() => handleSort(key)}
+                  _hover={{ color: "fg" }}
+                  _focusVisible={{
+                    outline: "2px solid",
+                    outlineColor: "primary.focusRing",
+                    outlineOffset: "1px",
+                    borderRadius: "xs",
+                  }}
+                  aria-label={`Sort by ${toSentenceCase(key)}`}
+                >
                   {toSentenceCase(key)}
-                  {sortKey === key &&
-                    (sortDir === "asc" ? (
+                  {sortKey === key ? (
+                    sortDir === "asc" ? (
                       <CaretUpIcon size={12} />
                     ) : (
                       <CaretDownIcon size={12} />
-                    ))}
-                </Flex>
+                    )
+                  ) : (
+                    <Box as="span" color="neutral.400" aria-hidden="true">
+                      <CaretUpDownIcon size={12} />
+                    </Box>
+                  )}
+                </chakra.button>
               </Table.ColumnHeader>
             ))}
           </Table.Row>
@@ -134,8 +173,11 @@ export default function TableWidget({ data, caption }: TableWidgetProps) {
                   const value = row[key];
 
                   const isRankKey = key.toLowerCase() === "rank";
+                  // Years are ordinary data, not ranks — don't badge them.
                   const isFirstNumericColumn =
-                    cellIndex === 0 && typeof value === "number";
+                    cellIndex === 0 &&
+                    typeof value === "number" &&
+                    key.toLowerCase() !== "year";
 
                   if (isRankKey || isFirstNumericColumn) {
                     return (
@@ -155,7 +197,11 @@ export default function TableWidget({ data, caption }: TableWidgetProps) {
                   return (
                     <Table.Cell
                       key={key}
-                      css={{ "&:nth-child(2)": { fontWeight: "medium" } }}
+                      textAlign={numericColumns.has(key) ? "end" : undefined}
+                      css={{
+                        "&:nth-child(2)": { fontWeight: "medium" },
+                        fontVariantNumeric: "tabular-nums",
+                      }}
                     >
                       {formatValue(value)}
                     </Table.Cell>

--- a/app/hooks/usePrefersReducedMotion.ts
+++ b/app/hooks/usePrefersReducedMotion.ts
@@ -1,0 +1,27 @@
+"use client";
+import { useSyncExternalStore } from "react";
+
+const QUERY = "(prefers-reduced-motion: reduce)";
+
+function subscribe(onStoreChange: () => void): () => void {
+  const mediaQuery = window.matchMedia(QUERY);
+  mediaQuery.addEventListener("change", onStoreChange);
+  return () => mediaQuery.removeEventListener("change", onStoreChange);
+}
+
+function getSnapshot(): boolean {
+  return window.matchMedia(QUERY).matches;
+}
+
+// SSR: assume no preference; the client snapshot corrects on hydration.
+function getServerSnapshot(): boolean {
+  return false;
+}
+
+/**
+ * Reactively tracks the user's `prefers-reduced-motion` setting so
+ * chart/workspace animations can be disabled for motion-sensitive users.
+ */
+export default function usePrefersReducedMotion(): boolean {
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+}

--- a/app/store/chat-tools/generateInsights.ts
+++ b/app/store/chat-tools/generateInsights.ts
@@ -113,8 +113,6 @@ export function generateInsightsTool(
         };
       });
 
-      console.log("FRONTEND: Received charts_data message:", widgets);
-
       useInsightStore.getState().addInsights(widgets);
     }
   } catch (error) {

--- a/app/theme/index.tsx
+++ b/app/theme/index.tsx
@@ -29,6 +29,10 @@ export const config = defineConfig({
         "0%": { backgroundPositionX: "100%" },
         "100%": { backgroundPositionX: "-100%" },
       },
+      fadeSlideIn: {
+        from: { opacity: 0, transform: "translateY(4px)" },
+        to: { opacity: 1, transform: "translateY(0)" },
+      },
       dynamicSlideLeft: {
         from: {
           transform: "translateX(var(--start-x))",

--- a/app/utils/__tests__/formatCharts.test.ts
+++ b/app/utils/__tests__/formatCharts.test.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect } from "vitest";
+import formatChartData, {
+  toAxisLabel,
+  formatYAxisLabel,
+  formatXAxisLabel,
+  formatTooltipValue,
+} from "../formatCharts";
+
+describe("toAxisLabel", () => {
+  it("extracts area unit suffixes", () => {
+    expect(toAxisLabel("area_km2")).toBe("Area (km²)");
+    expect(toAxisLabel("tree_cover_loss_ha")).toBe("Tree cover loss (ha)");
+  });
+
+  it("recognises CO₂e unit suffixes used by the GHG datasets", () => {
+    expect(toAxisLabel("net_flux_tCO2e")).toBe("Net flux (tCO₂e)");
+    expect(toAxisLabel("emissions_tco2e")).toBe("Emissions (tCO₂e)");
+    expect(toAxisLabel("emissions_mgco2e")).toBe("Emissions (MgCO₂e)");
+    expect(toAxisLabel("emission_factor_tco2e_per_tonne")).toBe(
+      "Emission factor (tCO₂e/t)"
+    );
+  });
+
+  it("maps _mt to megatonnes, not tonnes", () => {
+    expect(toAxisLabel("carbon_emissions_mt")).toBe("Carbon emissions (Mt)");
+  });
+
+  it("still maps plain tonne suffixes to t", () => {
+    expect(toAxisLabel("production_tonnes")).toBe("Production (t)");
+    expect(toAxisLabel("weight_t")).toBe("Weight (t)");
+  });
+
+  it("extracts percentage suffixes", () => {
+    expect(toAxisLabel("pct_of_total")).toBe("Pct of total");
+    expect(toAxisLabel("change_pct")).toBe("Change (%)");
+  });
+
+  it("humanises snake_case and camelCase without units", () => {
+    expect(toAxisLabel("land_cover_type")).toBe("Land cover type");
+    expect(toAxisLabel("gdpPerCapita")).toBe("Gdp per capita");
+  });
+
+  it("returns empty string for empty input", () => {
+    expect(toAxisLabel("")).toBe("");
+  });
+});
+
+describe("formatYAxisLabel", () => {
+  it("passes years through unchanged", () => {
+    expect(formatYAxisLabel(2023, "year")).toBe("2023");
+  });
+
+  it("returns 0 for zero", () => {
+    expect(formatYAxisLabel(0)).toBe("0");
+  });
+
+  it("keeps small values locale-formatted", () => {
+    expect(formatYAxisLabel(999)).toBe("999");
+    expect(formatYAxisLabel(-450)).toBe("-450");
+  });
+
+  it("compacts thousands/millions/billions and strips trailing .0", () => {
+    expect(formatYAxisLabel(1500)).toBe("1.5K");
+    expect(formatYAxisLabel(2000)).toBe("2K");
+    expect(formatYAxisLabel(4_510_000)).toBe("4.5M");
+    expect(formatYAxisLabel(3_000_000_000)).toBe("3B");
+  });
+
+  it("promotes to the next unit when rounding crosses it", () => {
+    expect(formatYAxisLabel(999_950)).toBe("1M");
+  });
+
+  it("formats negative magnitudes", () => {
+    expect(formatYAxisLabel(-45_000)).toBe("-45K");
+    expect(formatYAxisLabel(-2_500_000)).toBe("-2.5M");
+  });
+});
+
+describe("formatXAxisLabel", () => {
+  it("passes years through unchanged", () => {
+    expect(formatXAxisLabel(2023, "year")).toBe("2023");
+  });
+
+  it("truncates long category labels", () => {
+    expect(formatXAxisLabel("Tropical moist broadleaf forests")).toBe(
+      "Tropical moi…"
+    );
+  });
+
+  it("keeps short labels intact", () => {
+    expect(formatXAxisLabel("Brazil")).toBe("Brazil");
+  });
+});
+
+describe("formatTooltipValue", () => {
+  it("formats numbers with locale separators and 2dp max", () => {
+    expect(formatTooltipValue(4812000)).toBe("4,812,000");
+    expect(formatTooltipValue(1234567.891)).toBe("1,234,567.89");
+  });
+
+  it("passes years through unchanged", () => {
+    expect(formatTooltipValue(2023, "year")).toBe("2023");
+  });
+
+  it("parses numeric strings", () => {
+    expect(formatTooltipValue("4500")).toBe("4,500");
+  });
+
+  it("returns non-numeric values as-is", () => {
+    expect(formatTooltipValue("Brazil")).toBe("Brazil");
+    expect(formatTooltipValue("")).toBe("");
+  });
+});
+
+describe("formatChartData", () => {
+  it("returns empty result for empty or invalid data", () => {
+    expect(formatChartData([], "bar", "x", "y")).toEqual({
+      data: [],
+      series: [],
+    });
+    expect(formatChartData(null, "bar", "x", "y")).toEqual({
+      data: [],
+      series: [],
+    });
+  });
+
+  it("builds a single series for a simple bar chart", () => {
+    const data = [
+      { country: "Brazil", area_ha: 100 },
+      { country: "Peru", area_ha: 50 },
+    ];
+    const result = formatChartData(data, "bar", "country", "area_ha");
+    expect(result.series).toHaveLength(1);
+    expect(result.series[0].name).toBe("area_ha");
+    expect(result.data).toHaveLength(2);
+  });
+
+  it("preserves negative values for divergent datasets", () => {
+    const data = [
+      { country: "Brazil", net_flux_tCO2e: -450 },
+      { country: "Indonesia", net_flux_tCO2e: 320 },
+    ];
+    const result = formatChartData(
+      data,
+      "bar",
+      "country",
+      "net_flux_tCO2e",
+      "Forest greenhouse gas net flux (2001-2024)"
+    );
+    expect(result.data[0].net_flux_tCO2e).toBe(-450);
+    // Per-bar colors assigned by sign
+    expect(result.data[0]._barColor).not.toBe(result.data[1]._barColor);
+  });
+
+  it("creates one series per metric column for multi-series line charts", () => {
+    const data = [
+      { year: 2020, Brazil: 100, Peru: 50 },
+      { year: 2021, Brazil: 90, Peru: 60 },
+    ];
+    const result = formatChartData(data, "line", "year");
+    expect(result.series.map((s) => s.name)).toEqual(["Brazil", "Peru"]);
+  });
+
+  it("pivots long-format data for grouped bars", () => {
+    const data = [
+      { region: "A", year: "2020", area_km2: 10 },
+      { region: "A", year: "2021", area_km2: 12 },
+      { region: "B", year: "2020", area_km2: 8 },
+      { region: "B", year: "2021", area_km2: 9 },
+    ];
+    const result = formatChartData(data, "grouped-bar", "region", "area_km2");
+    expect(result.series.map((s) => s.name)).toEqual(["2020", "2021"]);
+    expect(result.data).toHaveLength(2);
+    expect(result.data[0]).toMatchObject({ region: "A", 2020: 10, 2021: 12 });
+  });
+
+  it("keeps the name column for scatter charts (regression)", () => {
+    const data = [
+      { country: "Brazil", gdp_per_capita: 8900, deforestation_ha: 4812000 },
+      { country: "Peru", gdp_per_capita: 6700, deforestation_ha: 310000 },
+    ];
+    const result = formatChartData(
+      data,
+      "scatter",
+      "gdp_per_capita",
+      "deforestation_ha"
+    );
+    expect(result.data).toHaveLength(2);
+    expect(result.data[0].name).toBe("Brazil");
+  });
+
+  it("assigns domain colors to known pie categories", () => {
+    const data = [
+      { driver: "Logging", area_ha: 100 },
+      { driver: "Wildfire", area_ha: 50 },
+    ];
+    const result = formatChartData(data, "pie", "driver", "area_ha");
+    const logging = result.series.find((s) => s.name === "Logging");
+    expect(logging?.color).toBe("#52A44E");
+  });
+});

--- a/app/utils/__tests__/provenanceRecord.test.ts
+++ b/app/utils/__tests__/provenanceRecord.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildProvenanceMarkdown,
+  provenanceFilename,
+} from "../provenanceRecord";
+
+const EXPORTED_AT = new Date("2026-06-12T10:00:00.000Z");
+
+describe("buildProvenanceMarkdown", () => {
+  it("builds an ordered record with narrative, code, and output steps", () => {
+    const md = buildProvenanceMarkdown({
+      title: "Tree cover loss in Brazil",
+      parts: [
+        { type: "text_output", content: "We query the dataset." },
+        { type: "code_block", content: "print('hi')" },
+        { type: "execution_output", content: "hi" },
+      ],
+      sourceUrls: ["https://example.org/data"],
+      exportedAt: EXPORTED_AT,
+    });
+
+    expect(md).toContain("# Tree cover loss in Brazil");
+    expect(md).toContain("exported 2026-06-12T10:00:00.000Z");
+    expect(md).toContain("## Step 1 — Narrative");
+    expect(md).toContain("## Step 2 — Code");
+    expect(md).toContain("```python\nprint('hi')\n```");
+    expect(md).toContain("## Step 3 — Execution output");
+    expect(md).toContain("## Sources");
+    expect(md).toContain("1. https://example.org/data");
+  });
+
+  it("omits the sources section when there are none", () => {
+    const md = buildProvenanceMarkdown({
+      title: "T",
+      parts: [{ type: "text_output", content: "x" }],
+      exportedAt: EXPORTED_AT,
+    });
+    expect(md).not.toContain("## Sources");
+  });
+
+  it("falls back to a generic title", () => {
+    const md = buildProvenanceMarkdown({
+      parts: [],
+      exportedAt: EXPORTED_AT,
+    });
+    expect(md).toContain("# Insight generation record");
+  });
+});
+
+describe("provenanceFilename", () => {
+  it("slugs the title", () => {
+    expect(provenanceFilename("Tree cover loss (2023)")).toBe(
+      "Tree_cover_loss__2023__generation_record.md"
+    );
+  });
+
+  it("handles missing titles", () => {
+    expect(provenanceFilename(undefined)).toBe("insight_generation_record.md");
+  });
+});

--- a/app/utils/exportChartImage.ts
+++ b/app/utils/exportChartImage.ts
@@ -1,0 +1,128 @@
+/**
+ * Exports a rendered chart (SVG plot + HTML legend) to a PNG download.
+ *
+ * The chart container mixes an HTML legend with the recharts SVG, so the
+ * whole container is rasterized via an SVG <foreignObject>: computed styles
+ * are inlined on a clone (CSS variables and classes don't survive
+ * serialization), the clone is serialized to a data-URL SVG, drawn onto a
+ * 2x canvas with the title and a white background, and downloaded.
+ */
+
+const EXPORT_SCALE = 2; // retina-quality raster
+const TITLE_BAND_PX = 40; // unscaled space reserved above the chart
+const PADDING_PX = 16; // unscaled padding around the chart
+
+/** Copy every computed style property onto the clone as inline style. */
+function inlineComputedStyles(source: Element, target: Element) {
+  const computed = window.getComputedStyle(source);
+  let cssText = "";
+  for (let i = 0; i < computed.length; i++) {
+    const property = computed[i];
+    cssText += `${property}:${computed.getPropertyValue(property)};`;
+  }
+  target.setAttribute("style", cssText);
+
+  const sourceChildren = source.children;
+  const targetChildren = target.children;
+  for (let i = 0; i < sourceChildren.length; i++) {
+    if (targetChildren[i]) {
+      inlineComputedStyles(sourceChildren[i], targetChildren[i]);
+    }
+  }
+}
+
+function loadImage(src: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const image = new Image();
+    image.onload = () => resolve(image);
+    image.onerror = () =>
+      reject(new Error("Failed to rasterize the chart snapshot."));
+    image.src = src;
+  });
+}
+
+function canvasToBlob(canvas: HTMLCanvasElement): Promise<Blob> {
+  return new Promise((resolve, reject) => {
+    canvas.toBlob((blob) => {
+      if (blob) resolve(blob);
+      else reject(new Error("Failed to encode the PNG."));
+    }, "image/png");
+  });
+}
+
+function drawTitle(
+  ctx: CanvasRenderingContext2D,
+  title: string,
+  maxWidth: number
+) {
+  ctx.fillStyle = "#13171A";
+  ctx.font = `600 ${15 * EXPORT_SCALE}px ui-sans-serif, system-ui, sans-serif`;
+  ctx.textBaseline = "middle";
+  let text = title;
+  while (text.length > 1 && ctx.measureText(text).width > maxWidth) {
+    text = `${text.slice(0, -2).trimEnd()}…`;
+  }
+  ctx.fillText(
+    text,
+    PADDING_PX * EXPORT_SCALE,
+    (PADDING_PX + TITLE_BAND_PX / 2) * EXPORT_SCALE
+  );
+}
+
+export function chartImageFilename(title: string | undefined): string {
+  return `${(title || "chart").replace(/[^a-z0-9]/gi, "_")}.png`;
+}
+
+export async function exportChartImage(
+  container: HTMLElement,
+  title?: string
+): Promise<void> {
+  const rect = container.getBoundingClientRect();
+  if (rect.width === 0 || rect.height === 0) {
+    throw new Error("Chart is not visible, so there is nothing to export.");
+  }
+
+  const clone = container.cloneNode(true) as HTMLElement;
+  inlineComputedStyles(container, clone);
+  clone.setAttribute("xmlns", "http://www.w3.org/1999/xhtml");
+
+  const width = Math.ceil(rect.width);
+  const height = Math.ceil(rect.height);
+  const svgString =
+    `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}">` +
+    `<foreignObject width="100%" height="100%">${new XMLSerializer().serializeToString(clone)}</foreignObject>` +
+    `</svg>`;
+
+  const image = await loadImage(
+    `data:image/svg+xml;charset=utf-8,${encodeURIComponent(svgString)}`
+  );
+
+  const canvas = document.createElement("canvas");
+  canvas.width = (width + PADDING_PX * 2) * EXPORT_SCALE;
+  canvas.height = (height + TITLE_BAND_PX + PADDING_PX * 2) * EXPORT_SCALE;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) {
+    throw new Error("Canvas 2D rendering is not available in this browser.");
+  }
+
+  ctx.fillStyle = "#FFFFFF";
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+  if (title) {
+    drawTitle(ctx, title, canvas.width - PADDING_PX * 2 * EXPORT_SCALE);
+  }
+  ctx.drawImage(
+    image,
+    PADDING_PX * EXPORT_SCALE,
+    (TITLE_BAND_PX + PADDING_PX) * EXPORT_SCALE,
+    width * EXPORT_SCALE,
+    height * EXPORT_SCALE
+  );
+
+  const blob = await canvasToBlob(canvas);
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = chartImageFilename(title);
+  link.click();
+  URL.revokeObjectURL(url);
+}

--- a/app/utils/formatCharts.tsx
+++ b/app/utils/formatCharts.tsx
@@ -146,8 +146,12 @@ export default function formatChartData(
 
   const xAxisKey = xAxis || keys[0]; //identify dataset
   const valueKeys = resolveValueKeys(keys, xAxisKey, yAxis, seriesFields);
+  // Scatter needs a third (name/label) column beyond x and y, so scoping to
+  // [xAxis, yAxis] would discard it and leave the chart unable to render.
   const shouldScopeColumns =
-    Boolean(seriesFields?.length) || (Boolean(yAxis) && type !== "grouped-bar");
+    type !== "scatter" &&
+    (Boolean(seriesFields?.length) ||
+      (Boolean(yAxis) && type !== "grouped-bar"));
   const scopedData = shouldScopeColumns
     ? filterChartDataColumns(data, [xAxisKey, ...valueKeys])
     : data;
@@ -414,11 +418,18 @@ export default function formatChartData(
 export const toAxisLabel = (key: string): string => {
   if (!key) return "";
 
-  // Extract common unit suffixes and format them as parenthetical
+  // Extract common unit suffixes and format them as parenthetical.
+  // Ordered most-specific first: "_tco2e_per_tonne" must win over "_tonnes",
+  // and the CO₂e family over the bare "_t" / "_mt" patterns.
   const unitPatterns: [RegExp, string][] = [
+    [/(_tco2e_per_tonne)$/i, "tCO₂e/t"],
+    [/(_mgco2e)$/i, "MgCO₂e"],
+    [/(_tco2e)$/i, "tCO₂e"],
+    [/(_co2e)$/i, "CO₂e"],
     [/(_km2|_km²)$/i, "km²"],
     [/(_ha)$/i, "ha"],
-    [/(_mt|_tonnes|_t)$/i, "t"],
+    [/(_mt)$/i, "Mt"],
+    [/(_tonnes|_t)$/i, "t"],
     [/(_pct|_percent|_%|_percentage)$/i, "%"],
   ];
 
@@ -471,9 +482,31 @@ export const formatYAxisLabel = (value: number, key?: string) => {
   }
   if (Number(value)) {
     if (Math.abs(value) < 1000) return value.toLocaleString();
-    if (Math.abs(value) < 1e6) return `${(value / 1e3).toFixed(1)}K`;
-    if (Math.abs(value) < 1e9) return `${(value / 1e6).toFixed(1)}M`;
-    return `${(value / 1e9).toFixed(1)}B`;
+    // Pick the unit from the *rounded* magnitude so 999,950 → "1M", not "1000K"
+    const units: [number, string][] = [
+      [1e9, "B"],
+      [1e6, "M"],
+      [1e3, "K"],
+    ];
+    for (const [divisor, suffix] of units) {
+      const scaled = Math.round((value / divisor) * 10) / 10;
+      if (Math.abs(scaled) >= 1) {
+        return `${scaled.toFixed(1).replace(/\.0$/, "")}${suffix}`;
+      }
+    }
   }
   return value.toString();
+};
+
+/**
+ * Full-precision locale formatting for tooltips: "1234567.891" → "1,234,567.89".
+ * Years and non-numeric values pass through unchanged.
+ */
+export const formatTooltipValue = (value: unknown, key?: string): string => {
+  if (key?.toString().toLowerCase() === "year") return String(value);
+  const num = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(num) || value === "" || value === null) {
+    return String(value);
+  }
+  return num.toLocaleString("en-US", { maximumFractionDigits: 2 });
 };

--- a/app/utils/provenanceRecord.ts
+++ b/app/utils/provenanceRecord.ts
@@ -1,0 +1,77 @@
+import type { CodeActPart } from "@/app/types/chat";
+
+/**
+ * Builds a single self-contained markdown record of how an insight was
+ * generated — narrative, code, and execution output in order, plus sources —
+ * so the provenance can be archived, attached to reports, or audited
+ * outside the app.
+ */
+
+const PART_HEADINGS: Record<CodeActPart["type"], string> = {
+  text_output: "Narrative",
+  code_block: "Code",
+  execution_output: "Execution output",
+};
+
+export interface ProvenanceRecordInput {
+  title?: string;
+  /** Parts with content already base64-decoded. */
+  parts: { type: CodeActPart["type"]; content: string }[];
+  sourceUrls?: string[];
+  /** Injectable for deterministic tests; defaults to now. */
+  exportedAt?: Date;
+}
+
+export function buildProvenanceMarkdown({
+  title,
+  parts,
+  sourceUrls,
+  exportedAt,
+}: ProvenanceRecordInput): string {
+  const lines: string[] = [];
+  const timestamp = (exportedAt ?? new Date()).toISOString();
+
+  lines.push(`# ${title || "Insight generation record"}`);
+  lines.push("");
+  lines.push(
+    `> AI-assisted analysis generation record · exported ${timestamp}`
+  );
+  lines.push(
+    "> AI models may produce incomplete or incorrect information. " +
+      "Verify outputs before using them in your work."
+  );
+
+  parts.forEach((part, index) => {
+    lines.push("");
+    lines.push(`## Step ${index + 1} — ${PART_HEADINGS[part.type]}`);
+    lines.push("");
+    if (part.type === "code_block") {
+      lines.push("```python");
+      lines.push(part.content);
+      lines.push("```");
+    } else if (part.type === "execution_output") {
+      lines.push("```");
+      lines.push(part.content);
+      lines.push("```");
+    } else {
+      lines.push(part.content);
+    }
+  });
+
+  if (sourceUrls && sourceUrls.length > 0) {
+    lines.push("");
+    lines.push("## Sources");
+    lines.push("");
+    sourceUrls.forEach((url, index) => {
+      lines.push(`${index + 1}. ${url}`);
+    });
+  }
+
+  lines.push("");
+  return lines.join("\n");
+}
+
+export function provenanceFilename(title: string | undefined): string {
+  const slug = (title || "insight").replace(/[^a-z0-9]/gi, "_").slice(0, 80);
+  return `${slug}_generation_record.md`;
+}


### PR DESCRIPTION
## Insight audit w/ Fable — fixes, accessibility, and newfeatures

Full audit of the insight/chart components (ChartWidget, TableWidget, WidgetMessage, InsightWorkspace, provenance drawer) against the backend dataset catalog.

### Fixes
- **Negative values were clipped** — y-axis was hard-coded to `[0, auto]`; GHG net-flux sinks now render below a zero
reference line
- **Scatter charts were broken** (pre-existing) — column scoping dropped the name column, leaving every scatter empty
- **Unit labels** — `_mt` → Mt (was "t"); added tCO₂e/MgCO₂e/CO₂e recognition
- **Hydration errors on /chart-debug** — `Math.random()` fixtures now deterministic

### Accessibility
Keyboard-sortable table headers, chart focus rings + aria-label data summaries, `aria-pressed` toggles, aria-live workspace counter, `prefers-reduced-motion` respected throughout.

### New features
- **Fit y-axis** toggle for line/area/scatter (bars stay zero-anchored by design)
- **Download menu**: CSV + chart PNG export (title + legend included)
- **Fullscreen**: side panel with insight narrative, analysis params, dataset
- **Provenance drawer**: step-numbered record + "Save record" Markdown export

<img width="720" height="720" alt="chrome-capture-2026-06-16" src="https://github.com/user-attachments/assets/a554ddf3-815c-47bb-a292-dedf127b510a" />

<img width="800" height="696" alt="Trend_in_Natural_Semi_Natural_Grassland_Extent_in_Mongolia__2000_2022_" src="https://github.com/user-attachments/assets/5c4807b1-aa85-4ab1-aff3-378e2c5b5174" />

### Polish
Entry animations, donut center totals, pie legend percentages, locale-formatted tooltips with humanized series names, right-aligned numeric columns, insight transitions + arrow-key navigation.