### PR TITLE
Placeholder frontend implementation for Sentinel-2 viewing

### DIFF
--- a/app/components/Map.tsx
+++ b/app/components/Map.tsx
@@ -29,8 +29,22 @@ import { Legend } from "@/app/components/legend/Legend";
 import InsightWorkspace from "./InsightWorkspace";
 import DisclaimerPanel from "./DisclaimerPanel";
 import useInsightStore from "@/app/store/insightStore";
+import { API_CONFIG } from "@/app/config/api";
+import { getAuthHeaders } from "@/app/lib/api-client";
 
 const MAPBOX_ACCESS_TOKEN = process.env.NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN;
+
+// Attach the bearer token to map resource requests against the API origin
+// (mosaic tile/tilejson endpoints require auth). MapLibre captures this
+// function at construction, so it must read the token per request — via
+// getAuthHeaders, which hits localStorage — for mid-session token refreshes
+// to be picked up.
+const transformRequest = (url: string) => {
+  if (url.startsWith(API_CONFIG.API_HOST)) {
+    return { url, headers: getAuthHeaders() };
+  }
+  return { url };
+};
 
 function Map({ disableMapAreaControls }: { disableMapAreaControls?: boolean }) {
   const mapRef = useRef<MapRef>(null);
@@ -124,6 +138,7 @@ function Map({ disableMapAreaControls }: { disableMapAreaControls?: boolean }) {
         onLoad={onMapLoad}
         onMove={onMapMove}
         attributionControl={false}
+        transformRequest={transformRequest}
       >
         <Source
           id="background"

--- a/app/components/legend/useLegendHook.tsx
+++ b/app/components/legend/useLegendHook.tsx
@@ -180,12 +180,14 @@ export function useLegendHook() {
         // entry — build a card from the imagery metadata carried on the layer.
         if (layer.imagery) {
           const { imagery } = layer;
-          const params: LegendParam[] = [
-            {
+          const params: LegendParam[] = [];
+          // Acquired date range is absent on cache hits — omit the chip then.
+          if (imagery.date_start && imagery.date_end) {
+            params.push({
               label: "DATES",
               value: `${formatImageryDate(imagery.date_start)} – ${formatImageryDate(imagery.date_end)}`,
-            },
-          ];
+            });
+          }
           // Search constraints: absent on imagery payloads created before
           // these fields existed (replayed old threads) — omit the chips.
           if (imagery.window_days !== undefined) {
@@ -216,7 +218,11 @@ export function useLegendHook() {
             id: layer.id,
             title: layer.name,
             opacity: (layer.opacity ?? 1) * 100,
-            info: `Sentinel-2 true-colour mosaic built from ${imagery.item_count} scene${imagery.item_count === 1 ? "" : "s"} closest to ${formatImageryDate(imagery.target_date)}. Contains modified Copernicus Sentinel data.`,
+            info: `Sentinel-2 true-colour mosaic${
+              imagery.item_count !== undefined
+                ? ` built from ${imagery.item_count} scene${imagery.item_count === 1 ? "" : "s"}`
+                : ""
+            } closest to ${formatImageryDate(imagery.target_date)}. Contains modified Copernicus Sentinel data.`,
             params,
             symbology: null,
             children: mayContainClouds ? (

--- a/app/components/legend/useLegendHook.tsx
+++ b/app/components/legend/useLegendHook.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 import { Text } from "@chakra-ui/react";
+import { format, parseISO } from "date-fns";
 
 import {
   LayerActionHandler,
@@ -54,6 +55,18 @@ function buildParams(
   }
 
   return result;
+}
+
+// Backend default for show_imagery's max_cloud_cover; anything above it
+// means the agent loosened the search and clouds are expected.
+const IMAGERY_DEFAULT_MAX_CLOUD_COVER = 20;
+
+function formatImageryDate(isoDate: string): string {
+  try {
+    return format(parseISO(isoDate), "MMM d, yyyy");
+  } catch {
+    return isoDate;
+  }
 }
 
 function renderLegendSymbology(legend: DatasetLegendConfig) {
@@ -159,6 +172,59 @@ export function useLegendHook() {
             title: layer.selectionName ?? layer.name,
             opacity: (layer.opacity ?? 1) * 100,
             symbology: null,
+          });
+          continue;
+        }
+
+        // Sentinel-2 mosaics from the show_imagery tool have no DATASET_CARDS
+        // entry — build a card from the imagery metadata carried on the layer.
+        if (layer.imagery) {
+          const { imagery } = layer;
+          const params: LegendParam[] = [
+            {
+              label: "DATES",
+              value: `${formatImageryDate(imagery.date_start)} – ${formatImageryDate(imagery.date_end)}`,
+            },
+          ];
+          // Search constraints: absent on imagery payloads created before
+          // these fields existed (replayed old threads) — omit the chips.
+          if (imagery.window_days !== undefined) {
+            params.push({
+              label: "WINDOW",
+              value: `±${imagery.window_days} days`,
+            });
+          }
+          if (imagery.max_cloud_cover !== undefined) {
+            params.push({
+              label: "CLOUD",
+              value: `< ${imagery.max_cloud_cover}%`,
+            });
+          }
+          if (imagery.aoi_names.length > 0) {
+            params.push({
+              label: "AREA",
+              value: imagery.aoi_names.join(", "),
+            });
+          }
+          // Above the default 20% threshold the agent loosened the search,
+          // so partly obscured imagery is expected — flag it so it doesn't
+          // read as a rendering bug.
+          const mayContainClouds =
+            imagery.max_cloud_cover !== undefined &&
+            imagery.max_cloud_cover > IMAGERY_DEFAULT_MAX_CLOUD_COVER;
+          entries.push({
+            id: layer.id,
+            title: layer.name,
+            opacity: (layer.opacity ?? 1) * 100,
+            info: `Sentinel-2 true-colour mosaic built from ${imagery.item_count} scene${imagery.item_count === 1 ? "" : "s"} closest to ${formatImageryDate(imagery.target_date)}. Contains modified Copernicus Sentinel data.`,
+            params,
+            symbology: null,
+            children: mayContainClouds ? (
+              <Text fontSize="xs">
+                Searched with a loosened cloud-cover limit (
+                {imagery.max_cloud_cover}%) — imagery may contain clouds.
+              </Text>
+            ) : undefined,
           });
           continue;
         }

--- a/app/components/map/layers/DynamicTileLayers.tsx
+++ b/app/components/map/layers/DynamicTileLayers.tsx
@@ -22,14 +22,19 @@ function layerId(id: string) {
  */
 function DynamicTileLayers() {
   const allLayers = useMapStore((s) => s.layers);
-  const rasterLayers = useMemo(
-    () =>
-      allLayers.filter(
-        (l): l is ManagedLayer & { tileUrl: string } =>
-          l.type === "raster" && !!l.tileUrl
-      ),
-    [allLayers]
-  );
+  const rasterLayers = useMemo(() => {
+    const rasters = allLayers.filter(
+      (l): l is ManagedLayer & { tileUrl: string } =>
+        l.type === "raster" && !!l.tileUrl
+    );
+    // Imagery mosaics are opaque, basemap-like layers: keep them at the
+    // bottom of the raster stack regardless of insertion order so dataset
+    // and context overlays stay visible above them.
+    return [
+      ...rasters.filter((l) => !l.imagery),
+      ...rasters.filter((l) => l.imagery),
+    ];
+  }, [allLayers]);
 
   return (
     <>
@@ -45,6 +50,21 @@ function DynamicTileLayers() {
           ? layerId(aboveLayer.id)
           : RASTER_TOP_SENTINEL_ID;
 
+        // Optional source tuning (set on imagery layers from their TileJSON).
+        // Spread conditionally so unset keys stay out of the source spec.
+        const sourceOptions = {
+          ...(rasterLayer.minzoom !== undefined
+            ? { minzoom: rasterLayer.minzoom }
+            : {}),
+          ...(rasterLayer.maxzoom !== undefined
+            ? { maxzoom: rasterLayer.maxzoom }
+            : {}),
+          ...(rasterLayer.bounds ? { bounds: rasterLayer.bounds } : {}),
+          ...(rasterLayer.attribution
+            ? { attribution: rasterLayer.attribution }
+            : {}),
+        };
+
         return (
           <Source
             key={rasterLayer.id}
@@ -52,6 +72,7 @@ function DynamicTileLayers() {
             type="raster"
             tiles={[rasterLayer.tileUrl]}
             tileSize={256}
+            {...sourceOptions}
           >
             <Layer
               id={id}

--- a/app/lib/parse-stream-message.ts
+++ b/app/lib/parse-stream-message.ts
@@ -66,6 +66,7 @@ export function parseStreamMessage(
       insight_count: langChainMessage.insight_count || 0,
       aoi: langChainMessage.aoi || undefined,
       aoi_selection: langChainMessage.aoi_selection || undefined,
+      imagery: langChainMessage.imagery || undefined,
       timestamp: timestamp.toISOString(),
       trace_id: traceId,
     };

--- a/app/lib/tool-display.ts
+++ b/app/lib/tool-display.ts
@@ -19,6 +19,10 @@ const TOOL_DISPLAY: Record<string, { active: string; error: string }> = {
     active: "Pulling data",
     error: "Unable to retrieve the data. Please try again.",
   },
+  show_imagery: {
+    active: "Loading satellite imagery",
+    error: "Unable to load satellite imagery. Please try again.",
+  },
 };
 
 const DEFAULT_TOOL_ERROR = "Unable to process this step. Please try again.";

--- a/app/store/chat-tools/showImagery.ts
+++ b/app/store/chat-tools/showImagery.ts
@@ -1,0 +1,104 @@
+import { format, parseISO } from "date-fns";
+import { StreamMessage } from "@/app/types/chat";
+import useMapStore from "../mapStore";
+import { API_CONFIG } from "@/app/config/api";
+import { apiFetch } from "@/app/lib/api-client";
+import { showApiError } from "@/app/hooks/useErrorHandler";
+
+export const IMAGERY_LAYER_ID_PREFIX = "imagery-";
+export const IMAGERY_LAYER_NAME = "Satellite imagery";
+export const IMAGERY_ATTRIBUTION = "Contains modified Copernicus Sentinel data";
+
+interface TileJson {
+  bounds?: [number, number, number, number];
+  minzoom?: number;
+  maxzoom?: number;
+}
+
+function layerName(targetDate: string): string {
+  try {
+    return `${IMAGERY_LAYER_NAME} (${format(parseISO(targetDate), "MMM d, yyyy")})`;
+  } catch {
+    return IMAGERY_LAYER_NAME;
+  }
+}
+
+/**
+ * Handles the show_imagery tool: renders the Sentinel-2 mosaic from the
+ * `imagery` agent-state entry as a raster layer.
+ *
+ * Each run adds its own legend entry — earlier mosaics are kept (the user
+ * removes them via the legend), with the newest one rendered on top of the
+ * imagery stack. Re-running an identical request yields the same mosaic_id
+ * and simply upserts the existing layer.
+ *
+ * The TileJSON is fetched first (authenticated, like all mosaic endpoints)
+ * to get the mosaic's bounds and zoom range. The mosaic_id is an opaque
+ * recipe token, so payloads stay valid indefinitely (the server rebuilds
+ * cold mosaics on demand — budget ~1–2s for this fetch when replaying an
+ * old thread). A 401 means the session expired and is surfaced like any
+ * other API auth error; a 404 is a rare hard error (deleted custom area,
+ * malformed URL, or a pre-auth-change mosaic token) and the layer is simply
+ * not shown.
+ */
+export async function showImageryTool(streamMessage: StreamMessage) {
+  const imagery = streamMessage.imagery;
+  if (!imagery) return;
+
+  const { addLayer, reorderLayers } = useMapStore.getState();
+
+  let tileJson: TileJson;
+  try {
+    const res = await apiFetch(imagery.tilejson_url);
+    if (res.status === 401 || res.status === 403) {
+      showApiError(
+        "Your session has expired. Please sign in again to view satellite imagery.",
+        { title: "Session Expired" }
+      );
+      return;
+    }
+    if (!res.ok) {
+      console.warn(
+        `Imagery mosaic unavailable (HTTP ${res.status}); not showing layer`
+      );
+      return;
+    }
+    tileJson = (await res.json()) as TileJson;
+  } catch (error) {
+    console.error("Failed to load imagery TileJSON:", error);
+    return;
+  }
+
+  const id = `${IMAGERY_LAYER_ID_PREFIX}${imagery.mosaic_id}`;
+
+  addLayer({
+    id,
+    name: layerName(imagery.target_date),
+    type: "raster",
+    visible: true,
+    tileUrl: `${API_CONFIG.API_HOST}${imagery.tile_url}`,
+    minzoom: tileJson.minzoom ?? 8,
+    maxzoom: tileJson.maxzoom ?? 14,
+    bounds: tileJson.bounds,
+    attribution: IMAGERY_ATTRIBUTION,
+    startDate: imagery.date_start,
+    endDate: imagery.date_end,
+    imagery,
+  });
+
+  // addLayer appends, which would leave the new mosaic underneath any
+  // earlier ones it overlaps. Reorder so the newest imagery layer sits at
+  // the top of the imagery group (which itself stays below dataset rasters).
+  const layers = useMapStore.getState().layers;
+  const nonImageryIds = layers
+    .filter((l) => !l.id.startsWith(IMAGERY_LAYER_ID_PREFIX))
+    .map((l) => l.id);
+  const olderImageryIds = layers
+    .filter((l) => l.id.startsWith(IMAGERY_LAYER_ID_PREFIX) && l.id !== id)
+    .map((l) => l.id);
+  reorderLayers([...nonImageryIds, id, ...olderImageryIds]);
+
+  // No camera movement here: the viewport was already positioned by
+  // pick_aoi, and re-fitting to the mosaic bounds would yank the map
+  // away from wherever the user is looking.
+}

--- a/app/store/chat-tools/showImagery.ts
+++ b/app/store/chat-tools/showImagery.ts
@@ -2,7 +2,7 @@ import { format, parseISO } from "date-fns";
 import { StreamMessage } from "@/app/types/chat";
 import useMapStore from "../mapStore";
 import { API_CONFIG } from "@/app/config/api";
-import { apiFetch } from "@/app/lib/api-client";
+import { getAuthHeaders } from "@/app/lib/api-client";
 import { showApiError } from "@/app/hooks/useErrorHandler";
 
 export const IMAGERY_LAYER_ID_PREFIX = "imagery-";
@@ -24,6 +24,19 @@ function layerName(targetDate: string): string {
 }
 
 /**
+ * Fetches a titiler resource. The backend emits absolute titiler URLs whose
+ * host it controls via its own MOSAIC_TILER_URL setting (the Zeno API itself,
+ * or a standalone titiler) — so we consume them as-is rather than rewriting
+ * the origin on the frontend. When the titiler is the Zeno API, its /mosaic
+ * routes require bearer auth, so attach it for requests to the API origin,
+ * mirroring the map's transformRequest. Other titiler hosts are unauthenticated.
+ */
+function fetchTitiler(url: string): Promise<Response> {
+  const headers = url.startsWith(API_CONFIG.API_HOST) ? getAuthHeaders() : {};
+  return fetch(url, { headers });
+}
+
+/**
  * Handles the show_imagery tool: renders the Sentinel-2 mosaic from the
  * `imagery` agent-state entry as a raster layer.
  *
@@ -32,14 +45,15 @@ function layerName(targetDate: string): string {
  * imagery stack. Re-running an identical request yields the same mosaic_id
  * and simply upserts the existing layer.
  *
- * The TileJSON is fetched first (authenticated, like all mosaic endpoints)
- * to get the mosaic's bounds and zoom range. The mosaic_id is an opaque
- * recipe token, so payloads stay valid indefinitely (the server rebuilds
- * cold mosaics on demand — budget ~1–2s for this fetch when replaying an
- * old thread). A 401 means the session expired and is surfaced like any
- * other API auth error; a 404 is a rare hard error (deleted custom area,
- * malformed URL, or a pre-auth-change mosaic token) and the layer is simply
- * not shown.
+ * The backend emits absolute titiler URLs (tile_url / tilejson_url) pointing
+ * at whatever titiler it is configured to use; the frontend consumes them
+ * directly (see fetchTitiler). The TileJSON is fetched first to get the
+ * mosaic's bounds and zoom range. The mosaic_id is an opaque recipe token, so
+ * payloads stay valid indefinitely (the server rebuilds cold mosaics on demand
+ * — budget ~1–2s for this fetch when replaying an old thread). A 401 means the
+ * session expired and is surfaced like any other API auth error; any other
+ * non-ok response is a rare hard error (deleted custom area, malformed URL, or
+ * a mosaic the titiler cannot read) and the layer is simply not shown.
  */
 export async function showImageryTool(streamMessage: StreamMessage) {
   const imagery = streamMessage.imagery;
@@ -49,7 +63,7 @@ export async function showImageryTool(streamMessage: StreamMessage) {
 
   let tileJson: TileJson;
   try {
-    const res = await apiFetch(imagery.tilejson_url);
+    const res = await fetchTitiler(imagery.tilejson_url);
     if (res.status === 401 || res.status === 403) {
       showApiError(
         "Your session has expired. Please sign in again to view satellite imagery.",
@@ -76,7 +90,7 @@ export async function showImageryTool(streamMessage: StreamMessage) {
     name: layerName(imagery.target_date),
     type: "raster",
     visible: true,
-    tileUrl: `${API_CONFIG.API_HOST}${imagery.tile_url}`,
+    tileUrl: imagery.tile_url,
     minzoom: tileJson.minzoom ?? 8,
     maxzoom: tileJson.maxzoom ?? 14,
     bounds: tileJson.bounds,

--- a/app/store/chatStore.ts
+++ b/app/store/chatStore.ts
@@ -361,6 +361,8 @@ const useChatStore = create<ChatState & ChatActions>((set, get) => ({
       query: message,
       query_type: queryType,
       thread_id: threadId,
+      // Hardcoded for this branch; revisit (URL param / store) before merge.
+      ff: "experimental",
     };
 
     // Set up abort controller for client-side timeout

--- a/app/store/chatStore.ts
+++ b/app/store/chatStore.ts
@@ -25,6 +25,7 @@ import { generateInsightsTool } from "./chat-tools/generateInsights";
 import { pickAoiTool } from "./chat-tools/pickAoi";
 import { pickDatasetTool } from "./chat-tools/pickDataset";
 import { pullDataTool } from "./chat-tools/pullData";
+import { showImageryTool } from "./chat-tools/showImagery";
 import { queryClient } from "@/app/lib/query-client";
 import {
   showApiError,
@@ -240,6 +241,12 @@ async function processStreamMessage(
           }
         })
       );
+      return;
+    }
+    // Handling for show_imagery tool: render the Sentinel-2 mosaic on the map
+    else if (streamMessage.name === "show_imagery" && streamMessage.imagery) {
+      // Non-blocking: TileJSON fetch shouldn't stall the stream
+      void Promise.resolve().then(() => showImageryTool(streamMessage));
       return;
     }
     // Handling for pull_data tool

--- a/app/store/layerManagerSlice.ts
+++ b/app/store/layerManagerSlice.ts
@@ -1,6 +1,6 @@
 import { StateCreator } from "zustand";
 import { FeatureCollection, Feature } from "geojson";
-import type { AOISelection } from "@/app/types/chat";
+import type { AOISelection, ImageryInfo } from "@/app/types/chat";
 import type { MapState } from "./mapStore";
 
 export interface FeatureRef {
@@ -35,6 +35,15 @@ export interface Layer {
   endDate?: string;
   // Set on a context-layer sub-layer to mark it as a child of `parentLayerId`
   parentLayerId?: string;
+  // Raster source tuning, derived from the mosaic's TileJSON. Without the
+  // zoom range MapLibre would request tiles outside z8–14 and get 404s
+  // instead of overscaling.
+  minzoom?: number;
+  maxzoom?: number;
+  bounds?: [number, number, number, number];
+  attribution?: string;
+  // Set when added from show_imagery (Sentinel-2 mosaic legend metadata)
+  imagery?: ImageryInfo;
 }
 
 export interface LayerManagerSlice {

--- a/app/types/chat.ts
+++ b/app/types/chat.ts
@@ -133,6 +133,7 @@ export interface StreamMessage {
   suggested_datasets?: SuggestedDataset[];
   aoi?: object;
   aoi_selection?: AOISelection;
+  imagery?: ImageryInfo;
   insights?: object[];
   charts_data?: object[];
   codeact_parts?: CodeActPart[];
@@ -142,6 +143,23 @@ export interface StreamMessage {
   start_date?: string;
   end_date?: string;
   trace_id?: string;
+}
+
+// Sentinel-2 mosaic payload written to agent state by the show_imagery tool.
+// Both URLs are relative to the Zeno API host and require bearer auth.
+export interface ImageryInfo {
+  tile_url: string;
+  tilejson_url: string;
+  mosaic_id: string;
+  item_count: number;
+  date_start: string;
+  date_end: string;
+  target_date: string;
+  aoi_names: string[];
+  // Search constraints used to build the mosaic. Absent on payloads created
+  // before these were introduced (replayed old threads).
+  window_days?: number;
+  max_cloud_cover?: number;
 }
 
 export interface AOI {
@@ -221,6 +239,7 @@ export interface LangChainUpdate {
   suggested_datasets?: SuggestedDataset[];
   aoi?: object;
   aoi_selection?: AOISelection;
+  imagery?: ImageryInfo;
   start_date?: string;
   end_date?: string;
   insights: object[];

--- a/app/types/chat.ts
+++ b/app/types/chat.ts
@@ -95,6 +95,8 @@ export interface ChatPrompt {
   query: string;
   query_type: string;
   thread_id: string;
+  // Feature flag selecting the agent tool profile (admin-gated server-side).
+  ff?: string;
 }
 export interface UiContext {
   aoi_selected?: {
@@ -153,9 +155,11 @@ export interface ImageryInfo {
   tile_url: string;
   tilejson_url: string;
   mosaic_id: string;
-  item_count: number;
-  date_start: string;
-  date_end: string;
+  // Scene count and acquired date range are only known when the mosaic is
+  // built; on a cache hit (mosaic already in S3) the backend omits them.
+  item_count?: number;
+  date_start?: string;
+  date_end?: string;
   target_date: string;
   aoi_names: string[];
   // Search constraints used to build the mosaic. Absent on payloads created

--- a/app/types/chat.ts
+++ b/app/types/chat.ts
@@ -146,7 +146,9 @@ export interface StreamMessage {
 }
 
 // Sentinel-2 mosaic payload written to agent state by the show_imagery tool.
-// Both URLs are relative to the Zeno API host and require bearer auth.
+// tile_url / tilejson_url are absolute URLs to the titiler the backend is
+// configured to use (its MOSAIC_TILER_URL). When that titiler is the Zeno API
+// itself, the /mosaic routes require bearer auth.
 export interface ImageryInfo {
   tile_url: string;
   tilejson_url: string;


### PR DESCRIPTION
This PR is to show how to use the new sentinel-2 endpoint that will be available after the backend feature has been merged, see https://github.com/wri/project-zeno/pull/710

## Render Sentinel-2 imagery layers from the `show_imagery` agent tool
### Summary
The agent's new `show_imagery` tool (project-zeno) builds a Sentinel-2 mosaic
for the current AOI around a target date and writes an `imagery` entry into
agent state. This PR makes the frontend render that entry as a raster map
layer, both when it arrives on the live chat stream and when a thread is
replayed.
### How it works
- `imagery` is parsed off tool updates in the chat stream (same path as
  `dataset` / `aoi_selection`) and dispatched to a new `showImageryTool`
  handler, for live chat and thread replay alike.
- The handler fetches the mosaic's TileJSON (authenticated) to get bounds and
  the native zoom range (z8–14), then adds a raster layer via the existing
  layer manager. The zoom range and bounds are set on the source so MapLibre
  overscales beyond z14 and clips requests outside the mosaic instead of
  requesting empty tiles.
- Mosaic ids are opaque recipe tokens: payloads stay valid indefinitely and
  the server rebuilds cold mosaics on demand (first TileJSON/tile load may
  take ~1–2 s). A 404 means the underlying custom area was deleted or the URL
  is malformed — the layer is not shown.
### Layer behaviour
- Each `show_imagery` run adds its own layer and legend entry; earlier
  mosaics are kept so different dates can be compared, and are removed via
  the legend. Re-running an identical request returns the same mosaic id and
  upserts the existing layer instead of duplicating it.
- The newest mosaic renders on top of the imagery group, and the whole group
  stays pinned below dataset/context rasters so analytical overlays remain
  visible. AOI outlines render above all rasters as before.
- Adding imagery does not move the camera; the viewport stays wherever
  `pick_aoi` (or the user) left it.
### Legend
Imagery layers get a card titled with the target date (e.g. "Satellite
imagery (Jun 1, 2025)") showing:
- DATES chip — acquisition range of the scenes actually used
- WINDOW / CLOUD chips — the search constraints (`±N days`, `< N% cloud`),
  omitted for payloads created before these fields existed
- AREA chip — AOI names covered by the mosaic
- a "may contain clouds" note when the cloud-cover limit was loosened above
  the default 20%, so partly obscured imagery doesn't read as a rendering bug
- an info popover with scene count, target date, and Copernicus attribution
Opacity and remove controls work like any other layer.
### Auth
The `/mosaic/*` endpoints require the same bearer token as the rest of the
API:
- The map now sets a `transformRequest` that attaches the `Authorization`
  header to any map resource request against the API origin. The token is
  read per request, so a token refreshed mid-session applies to subsequent
  tile loads.
- The TileJSON fetch goes through `apiFetch` (standard auth headers); a
  401/403 surfaces the usual session-expired toast rather than silently
  hiding the layer.
### Changes
- `app/types/chat.ts` — `ImageryInfo` type; `imagery` key on
  `LangChainUpdate` and `StreamMessage`
- `app/lib/parse-stream-message.ts` — extract `imagery` from tool updates
- `app/store/chat-tools/showImagery.ts` — new tool handler
- `app/store/chatStore.ts` — dispatch `show_imagery`
- `app/lib/tool-display.ts` — reasoning-timeline / error labels
- `app/store/layerManagerSlice.ts` — optional `minzoom` / `maxzoom` /
  `bounds` / `attribution` / `imagery` fields on `Layer`
- `app/components/map/layers/DynamicTileLayers.tsx` — pass source options
  through; pin imagery below other rasters
- `app/components/legend/useLegendHook.tsx` — imagery legend card
- `app/components/Map.tsx` — `transformRequest` with bearer auth