### PR TITLE
PZB-942: fix api.mapbox rendering at 1x

### DIFF
--- a/app/components/Map.tsx
+++ b/app/components/Map.tsx
@@ -32,6 +32,7 @@ import { Legend } from "@/app/components/legend/Legend";
 import InsightWorkspace from "./InsightWorkspace";
 import DisclaimerPanel from "./DisclaimerPanel";
 import useInsightStore from "@/app/store/insightStore";
+import { buildBasemapTileUrl } from "@/app/utils/basemapTileUrl";
 
 const MAPBOX_ACCESS_TOKEN = process.env.NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN;
 
@@ -134,7 +135,11 @@ function Map({ disableMapAreaControls }: { disableMapAreaControls?: boolean }) {
           id="background"
           type="raster"
           tiles={[
-            `https://api.mapbox.com/styles/v1/${basemapTiles}/tiles/{z}/{x}/{y}?access_token=${MAPBOX_ACCESS_TOKEN}`,
+            buildBasemapTileUrl(
+              basemapTiles,
+              MAPBOX_ACCESS_TOKEN,
+              typeof window === "undefined" ? 1 : window.devicePixelRatio
+            ),
           ]}
         >
           <Layer id="background-tiles" type="raster" />

--- a/app/utils/__tests__/basemapTileUrl.test.ts
+++ b/app/utils/__tests__/basemapTileUrl.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "vitest";
+import { buildBasemapTileUrl } from "../basemapTileUrl";
+
+describe("buildBasemapTileUrl", () => {
+  it("builds a 1x tile URL when pixel ratio is 1", () => {
+    expect(buildBasemapTileUrl("devseed/abc123", "token", 1)).toBe(
+      "https://api.mapbox.com/styles/v1/devseed/abc123/tiles/{z}/{x}/{y}?access_token=token"
+    );
+  });
+
+  it("requests @2x tiles when pixel ratio is greater than 1", () => {
+    expect(buildBasemapTileUrl("devseed/abc123", "token", 2)).toBe(
+      "https://api.mapbox.com/styles/v1/devseed/abc123/tiles/{z}/{x}/{y}@2x?access_token=token"
+    );
+  });
+
+  it("requests @2x tiles for fractional pixel ratios above 1", () => {
+    expect(buildBasemapTileUrl("devseed/abc123", "token", 1.5)).toContain(
+      "{z}/{x}/{y}@2x?"
+    );
+  });
+});

--- a/app/utils/__tests__/basemapTileUrl.test.ts
+++ b/app/utils/__tests__/basemapTileUrl.test.ts
@@ -19,4 +19,16 @@ describe("buildBasemapTileUrl", () => {
       "{z}/{x}/{y}@2x?"
     );
   });
+
+  it("omits the access_token query param when no token is provided", () => {
+    expect(buildBasemapTileUrl("devseed/abc123", undefined, 1)).toBe(
+      "https://api.mapbox.com/styles/v1/devseed/abc123/tiles/{z}/{x}/{y}"
+    );
+  });
+
+  it("URL-encodes the access token", () => {
+    expect(buildBasemapTileUrl("devseed/abc123", "a b&c", 1)).toBe(
+      "https://api.mapbox.com/styles/v1/devseed/abc123/tiles/{z}/{x}/{y}?access_token=a%20b%26c"
+    );
+  });
 });

--- a/app/utils/basemapTileUrl.ts
+++ b/app/utils/basemapTileUrl.ts
@@ -1,0 +1,11 @@
+/**
+ * Builds a Mapbox Static Tiles API URL template for a MapLibre raster source.
+ */
+export function buildBasemapTileUrl(
+  stylePath: string,
+  accessToken: string | undefined,
+  pixelRatio: number
+): string {
+  const scale = pixelRatio > 1 ? "@2x" : "";
+  return `https://api.mapbox.com/styles/v1/${stylePath}/tiles/{z}/{x}/{y}${scale}?access_token=${accessToken}`;
+}

--- a/app/utils/basemapTileUrl.ts
+++ b/app/utils/basemapTileUrl.ts
@@ -7,5 +7,8 @@ export function buildBasemapTileUrl(
   pixelRatio: number
 ): string {
   const scale = pixelRatio > 1 ? "@2x" : "";
-  return `https://api.mapbox.com/styles/v1/${stylePath}/tiles/{z}/{x}/{y}${scale}?access_token=${accessToken}`;
+  const base = `https://api.mapbox.com/styles/v1/${stylePath}/tiles/{z}/{x}/{y}${scale}`;
+  return accessToken
+    ? `${base}?access_token=${encodeURIComponent(accessToken)}`
+    : base;
 }


### PR DESCRIPTION
## Pull request type
- [x] Bugfix

## What is the current behavior?

The basemap tiles are fetched from the Mapbox Static Tiles API without an @2x suffix, causing them to be rasterized at 512×512px. On HiDPI/Retina displays (devicePixelRatio > 1), each pixel is stretched across 4 device pixels, making the basemap appear blurry compared to the Mapbox Studio style preview.

## What is the new behavior?

The tile URL is now built via buildBasemapTileUrl(), which appends @2x to the tile path when window.devicePixelRatio > 1. On Retina displays, Mapbox serves 1024×1024px tiles that render at full device resolution, matching the sharpness of the Studio preview. On 1x displays the behaviour is unchanged.

## Does this introduce a breaking change?

- [x] No

## Demo
<img width="1509" height="656" alt="Screenshot 2026-06-15 at 20 50 23" src="https://github.com/user-attachments/assets/67339458-47a6-4b20-838e-550f55197697" />
