### PR TITLE
fix(charts): correct unit labels, scatter fix, deterministic chart-debug fixtures

### DIFF
--- a/app/chart-debug/ChartDebugPanel.tsx
+++ b/app/chart-debug/ChartDebugPanel.tsx
@@ -268,12 +268,17 @@ const DRIVER_PIE = [
   { driver: "Unknown", area_ha: 180000 },
 ];
 
+// Deterministic pseudo-random so SSR and client render the same fixture
+// values (Math.random() here caused hydration mismatches).
+const pseudoRandom = (i: number, salt: number) =>
+  ((i * 9301 + salt * 49297) % 233280) / 233280;
+
 // Large table for pagination testing
 const LARGE_TABLE_DATA = Array.from({ length: 50 }, (_, i) => ({
   rank: i + 1,
   province: `Province ${String.fromCharCode(65 + (i % 26))}${i >= 26 ? "2" : ""}`,
-  area_ha: Math.round(50000 - i * 800 + Math.random() * 200),
-  change_pct: +(-2 - Math.random() * 8).toFixed(1),
+  area_ha: Math.round(50000 - i * 800 + pseudoRandom(i, 1) * 200),
+  change_pct: +(-2 - pseudoRandom(i, 2) * 8).toFixed(1),
 }));
 
 // Multi-series line for dash-pattern testing
@@ -306,14 +311,28 @@ const WIDE_TABLE_DATA = Array.from({ length: 12 }, (_, i) => ({
     "Paraguay",
     "Mexico",
   ][i],
-  tree_loss_2018_ha: Math.round(4000000 - i * 350000 + Math.random() * 50000),
-  tree_loss_2019_ha: Math.round(3800000 - i * 320000 + Math.random() * 50000),
-  tree_loss_2020_ha: Math.round(3600000 - i * 300000 + Math.random() * 50000),
-  tree_loss_2021_ha: Math.round(3400000 - i * 280000 + Math.random() * 50000),
-  tree_loss_2022_ha: Math.round(3200000 - i * 260000 + Math.random() * 50000),
-  tree_loss_2023_ha: Math.round(3000000 - i * 240000 + Math.random() * 50000),
-  primary_loss_ha: Math.round(1500000 - i * 120000 + Math.random() * 30000),
-  pct_global: +(25 - i * 2.2 + Math.random()).toFixed(1),
+  tree_loss_2018_ha: Math.round(
+    4000000 - i * 350000 + pseudoRandom(i, 3) * 50000
+  ),
+  tree_loss_2019_ha: Math.round(
+    3800000 - i * 320000 + pseudoRandom(i, 4) * 50000
+  ),
+  tree_loss_2020_ha: Math.round(
+    3600000 - i * 300000 + pseudoRandom(i, 5) * 50000
+  ),
+  tree_loss_2021_ha: Math.round(
+    3400000 - i * 280000 + pseudoRandom(i, 6) * 50000
+  ),
+  tree_loss_2022_ha: Math.round(
+    3200000 - i * 260000 + pseudoRandom(i, 7) * 50000
+  ),
+  tree_loss_2023_ha: Math.round(
+    3000000 - i * 240000 + pseudoRandom(i, 8) * 50000
+  ),
+  primary_loss_ha: Math.round(
+    1500000 - i * 120000 + pseudoRandom(i, 9) * 30000
+  ),
+  pct_global: +(25 - i * 2.2 + pseudoRandom(i, 10)).toFixed(1),
 }));
 
 // Long category names for label testing
@@ -1028,8 +1047,7 @@ export default function ChartDebugPanel() {
 
         <Separator my={8} />
         <Text fontSize="xs" color="fg.subtle" textAlign="center">
-          {FIXTURES.length} fixtures · showing {filtered.length} · rendered at{" "}
-          {new Date().toLocaleTimeString()}
+          {FIXTURES.length} fixtures · showing {filtered.length}
         </Text>
       </Container>
     </Box>

--- a/app/store/chat-tools/generateInsights.ts
+++ b/app/store/chat-tools/generateInsights.ts
@@ -113,8 +113,6 @@ export function generateInsightsTool(
         };
       });
 
-      console.log("FRONTEND: Received charts_data message:", widgets);
-
       useInsightStore.getState().addInsights(widgets);
     }
   } catch (error) {

--- a/app/utils/__tests__/formatCharts.test.ts
+++ b/app/utils/__tests__/formatCharts.test.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect } from "vitest";
+import formatChartData, {
+  toAxisLabel,
+  formatYAxisLabel,
+  formatXAxisLabel,
+  formatTooltipValue,
+} from "../formatCharts";
+
+describe("toAxisLabel", () => {
+  it("extracts area unit suffixes", () => {
+    expect(toAxisLabel("area_km2")).toBe("Area (km²)");
+    expect(toAxisLabel("tree_cover_loss_ha")).toBe("Tree cover loss (ha)");
+  });
+
+  it("recognises CO₂e unit suffixes used by the GHG datasets", () => {
+    expect(toAxisLabel("net_flux_tCO2e")).toBe("Net flux (tCO₂e)");
+    expect(toAxisLabel("emissions_tco2e")).toBe("Emissions (tCO₂e)");
+    expect(toAxisLabel("emissions_mgco2e")).toBe("Emissions (MgCO₂e)");
+    expect(toAxisLabel("emission_factor_tco2e_per_tonne")).toBe(
+      "Emission factor (tCO₂e/t)"
+    );
+  });
+
+  it("maps _mt to megatonnes, not tonnes", () => {
+    expect(toAxisLabel("carbon_emissions_mt")).toBe("Carbon emissions (Mt)");
+  });
+
+  it("still maps plain tonne suffixes to t", () => {
+    expect(toAxisLabel("production_tonnes")).toBe("Production (t)");
+    expect(toAxisLabel("weight_t")).toBe("Weight (t)");
+  });
+
+  it("extracts percentage suffixes", () => {
+    expect(toAxisLabel("pct_of_total")).toBe("Pct of total");
+    expect(toAxisLabel("change_pct")).toBe("Change (%)");
+  });
+
+  it("humanises snake_case and camelCase without units", () => {
+    expect(toAxisLabel("land_cover_type")).toBe("Land cover type");
+    expect(toAxisLabel("gdpPerCapita")).toBe("Gdp per capita");
+  });
+
+  it("returns empty string for empty input", () => {
+    expect(toAxisLabel("")).toBe("");
+  });
+});
+
+describe("formatYAxisLabel", () => {
+  it("passes years through unchanged", () => {
+    expect(formatYAxisLabel(2023, "year")).toBe("2023");
+  });
+
+  it("returns 0 for zero", () => {
+    expect(formatYAxisLabel(0)).toBe("0");
+  });
+
+  it("keeps small values locale-formatted", () => {
+    expect(formatYAxisLabel(999)).toBe("999");
+    expect(formatYAxisLabel(-450)).toBe("-450");
+  });
+
+  it("compacts thousands/millions/billions and strips trailing .0", () => {
+    expect(formatYAxisLabel(1500)).toBe("1.5K");
+    expect(formatYAxisLabel(2000)).toBe("2K");
+    expect(formatYAxisLabel(4_510_000)).toBe("4.5M");
+    expect(formatYAxisLabel(3_000_000_000)).toBe("3B");
+  });
+
+  it("promotes to the next unit when rounding crosses it", () => {
+    expect(formatYAxisLabel(999_950)).toBe("1M");
+  });
+
+  it("formats negative magnitudes", () => {
+    expect(formatYAxisLabel(-45_000)).toBe("-45K");
+    expect(formatYAxisLabel(-2_500_000)).toBe("-2.5M");
+  });
+});
+
+describe("formatXAxisLabel", () => {
+  it("passes years through unchanged", () => {
+    expect(formatXAxisLabel(2023, "year")).toBe("2023");
+  });
+
+  it("truncates long category labels", () => {
+    expect(formatXAxisLabel("Tropical moist broadleaf forests")).toBe(
+      "Tropical moi…"
+    );
+  });
+
+  it("keeps short labels intact", () => {
+    expect(formatXAxisLabel("Brazil")).toBe("Brazil");
+  });
+});
+
+describe("formatTooltipValue", () => {
+  it("formats numbers with locale separators and 2dp max", () => {
+    expect(formatTooltipValue(4812000)).toBe("4,812,000");
+    expect(formatTooltipValue(1234567.891)).toBe("1,234,567.89");
+  });
+
+  it("passes years through unchanged", () => {
+    expect(formatTooltipValue(2023, "year")).toBe("2023");
+  });
+
+  it("parses numeric strings", () => {
+    expect(formatTooltipValue("4500")).toBe("4,500");
+  });
+
+  it("returns non-numeric values as-is", () => {
+    expect(formatTooltipValue("Brazil")).toBe("Brazil");
+    expect(formatTooltipValue("")).toBe("");
+  });
+});
+
+describe("formatChartData", () => {
+  it("returns empty result for empty or invalid data", () => {
+    expect(formatChartData([], "bar", "x", "y")).toEqual({
+      data: [],
+      series: [],
+    });
+    expect(formatChartData(null, "bar", "x", "y")).toEqual({
+      data: [],
+      series: [],
+    });
+  });
+
+  it("builds a single series for a simple bar chart", () => {
+    const data = [
+      { country: "Brazil", area_ha: 100 },
+      { country: "Peru", area_ha: 50 },
+    ];
+    const result = formatChartData(data, "bar", "country", "area_ha");
+    expect(result.series).toHaveLength(1);
+    expect(result.series[0].name).toBe("area_ha");
+    expect(result.data).toHaveLength(2);
+  });
+
+  it("preserves negative values for divergent datasets", () => {
+    const data = [
+      { country: "Brazil", net_flux_tCO2e: -450 },
+      { country: "Indonesia", net_flux_tCO2e: 320 },
+    ];
+    const result = formatChartData(
+      data,
+      "bar",
+      "country",
+      "net_flux_tCO2e",
+      "Forest greenhouse gas net flux (2001-2024)"
+    );
+    expect(result.data[0].net_flux_tCO2e).toBe(-450);
+    // Per-bar colors assigned by sign
+    expect(result.data[0]._barColor).not.toBe(result.data[1]._barColor);
+  });
+
+  it("creates one series per metric column for multi-series line charts", () => {
+    const data = [
+      { year: 2020, Brazil: 100, Peru: 50 },
+      { year: 2021, Brazil: 90, Peru: 60 },
+    ];
+    const result = formatChartData(data, "line", "year");
+    expect(result.series.map((s) => s.name)).toEqual(["Brazil", "Peru"]);
+  });
+
+  it("pivots long-format data for grouped bars", () => {
+    const data = [
+      { region: "A", year: "2020", area_km2: 10 },
+      { region: "A", year: "2021", area_km2: 12 },
+      { region: "B", year: "2020", area_km2: 8 },
+      { region: "B", year: "2021", area_km2: 9 },
+    ];
+    const result = formatChartData(data, "grouped-bar", "region", "area_km2");
+    expect(result.series.map((s) => s.name)).toEqual(["2020", "2021"]);
+    expect(result.data).toHaveLength(2);
+    expect(result.data[0]).toMatchObject({ region: "A", 2020: 10, 2021: 12 });
+  });
+
+  it("keeps the name column for scatter charts (regression)", () => {
+    const data = [
+      { country: "Brazil", gdp_per_capita: 8900, deforestation_ha: 4812000 },
+      { country: "Peru", gdp_per_capita: 6700, deforestation_ha: 310000 },
+    ];
+    const result = formatChartData(
+      data,
+      "scatter",
+      "gdp_per_capita",
+      "deforestation_ha"
+    );
+    expect(result.data).toHaveLength(2);
+    expect(result.data[0].name).toBe("Brazil");
+  });
+
+  it("assigns domain colors to known pie categories", () => {
+    const data = [
+      { driver: "Logging", area_ha: 100 },
+      { driver: "Wildfire", area_ha: 50 },
+    ];
+    const result = formatChartData(data, "pie", "driver", "area_ha");
+    const logging = result.series.find((s) => s.name === "Logging");
+    expect(logging?.color).toBe("#52A44E");
+  });
+});

--- a/app/utils/formatCharts.tsx
+++ b/app/utils/formatCharts.tsx
@@ -146,8 +146,12 @@ export default function formatChartData(
 
   const xAxisKey = xAxis || keys[0]; //identify dataset
   const valueKeys = resolveValueKeys(keys, xAxisKey, yAxis, seriesFields);
+  // Scatter needs a third (name/label) column beyond x and y, so scoping to
+  // [xAxis, yAxis] would discard it and leave the chart unable to render.
   const shouldScopeColumns =
-    Boolean(seriesFields?.length) || (Boolean(yAxis) && type !== "grouped-bar");
+    type !== "scatter" &&
+    (Boolean(seriesFields?.length) ||
+      (Boolean(yAxis) && type !== "grouped-bar"));
   const scopedData = shouldScopeColumns
     ? filterChartDataColumns(data, [xAxisKey, ...valueKeys])
     : data;
@@ -414,11 +418,18 @@ export default function formatChartData(
 export const toAxisLabel = (key: string): string => {
   if (!key) return "";
 
-  // Extract common unit suffixes and format them as parenthetical
+  // Extract common unit suffixes and format them as parenthetical.
+  // Ordered most-specific first: "_tco2e_per_tonne" must win over "_tonnes",
+  // and the CO₂e family over the bare "_t" / "_mt" patterns.
   const unitPatterns: [RegExp, string][] = [
+    [/(_tco2e_per_tonne)$/i, "tCO₂e/t"],
+    [/(_mgco2e)$/i, "MgCO₂e"],
+    [/(_tco2e)$/i, "tCO₂e"],
+    [/(_co2e)$/i, "CO₂e"],
     [/(_km2|_km²)$/i, "km²"],
     [/(_ha)$/i, "ha"],
-    [/(_mt|_tonnes|_t)$/i, "t"],
+    [/(_mt)$/i, "Mt"],
+    [/(_tonnes|_t)$/i, "t"],
     [/(_pct|_percent|_%|_percentage)$/i, "%"],
   ];
 
@@ -471,9 +482,31 @@ export const formatYAxisLabel = (value: number, key?: string) => {
   }
   if (Number(value)) {
     if (Math.abs(value) < 1000) return value.toLocaleString();
-    if (Math.abs(value) < 1e6) return `${(value / 1e3).toFixed(1)}K`;
-    if (Math.abs(value) < 1e9) return `${(value / 1e6).toFixed(1)}M`;
-    return `${(value / 1e9).toFixed(1)}B`;
+    // Pick the unit from the *rounded* magnitude so 999,950 → "1M", not "1000K"
+    const units: [number, string][] = [
+      [1e9, "B"],
+      [1e6, "M"],
+      [1e3, "K"],
+    ];
+    for (const [divisor, suffix] of units) {
+      const scaled = Math.round((value / divisor) * 10) / 10;
+      if (Math.abs(scaled) >= 1) {
+        return `${scaled.toFixed(1).replace(/\.0$/, "")}${suffix}`;
+      }
+    }
   }
   return value.toString();
+};
+
+/**
+ * Full-precision locale formatting for tooltips: "1234567.891" → "1,234,567.89".
+ * Years and non-numeric values pass through unchanged.
+ */
+export const formatTooltipValue = (value: unknown, key?: string): string => {
+  if (key?.toString().toLowerCase() === "year") return String(value);
+  const num = typeof value === "number" ? value : Number(value);
+  if (!Number.isFinite(num) || value === "" || value === null) {
+    return String(value);
+  }
+  return num.toLocaleString("en-US", { maximumFractionDigits: 2 });
 };


### PR DESCRIPTION
Part 1 of 6 — split from #537. Bug fixes only, no new features. Safe to merge first.

## Changes

**`formatCharts.tsx` + tests**
- Recognise `tCO₂e`/`MgCO₂e`/`CO₂e` unit suffixes (GHG datasets were rendering as e.g. "Net flux t co2e")
- Map `_mt` → Mt instead of t
- Compact y-axis labels strip trailing `.0` and promote across units when rounding crosses them (999,950 → 1M, not 1000.0K)
- `formatTooltipValue` for full-precision locale tooltip values
- Fix scatter chart "No data available" — column scoping was dropping the name column
- Unit tests covering labels, formatting, and chart data shaping

**`chart-debug/ChartDebugPanel.tsx`**
- Replace `Math.random()` fixtures with index-seeded pseudo-random values — SSR and client now render identical markup (fixes hydration mismatch on `/chart-debug`)
- Drop render-time timestamp from footer for the same reason

**`generateInsights.ts`**
- Remove stray `console.log`

## Merge order
**Batch 1 (independent):** this PR · #B-table-widget · #F-provenance  
**Batch 2:** #C-chart-widget (depends on this)  
**Batch 3:** #D-widget-message · #E-insight-workspace (both depend on C)