### PR TITLE
feat(provenance): audit-oriented generation record in the provenance drawer

### DIFF
--- a/app/components/InsightProvenanceDrawer.tsx
+++ b/app/components/InsightProvenanceDrawer.tsx
@@ -28,6 +28,10 @@ import { Prism as SyntaxHighlighter } from "react-syntax-highlighter";
 import { vs } from "react-syntax-highlighter/dist/esm/styles/prism";
 import { fetchExternalData } from "@/app/actions/fetch-data";
 import { Tooltip } from "@/app/components/ui/tooltip";
+import {
+  buildProvenanceMarkdown,
+  provenanceFilename,
+} from "@/app/utils/provenanceRecord";
 import JSZip from "jszip";
 import Image from "next/image";
 
@@ -117,7 +121,7 @@ function extractDataUrls(code: string): string[] {
 
 // --- Components ---
 
-function CodeBlockViewer({ code }: { code: string }) {
+function CodeBlockViewer({ code, step }: { code: string; step?: number }) {
   const { copy, copied } = useClipboard({ value: code });
   const [downloading, setDownloading] = useState(false);
 
@@ -174,6 +178,11 @@ function CodeBlockViewer({ code }: { code: string }) {
           <Image src="/python-logo.svg" alt="Python" width={14} height={14} />
           <Text fontSize="xs" color="neutral.600">
             Code
+            {step !== undefined && (
+              <Text as="span" color="neutral.500" fontFamily="mono" ml={1}>
+                · step {step}
+              </Text>
+            )}
           </Text>
         </Flex>
         <Flex gap={2}>
@@ -230,6 +239,21 @@ export default function InsightProvenanceDrawer({
 }: InsightProvenanceDrawerProps) {
   const parts = generation?.codeact_parts || [];
 
+  const handleDownloadRecord = () => {
+    const markdown = buildProvenanceMarkdown({
+      title,
+      parts: parts.map((part) => ({
+        type: part.type,
+        content: safeBase64Decode(part.content),
+      })),
+      sourceUrls: generation?.source_urls,
+    });
+    const blob = new Blob([markdown], {
+      type: "text/markdown;charset=utf-8;",
+    });
+    triggerDownload(blob, provenanceFilename(title));
+  };
+
   return (
     <Drawer.Root
       open={isOpen}
@@ -248,23 +272,55 @@ export default function InsightProvenanceDrawer({
               pt={5}
               pb={3}
             >
-              <Heading size="sm" m={0} maxW="calc(100% - 80px)">
-                {title ? `${title}` : "How this was generated"}
-              </Heading>
-              <Drawer.CloseTrigger asChild>
-                <Button
-                  size="xs"
-                  variant="outline"
-                  color="neutral.600"
-                  borderColor="neutral.300"
-                  bg="white"
-                  h={6}
-                  rounded="sm"
+              <Box maxW="calc(100% - 160px)">
+                <Heading size="sm" m={0}>
+                  {title ? `${title}` : "How this was generated"}
+                </Heading>
+                <Text
+                  fontSize="10px"
+                  fontFamily="mono"
+                  letterSpacing="0.03em"
+                  color="neutral.500"
+                  mt={1}
                 >
-                  <X />
-                  Close
-                </Button>
-              </Drawer.CloseTrigger>
+                  GENERATION RECORD · AI-ASSISTED ANALYSIS
+                </Text>
+              </Box>
+              <Flex gap={2}>
+                {parts.length > 0 && (
+                  <Tooltip content="Download this record as Markdown for archiving or audit">
+                    <Button
+                      size="xs"
+                      variant="outline"
+                      color="neutral.600"
+                      borderColor="neutral.300"
+                      bg="white"
+                      h={6}
+                      rounded="sm"
+                      onClick={handleDownloadRecord}
+                    >
+                      <DownloadSimple />
+                      Save record
+                    </Button>
+                  </Tooltip>
+                )}
+                {/* position=static overrides the drawer recipe's absolute
+                    top-right placement so Close sits inline next to Save */}
+                <Drawer.CloseTrigger asChild position="static">
+                  <Button
+                    size="xs"
+                    variant="outline"
+                    color="neutral.600"
+                    borderColor="neutral.300"
+                    bg="white"
+                    h={6}
+                    rounded="sm"
+                  >
+                    <X />
+                    Close
+                  </Button>
+                </Drawer.CloseTrigger>
+              </Flex>
             </Drawer.Header>
             <Drawer.Body bg="neutral.200" pt={0}>
               {parts.length === 0 ? (
@@ -341,7 +397,7 @@ export default function InsightProvenanceDrawer({
                             </Box>
                           )}
                           {part.type === "code_block" && (
-                            <CodeBlockViewer code={content} />
+                            <CodeBlockViewer code={content} step={i + 1} />
                           )}
                           {part.type === "execution_output" && (
                             <Box
@@ -363,6 +419,14 @@ export default function InsightProvenanceDrawer({
                                   <Terminal size={14} />
                                   <Text fontSize="xs" color="neutral.600">
                                     Execution output
+                                    <Text
+                                      as="span"
+                                      color="neutral.500"
+                                      fontFamily="mono"
+                                      ml={1}
+                                    >
+                                      · step {i + 1}
+                                    </Text>
                                   </Text>
                                 </Flex>
                                 <Flex gap={2}>
@@ -407,18 +471,28 @@ export default function InsightProvenanceDrawer({
                         <Heading size="xs" mb={2}>
                           Sources
                         </Heading>
-                        <Flex direction="column" gap={1}>
+                        <Flex direction="column" gap={1} as="ol" pl={0} m={0}>
                           {generation.source_urls.map((url, idx) => (
-                            <Link
-                              key={idx}
-                              fontSize="xs"
-                              color="blue.600"
-                              href={url}
-                              target="_blank"
-                              rel="noopener noreferrer"
-                            >
-                              {url}
-                            </Link>
+                            <Flex as="li" key={idx} gap={2} align="baseline">
+                              <Text
+                                fontSize="xs"
+                                fontFamily="mono"
+                                color="neutral.500"
+                                flexShrink={0}
+                              >
+                                {idx + 1}.
+                              </Text>
+                              <Link
+                                fontSize="xs"
+                                color="blue.600"
+                                href={url}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                wordBreak="break-all"
+                              >
+                                {url}
+                              </Link>
+                            </Flex>
                           ))}
                         </Flex>
                       </Box>

--- a/app/utils/__tests__/provenanceRecord.test.ts
+++ b/app/utils/__tests__/provenanceRecord.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildProvenanceMarkdown,
+  provenanceFilename,
+} from "../provenanceRecord";
+
+const EXPORTED_AT = new Date("2026-06-12T10:00:00.000Z");
+
+describe("buildProvenanceMarkdown", () => {
+  it("builds an ordered record with narrative, code, and output steps", () => {
+    const md = buildProvenanceMarkdown({
+      title: "Tree cover loss in Brazil",
+      parts: [
+        { type: "text_output", content: "We query the dataset." },
+        { type: "code_block", content: "print('hi')" },
+        { type: "execution_output", content: "hi" },
+      ],
+      sourceUrls: ["https://example.org/data"],
+      exportedAt: EXPORTED_AT,
+    });
+
+    expect(md).toContain("# Tree cover loss in Brazil");
+    expect(md).toContain("exported 2026-06-12T10:00:00.000Z");
+    expect(md).toContain("## Step 1 — Narrative");
+    expect(md).toContain("## Step 2 — Code");
+    expect(md).toContain("```python\nprint('hi')\n```");
+    expect(md).toContain("## Step 3 — Execution output");
+    expect(md).toContain("## Sources");
+    expect(md).toContain("1. https://example.org/data");
+  });
+
+  it("omits the sources section when there are none", () => {
+    const md = buildProvenanceMarkdown({
+      title: "T",
+      parts: [{ type: "text_output", content: "x" }],
+      exportedAt: EXPORTED_AT,
+    });
+    expect(md).not.toContain("## Sources");
+  });
+
+  it("falls back to a generic title", () => {
+    const md = buildProvenanceMarkdown({
+      parts: [],
+      exportedAt: EXPORTED_AT,
+    });
+    expect(md).toContain("# Insight generation record");
+  });
+});
+
+describe("provenanceFilename", () => {
+  it("slugs the title", () => {
+    expect(provenanceFilename("Tree cover loss (2023)")).toBe(
+      "Tree_cover_loss__2023__generation_record.md"
+    );
+  });
+
+  it("handles missing titles", () => {
+    expect(provenanceFilename(undefined)).toBe("insight_generation_record.md");
+  });
+});

--- a/app/utils/provenanceRecord.ts
+++ b/app/utils/provenanceRecord.ts
@@ -1,0 +1,77 @@
+import type { CodeActPart } from "@/app/types/chat";
+
+/**
+ * Builds a single self-contained markdown record of how an insight was
+ * generated — narrative, code, and execution output in order, plus sources —
+ * so the provenance can be archived, attached to reports, or audited
+ * outside the app.
+ */
+
+const PART_HEADINGS: Record<CodeActPart["type"], string> = {
+  text_output: "Narrative",
+  code_block: "Code",
+  execution_output: "Execution output",
+};
+
+export interface ProvenanceRecordInput {
+  title?: string;
+  /** Parts with content already base64-decoded. */
+  parts: { type: CodeActPart["type"]; content: string }[];
+  sourceUrls?: string[];
+  /** Injectable for deterministic tests; defaults to now. */
+  exportedAt?: Date;
+}
+
+export function buildProvenanceMarkdown({
+  title,
+  parts,
+  sourceUrls,
+  exportedAt,
+}: ProvenanceRecordInput): string {
+  const lines: string[] = [];
+  const timestamp = (exportedAt ?? new Date()).toISOString();
+
+  lines.push(`# ${title || "Insight generation record"}`);
+  lines.push("");
+  lines.push(
+    `> AI-assisted analysis generation record · exported ${timestamp}`
+  );
+  lines.push(
+    "> AI models may produce incomplete or incorrect information. " +
+      "Verify outputs before using them in your work."
+  );
+
+  parts.forEach((part, index) => {
+    lines.push("");
+    lines.push(`## Step ${index + 1} — ${PART_HEADINGS[part.type]}`);
+    lines.push("");
+    if (part.type === "code_block") {
+      lines.push("```python");
+      lines.push(part.content);
+      lines.push("```");
+    } else if (part.type === "execution_output") {
+      lines.push("```");
+      lines.push(part.content);
+      lines.push("```");
+    } else {
+      lines.push(part.content);
+    }
+  });
+
+  if (sourceUrls && sourceUrls.length > 0) {
+    lines.push("");
+    lines.push("## Sources");
+    lines.push("");
+    sourceUrls.forEach((url, index) => {
+      lines.push(`${index + 1}. ${url}`);
+    });
+  }
+
+  lines.push("");
+  return lines.join("\n");
+}
+
+export function provenanceFilename(title: string | undefined): string {
+  const slug = (title || "insight").replace(/[^a-z0-9]/gi, "_").slice(0, 80);
+  return `${slug}_generation_record.md`;
+}


### PR DESCRIPTION
Part 3 of 6 — split from #537. Fully independent, no dependencies.

## Changes

**New `provenanceRecord.ts` utility + unit tests**
- Builds a self-contained Markdown export from the provenance data (narrative, code blocks, execution output, sources, timestamp)

**`InsightProvenanceDrawer.tsx`**
- Header gains a GENERATION RECORD subtitle and a Save record button that exports the full provenance as a `.md` file
- Code and execution-output blocks are step-numbered for referenceable audits
- Sources are numbered and wrap-safe
- Close button repositioned inline so it no longer overlaps header actions

## Merge order
**Batch 1 (independent):** #540-chart-fixes · #541-table-widget · this PR  
**Batch 2:** #C-chart-widget  
**Batch 3:** #D-widget-message · #E-insight-workspace