### PR TITLE
feat(chart-widget): negative domains, formatted tooltips, donut totals, a11y, motion

### DIFF
--- a/app/components/widgets/ChartWidget.tsx
+++ b/app/components/widgets/ChartWidget.tsx
@@ -235,21 +235,11 @@ function DonutCenterLabel({
     <text x={cx} y={cy} textAnchor="middle" dominantBaseline="central">
       <tspan
         x={cx}
-        dy="-0.3em"
         fontSize={expanded ? "22" : "14"}
         fontWeight="600"
         fill="var(--chakra-colors-fg)"
       >
         {formatYAxisLabel(total, axisKey)}
-      </tspan>
-      <tspan
-        x={cx}
-        dy="1.5em"
-        fontSize={expanded ? "12" : "9"}
-        letterSpacing="0.05em"
-        fill="var(--chakra-colors-fg-muted)"
-      >
-        TOTAL
       </tspan>
     </text>
   );

--- a/app/components/widgets/ChartWidget.tsx
+++ b/app/components/widgets/ChartWidget.tsx
@@ -16,17 +16,21 @@ import {
   CartesianGrid,
   Label,
   Legend,
+  ReferenceLine,
   Tooltip,
   XAxis,
   YAxis,
+  usePlotArea,
 } from "recharts";
 import formatChartData, {
   formatYAxisLabel,
   formatXAxisLabel,
+  formatTooltipValue,
   toAxisLabel,
 } from "@/app/utils/formatCharts";
 import { InsightWidget } from "@/app/types/chat";
 import { STROKE_DASH_PATTERNS } from "@/app/utils/ChartColors";
+import usePrefersReducedMotion from "@/app/hooks/usePrefersReducedMotion";
 
 type ChartType =
   | "bar"
@@ -43,6 +47,8 @@ const TICK_MARGIN = 6; // gap between tick text and axis line
 const TITLE_BAND = 22; // reserved column: title (~14px) + breathing room
 const TICK_ANGLE_RAD = (35 * Math.PI) / 180;
 const MAX_X_TICKS = 12; // density target before we thin tick labels
+const ANIMATION_MS = 650; // entry animation; disabled under reduced motion
+const MAX_LINE_DOTS = 14; // beyond this, per-point dots become noise
 
 // Chart wrapper components
 type ChartWrapperComponent =
@@ -65,6 +71,32 @@ const chartWrappers: Record<ChartType, ChartWrapperComponent> = {
 interface ChartWidgetProps {
   widget: InsightWidget;
   expanded?: boolean;
+  /**
+   * Rescale the y-axis to the data range instead of anchoring at zero.
+   * Useful for flat series; offered only for line/area/scatter — truncated
+   * axes misrepresent bar charts, whose lengths encode magnitude.
+   */
+  fitYAxis?: boolean;
+}
+
+/** Chart types where a fit-to-data y-axis is honest and useful. */
+export const AXIS_FIT_TYPES: ReadonlySet<string> = new Set([
+  "line",
+  "area",
+  "scatter",
+]);
+
+/**
+ * Floor the y-domain to a round number just below the data minimum, so a
+ * fitted axis starts at e.g. 35,000 rather than 35,612. Explicit numbers are
+ * needed because recharts' "auto" minimum stays pinned to the 0 baseline
+ * that Area items feed into the domain.
+ */
+function niceFloor(min: number, max: number): number {
+  if (!Number.isFinite(min) || min <= 0) return min;
+  const range = max - min || Math.abs(min) || 1;
+  const step = Math.pow(10, Math.floor(Math.log10(range)));
+  return Math.floor(min / step) * step;
 }
 interface CustomTooltipProps {
   active?: boolean;
@@ -78,8 +110,7 @@ interface CustomTooltipProps {
 const CustomScatterTooltip = ({ active, payload }: CustomTooltipProps) => {
   if (active && payload && payload.length >= 2) {
     const dataPoint = payload[0].payload;
-    const xAxisPayload = payload[0];
-    const yAxisPayload = payload[1];
+    const axisPayloads = [payload[0], payload[1]];
 
     return (
       <Box
@@ -96,37 +127,22 @@ const CustomScatterTooltip = ({ active, payload }: CustomTooltipProps) => {
             {String(dataPoint.name)}
           </Heading>
         )}
-        <Flex
-          justifyContent="space-between"
-          fontSize="xs"
-          fontWeight="normal"
-          color="fg.muted"
-        >
-          <Text as="span" mr={4}>
-            {xAxisPayload.name}
-          </Text>
-          <Text fontFamily="mono" textAlign="right">
-            {xAxisPayload.name === "year"
-              ? xAxisPayload.value
-              : Number(xAxisPayload.value).toLocaleString()}
-          </Text>
-        </Flex>
-        <Flex
-          justifyContent="space-between"
-          fontSize="xs"
-          fontWeight="normal"
-          color="fg.muted"
-        >
-          <Text as="span" mr={4}>
-            {yAxisPayload.name}
-          </Text>
-          <Text fontFamily="mono" textAlign="right">
-            {/* FIX: Correctly reference the y-axis payload value */}
-            {yAxisPayload.name === "year"
-              ? yAxisPayload.value
-              : Number(yAxisPayload.value).toLocaleString()}
-          </Text>
-        </Flex>
+        {axisPayloads.map((axisPayload, idx) => (
+          <Flex
+            key={idx}
+            justifyContent="space-between"
+            fontSize="xs"
+            fontWeight="normal"
+            color="fg.muted"
+          >
+            <Text as="span" mr={4}>
+              {toAxisLabel(axisPayload.name)}
+            </Text>
+            <Text fontFamily="mono" textAlign="right">
+              {formatTooltipValue(axisPayload.value, axisPayload.name)}
+            </Text>
+          </Flex>
+        ))}
       </Box>
     );
   }
@@ -136,40 +152,108 @@ const CustomScatterTooltip = ({ active, payload }: CustomTooltipProps) => {
 
 interface CustomPieLegendProps {
   series: { name?: string | number; color?: string }[];
+  /** Share of total per slice name, formatted (e.g. "26%"). */
+  shares?: Map<string, string>;
 }
 
-const CustomPieLegend = ({ series }: CustomPieLegendProps) => {
+const CustomPieLegend = ({ series, shares }: CustomPieLegendProps) => {
   if (!series) return null;
 
   return (
     <Flex direction="column" gap={1} as="ul" listStyleType="none" m={0} p={0}>
       {series
         .filter((entry) => entry.name && entry.color)
-        .map((entry, index) => (
-          <Flex as="li" key={`item-${index}`} align="center" gap={1.5}>
-            <Box
-              w={2.5}
-              h={2.5}
-              bg={entry.color}
-              border="1px solid"
-              borderColor="neutral.400"
-              rounded="sm"
-              flexShrink={0}
-            />
-            <Text
-              fontSize="2xs"
-              color="neutral.500"
-              overflow="hidden"
-              textOverflow="ellipsis"
-              whiteSpace="nowrap"
-            >
-              {String(entry.name)}
-            </Text>
-          </Flex>
-        ))}
+        .map((entry, index) => {
+          const share = shares?.get(String(entry.name));
+          return (
+            <Flex as="li" key={`item-${index}`} align="center" gap={1.5}>
+              <Box
+                w={2.5}
+                h={2.5}
+                bg={entry.color}
+                border="1px solid"
+                borderColor="neutral.400"
+                rounded="sm"
+                flexShrink={0}
+              />
+              <Text
+                fontSize="2xs"
+                color="neutral.500"
+                overflow="hidden"
+                textOverflow="ellipsis"
+                whiteSpace="nowrap"
+                flex="1"
+              >
+                {String(entry.name)}
+              </Text>
+              {share && (
+                <Text
+                  fontSize="2xs"
+                  color="fg.muted"
+                  fontFamily="mono"
+                  flexShrink={0}
+                  css={{ fontVariantNumeric: "tabular-nums" }}
+                >
+                  {share}
+                </Text>
+              )}
+            </Flex>
+          );
+        })}
     </Flex>
   );
 };
+
+/** "26%" for most slices, "<1%" for slivers — keeps the legend scannable. */
+function formatShare(value: number, total: number): string | undefined {
+  if (!total || total <= 0 || !Number.isFinite(value)) return undefined;
+  const pct = (value / total) * 100;
+  if (pct > 0 && pct < 1) return "<1%";
+  return `${Math.round(pct)}%`;
+}
+
+/**
+ * Donut centre total. Rendered as a <Pie> child so it sits in the chart's
+ * SVG; reads the plot area from recharts context because the pie (default
+ * cx/cy of 50%) is centred there. Recharts 3 doesn't hand <Label content>
+ * renderers a viewBox, so a context-reading component is the reliable path.
+ */
+function DonutCenterLabel({
+  total,
+  axisKey,
+  expanded = false,
+}: {
+  total: number;
+  axisKey?: string;
+  expanded?: boolean;
+}) {
+  const plotArea = usePlotArea();
+  if (!plotArea || total <= 0) return null;
+  const cx = plotArea.x + plotArea.width / 2;
+  const cy = plotArea.y + plotArea.height / 2;
+  return (
+    <text x={cx} y={cy} textAnchor="middle" dominantBaseline="central">
+      <tspan
+        x={cx}
+        dy="-0.3em"
+        fontSize={expanded ? "22" : "14"}
+        fontWeight="600"
+        fill="var(--chakra-colors-fg)"
+      >
+        {formatYAxisLabel(total, axisKey)}
+      </tspan>
+      <tspan
+        x={cx}
+        dy="1.5em"
+        fontSize={expanded ? "12" : "9"}
+        letterSpacing="0.05em"
+        fill="var(--chakra-colors-fg-muted)"
+      >
+        TOTAL
+      </tspan>
+    </text>
+  );
+}
 
 interface CustomPieTooltipWithTotalProps extends CustomTooltipProps {
   total?: number;
@@ -204,7 +288,7 @@ const CustomPieTooltip = ({
             {dataPoint.name}
           </Text>
           <Text fontFamily="mono" textAlign="right">
-            {value.toLocaleString()}
+            {formatTooltipValue(value)}
             {pct !== null && (
               <Text as="span" color="fg.subtle" ml={1}>
                 ({pct}%)
@@ -218,9 +302,28 @@ const CustomPieTooltip = ({
   return null;
 };
 
+function ChartFallback({ message }: { message: string }) {
+  return (
+    <Flex
+      align="center"
+      justify="center"
+      minH="120px"
+      border="1px dashed"
+      borderColor="border"
+      borderRadius="md"
+      p={4}
+    >
+      <Text fontSize="sm" color="fg.muted">
+        {message}
+      </Text>
+    </Flex>
+  );
+}
+
 export default function ChartWidget({
   widget,
   expanded = false,
+  fitYAxis = false,
 }: ChartWidgetProps) {
   const { data, xAxis, yAxis, type, seriesFields } = widget;
   const ChartTypeWrapper = chartWrappers[type as ChartType];
@@ -240,48 +343,52 @@ export default function ChartWidget({
     [data, type, xAxis, yAxis, widget.datasetName, seriesFields]
   );
 
-  const chart = useChart({ data: formattedData, series });
+  // Humanize series labels that are raw column keys (snake_case or the
+  // y-axis key) — tooltip and legend then show "Tree cover loss (ha)"
+  // instead of "tree_cover_loss_ha". Category-valued series names like
+  // "DR Congo" are left untouched. dataKeys still use the raw `name`.
+  const labelledSeries = useMemo(
+    () =>
+      series.map((s) =>
+        s.name === yAxis || s.name.includes("_")
+          ? { ...s, label: toAxisLabel(s.name) }
+          : s
+      ),
+    [series, yAxis]
+  );
+
+  const chart = useChart({ data: formattedData, series: labelledSeries });
+  const prefersReducedMotion = usePrefersReducedMotion();
+  const animate = !prefersReducedMotion;
 
   const pieTotal = useMemo(() => {
     if (type !== "pie" || !yAxis) return 0;
     return formattedData.reduce((sum, d) => sum + (Number(d[yAxis]) || 0), 0);
   }, [type, yAxis, formattedData]);
 
+  const pieShares = useMemo(() => {
+    if (type !== "pie" || !yAxis || !xAxis || pieTotal <= 0) return undefined;
+    const shares = new Map<string, string>();
+    for (const row of formattedData) {
+      const share = formatShare(Number(row[yAxis]), pieTotal);
+      if (share) shares.set(String(row[xAxis]), share);
+    }
+    return shares;
+  }, [type, xAxis, yAxis, formattedData, pieTotal]);
+
   if (!xAxis || (type === "scatter" && !yAxis)) {
-    return (
-      <Flex
-        align="center"
-        justify="center"
-        minH="120px"
-        border="1px dashed"
-        borderColor="border"
-        borderRadius="md"
-        p={4}
-      >
-        <Text fontSize="sm" color="fg.muted">
-          Chart is missing axis configuration.
-        </Text>
-      </Flex>
-    );
+    return <ChartFallback message="Chart is missing axis configuration." />;
   }
 
   if (!ChartTypeWrapper || formattedData.length === 0 || series.length === 0) {
     return (
-      <Flex
-        align="center"
-        justify="center"
-        minH="120px"
-        border="1px dashed"
-        borderColor="border"
-        borderRadius="md"
-        p={4}
-      >
-        <Text fontSize="sm" color="fg.muted">
-          {!ChartTypeWrapper
+      <ChartFallback
+        message={
+          !ChartTypeWrapper
             ? `Unsupported chart type: "${type}"`
-            : "No data available for this chart."}
-        </Text>
-      </Flex>
+            : "No data available for this chart."
+        }
+      />
     );
   }
 
@@ -310,10 +417,15 @@ export default function ChartWidget({
   }
 
   // Sized from the longest formatted tick so titles hug the ticks regardless
-  // of content — fixed sizes leave dead bands or cause overlap.
+  // of content — fixed sizes leave dead bands or cause overlap. The same pass
+  // detects negative values (e.g. GHG net-flux sinks) so the Y domain can
+  // extend below zero instead of clipping those bars.
   const yKeys = type === "scatter" ? [yAxis] : series.map((s) => s.name);
   let longestXTickChars = 0;
   let longestYTickChars = 0;
+  let hasNegativeValues = false;
+  let dataMinValue = Infinity;
+  let dataMaxValue = -Infinity;
   for (const row of formattedData) {
     const xFormatted =
       type === "scatter"
@@ -324,6 +436,9 @@ export default function ChartWidget({
     for (const k of yKeys) {
       const v = Number(row[k]);
       if (!Number.isFinite(v)) continue;
+      if (v < 0) hasNegativeValues = true;
+      dataMinValue = Math.min(dataMinValue, v);
+      dataMaxValue = Math.max(dataMaxValue, v);
       longestYTickChars = Math.max(
         longestYTickChars,
         formatYAxisLabel(v, yAxis).length
@@ -344,6 +459,12 @@ export default function ChartWidget({
     longestYTickChars * CHAR_PX + TICK_MARGIN + TITLE_BAND
   );
 
+  const animationProps = {
+    isAnimationActive: animate,
+    animationDuration: ANIMATION_MS,
+    animationEasing: "ease-out" as const,
+  };
+
   const renderChartItems = () => {
     switch (type) {
       case "pie": {
@@ -352,9 +473,9 @@ export default function ChartWidget({
             data={chart.data}
             nameKey={chart.key(xAxis)}
             dataKey={chart.key(yAxis)}
-            innerRadius={35}
-            outerRadius={75}
-            isAnimationActive={false}
+            innerRadius={expanded ? "42%" : 35}
+            outerRadius={expanded ? "80%" : 75}
+            {...animationProps}
             startAngle={90}
             endAngle={-270}
           >
@@ -366,6 +487,11 @@ export default function ChartWidget({
                 stroke="var(--chakra-colors-bg)"
               />
             ))}
+            <DonutCenterLabel
+              total={pieTotal}
+              axisKey={yAxis}
+              expanded={expanded}
+            />
           </Pie>
         );
       }
@@ -376,11 +502,14 @@ export default function ChartWidget({
             name={item.name?.toString()}
             data={chart.data} // Scatter plots often use the full dataset
             fill={chart.color(item.color)}
-            isAnimationActive={false}
+            {...animationProps}
           />
         ));
       }
       case "line": {
+        // Per-point dots clutter long series; keep them for short ones and
+        // always show an emphasized dot on hover.
+        const showDots = formattedData.length <= MAX_LINE_DOTS;
         return chart.series.map((item, idx) => (
           <Line
             key={item.name}
@@ -392,7 +521,13 @@ export default function ChartWidget({
             strokeDasharray={
               STROKE_DASH_PATTERNS[idx % STROKE_DASH_PATTERNS.length]
             }
-            isAnimationActive={false}
+            dot={showDots ? { r: 2.5, strokeWidth: 1 } : false}
+            activeDot={{
+              r: 4.5,
+              strokeWidth: 2,
+              stroke: "var(--chakra-colors-bg)",
+            }}
+            {...animationProps}
           />
         ));
       }
@@ -411,13 +546,24 @@ export default function ChartWidget({
             strokeDasharray={
               STROKE_DASH_PATTERNS[idx % STROKE_DASH_PATTERNS.length]
             }
-            isAnimationActive={false}
+            activeDot={{
+              r: 4.5,
+              strokeWidth: 2,
+              stroke: "var(--chakra-colors-bg)",
+            }}
+            {...animationProps}
           />
         ));
       }
       case "bar":
       case "grouped-bar":
       case "stacked-bar": {
+        // Rounded tops read well on upward bars only — skip for stacked
+        // segments and for divergent charts where bars also point down.
+        const barRadius: [number, number, number, number] | undefined =
+          type !== "stacked-bar" && !hasNegativeValues
+            ? [3, 3, 0, 0]
+            : undefined;
         return chart.series.map((item) => (
           <Bar
             key={item.name}
@@ -425,7 +571,8 @@ export default function ChartWidget({
             dataKey={chart.key(item.name)}
             stackId={type === "stacked-bar" ? "a" : undefined}
             fill={chart.color(item.color)}
-            isAnimationActive={false}
+            radius={barRadius}
+            {...animationProps}
           >
             {typeof formattedData[0]?._barColor === "string" &&
               formattedData.map((entry, index) => (
@@ -439,24 +586,50 @@ export default function ChartWidget({
     }
   };
 
-  const chartLabel =
-    `${type} chart: ${widget.title || ""}. ${widget.description || ""}`.trim();
+  const pointsSummary =
+    type === "pie"
+      ? `${formattedData.length} slices`
+      : `${formattedData.length} data points`;
+  const chartLabel = [
+    `${type} chart: ${widget.title || ""}.`,
+    `${pointsSummary}.`,
+    widget.description || "",
+  ]
+    .join(" ")
+    .trim();
 
   return (
-    <Box role="img" aria-label={chartLabel} tabIndex={0}>
+    <Box
+      role="img"
+      aria-label={chartLabel}
+      tabIndex={0}
+      borderRadius="sm"
+      _focusVisible={{
+        outline: "2px solid",
+        outlineColor: "primary.focusRing",
+        outlineOffset: "2px",
+      }}
+    >
       <Chart.Root
         maxH={expanded ? "75vh" : type === "pie" ? "190px" : "280px"}
         chart={chart}
         overflow="hidden"
       >
-        <ChartTypeWrapper data={chart.data}>
+        <ChartTypeWrapper
+          data={chart.data}
+          // Anchor area fills to the data minimum when fitting, so the 0
+          // baseline stops forcing the y-domain down to zero.
+          {...(type === "area" && fitYAxis
+            ? { baseValue: "dataMin" as const }
+            : {})}
+        >
           {type !== "pie" && (
             <CartesianGrid strokeDasharray="3 3" vertical={false} />
           )}
           <Legend
             content={
               type === "pie" ? (
-                <CustomPieLegend series={chart.series} />
+                <CustomPieLegend series={chart.series} shares={pieShares} />
               ) : (
                 <Chart.Legend />
               )
@@ -526,7 +699,20 @@ export default function ChartWidget({
                 }
                 axisLine={false}
                 tickLine={false}
-                domain={[0, "auto"]}
+                // Default: floor at 0 for all-positive data, but extend below
+                // zero for divergent datasets (e.g. GHG net flux sinks) so
+                // negative bars aren't clipped. "Fit y-axis" rescales to the
+                // data range for flat line/area/scatter series.
+                domain={
+                  fitYAxis &&
+                  AXIS_FIT_TYPES.has(type) &&
+                  Number.isFinite(dataMinValue)
+                    ? [niceFloor(dataMinValue, dataMaxValue), "auto"]
+                    : [(dataMin: number) => Math.min(0, dataMin), "auto"]
+                }
+                // Without this, recharts re-expands a fitted domain to cover
+                // the 0 baseline that area fills contribute.
+                allowDataOverflow={fitYAxis && AXIS_FIT_TYPES.has(type)}
                 fontSize={TICK_FONT_PX}
               >
                 {yAxis && (
@@ -543,6 +729,13 @@ export default function ChartWidget({
                   />
                 )}
               </YAxis>
+              {hasNegativeValues && (
+                <ReferenceLine
+                  y={0}
+                  stroke="var(--chakra-colors-neutral-400)"
+                  strokeWidth={1}
+                />
+              )}
             </>
           )}
           <Tooltip
@@ -555,7 +748,11 @@ export default function ChartWidget({
               ) : type === "pie" ? (
                 <CustomPieTooltip total={pieTotal} />
               ) : (
-                <Chart.Tooltip />
+                <Chart.Tooltip
+                  formatter={(value) =>
+                    formatTooltipValue(value, chart.key(yAxis))
+                  }
+                />
               )
             }
           />

--- a/app/hooks/usePrefersReducedMotion.ts
+++ b/app/hooks/usePrefersReducedMotion.ts
@@ -1,0 +1,27 @@
+"use client";
+import { useSyncExternalStore } from "react";
+
+const QUERY = "(prefers-reduced-motion: reduce)";
+
+function subscribe(onStoreChange: () => void): () => void {
+  const mediaQuery = window.matchMedia(QUERY);
+  mediaQuery.addEventListener("change", onStoreChange);
+  return () => mediaQuery.removeEventListener("change", onStoreChange);
+}
+
+function getSnapshot(): boolean {
+  return window.matchMedia(QUERY).matches;
+}
+
+// SSR: assume no preference; the client snapshot corrects on hydration.
+function getServerSnapshot(): boolean {
+  return false;
+}
+
+/**
+ * Reactively tracks the user's `prefers-reduced-motion` setting so
+ * chart/workspace animations can be disabled for motion-sensitive users.
+ */
+export default function usePrefersReducedMotion(): boolean {
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+}


### PR DESCRIPTION
Part 4 of 6 — split from #537. Depends on #540 (chart fixes) — base branch set accordingly so the diff is clean.

## Changes

**New `usePrefersReducedMotion.ts` hook**
- Reads `prefers-reduced-motion` media query; gates all animations

**`ChartWidget.tsx`**
- Y domain extends below zero for divergent data (GHG net-flux sinks were clipped by the hard `[0, auto]` domain); zero `<ReferenceLine>` when negatives present
- Optional `fitYAxis` prop rescales line/area/scatter to the data range with a nice-floored minimum (bars stay zero-anchored by design)
- Locale-formatted tooltip values; scatter and pie tooltips humanise field names; raw column-key names get humanised labels in legend
- Donut charts show a centre total (recharts 3 does not pass `Label` content renderers a viewBox — uses `usePlotArea`)
- Pie legends show per-slice percentage shares
- Entry animations (650ms ease-out) gated by `usePrefersReducedMotion`; rounded bar tops; hover-emphasised line/area dots
- Focus ring on the focusable chart `<figure>` and a data summary in `aria-label`

## Merge order
Merge #540 into develop first, then merge this PR.  
**After this merges:** #D-widget-message and #E-insight-workspace can be retargeted to develop.