### PR TITLE
feat(widget-message): fit y-axis toggle, download menu with PNG export, richer fullscreen

### DIFF
--- a/app/components/WidgetMessage.tsx
+++ b/app/components/WidgetMessage.tsx
@@ -1,19 +1,23 @@
 "use client";
-import { useState } from "react";
+import { useRef, useState } from "react";
 import {
   Box,
   Heading,
   Flex,
   Button,
   Dialog,
+  Menu,
   Portal,
   CloseButton,
+  Text,
   useDisclosure,
 } from "@chakra-ui/react";
 import {
   MicroscopeIcon as Microscope,
   ArrowsOutIcon,
   DownloadSimpleIcon,
+  FileCsvIcon,
+  ImageIcon,
   TableIcon,
   ChartBarIcon,
   CaretDownIcon,
@@ -21,16 +25,41 @@ import {
 import { InsightWidget, DatasetInfo } from "@/app/types/chat";
 import TableWidget from "./widgets/TableWidget";
 import DatasetCardWidget from "./widgets/DatasetCardWidget";
-import ChartWidget from "./widgets/ChartWidget";
+import ChartWidget, { AXIS_FIT_TYPES } from "./widgets/ChartWidget";
 import { WidgetIcons } from "../utils/widgetIcons";
 import InsightProvenanceDrawer from "./InsightProvenanceDrawer";
 import VisualizationDisclaimer from "./VisualizationDisclaimer";
 import WidgetErrorBoundary from "./widgets/WidgetErrorBoundary";
 import ScrollableTableWrapper from "./widgets/ScrollableTableWrapper";
+import { AnalysisParamsChips } from "./widgets/AnalysisParameters";
+import { buildChips } from "./widgets/analysis-params-utils";
+import { exportChartImage } from "@/app/utils/exportChartImage";
+import { toaster } from "@/app/components/ui/toaster";
 
 interface WidgetMessageProps {
   widget: InsightWidget;
   inWorkspace?: boolean;
+}
+
+/** Y-axis with the classic break squiggle — icon for the fit-axis toggle. */
+function AxisBreakIcon({ size = 14 }: { size?: number }) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 14 14"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      aria-hidden="true"
+    >
+      <path d="M7 1.5v3.5" />
+      <path d="M4.5 7.5l5-2" />
+      <path d="M4.5 10l5-2" />
+      <path d="M7 11v1.5" />
+    </svg>
+  );
 }
 
 export default function WidgetMessage({
@@ -38,6 +67,9 @@ export default function WidgetMessage({
   inWorkspace,
 }: WidgetMessageProps) {
   const [showAsTable, setShowAsTable] = useState(false);
+  const [fitYAxis, setFitYAxis] = useState(false);
+  const [exportingImage, setExportingImage] = useState(false);
+  const chartRef = useRef<HTMLDivElement>(null);
   const { open, onOpen, onClose } = useDisclosure();
   const {
     open: expanded,
@@ -50,6 +82,25 @@ export default function WidgetMessage({
 
   const handleOpen = () => {
     onOpen();
+  };
+
+  const handleDownloadImage = async () => {
+    if (!chartRef.current || exportingImage) return;
+    setExportingImage(true);
+    try {
+      await exportChartImage(chartRef.current, widget.title);
+    } catch (error) {
+      console.error("Chart image export failed:", error);
+      toaster.create({
+        title: "Image export failed",
+        description:
+          "The chart couldn't be saved as an image. You can still download the data as CSV.",
+        type: "error",
+        duration: 4000,
+      });
+    } finally {
+      setExportingImage(false);
+    }
   };
 
   const handleDownloadCsv = () => {
@@ -94,6 +145,10 @@ export default function WidgetMessage({
   const isChartType = chartTypes.includes(widget.type);
   const hasData = Array.isArray(widget.data) && widget.data.length > 0;
   const showDisclaimer = (isChartType || widget.type === "table") && hasData;
+  const supportsAxisFit = AXIS_FIT_TYPES.has(widget.type);
+  const fullscreenChips = widget.analysisParams
+    ? buildChips(widget.analysisParams)
+    : [];
   return (
     <Box
       rounded="md"
@@ -127,6 +182,8 @@ export default function WidgetMessage({
               borderColor="border.emphasized"
               rounded="md"
               overflow="hidden"
+              role="group"
+              aria-label="Visualization format"
             >
               <Button
                 size="xs"
@@ -136,6 +193,7 @@ export default function WidgetMessage({
                 h={6}
                 rounded="none"
                 fontWeight="medium"
+                aria-pressed={!showAsTable}
               >
                 <ChartBarIcon size={14} />
                 Chart
@@ -148,11 +206,30 @@ export default function WidgetMessage({
                 h={6}
                 rounded="none"
                 fontWeight="medium"
+                aria-pressed={showAsTable}
               >
                 <TableIcon size={14} />
                 Table
               </Button>
             </Flex>
+          )}
+          {/* Fit y-axis to data — only for types where a non-zero baseline
+              is honest (line/area/scatter; bar lengths encode magnitude) */}
+          {isChartType && hasData && supportsAxisFit && !showAsTable && (
+            <Button
+              size="xs"
+              variant={fitYAxis ? "solid" : "outline"}
+              colorPalette={fitYAxis ? "primary" : undefined}
+              onClick={() => setFitYAxis((v) => !v)}
+              h={6}
+              rounded="sm"
+              color={fitYAxis ? undefined : "neutral.500"}
+              aria-pressed={fitYAxis}
+              title="Rescale the y-axis to the data range instead of starting at zero"
+            >
+              <AxisBreakIcon />
+              Fit y-axis
+            </Button>
           )}
           {/* Show full-screen */}
           {isChartType && hasData && (
@@ -171,7 +248,9 @@ export default function WidgetMessage({
         </Flex>
         {isChartType && !showAsTable && (
           <WidgetErrorBoundary fallbackTitle="Unable to render chart">
-            <ChartWidget widget={widget} />
+            <Box ref={chartRef}>
+              <ChartWidget widget={widget} fitYAxis={fitYAxis} />
+            </Box>
           </WidgetErrorBoundary>
         )}
         {isChartType && showAsTable && Array.isArray(widget.data) && (
@@ -225,18 +304,38 @@ export default function WidgetMessage({
                 View how this was generated
               </Button>
             )}
-            <Button
-              size="xs"
-              variant="outline"
-              onClick={handleDownloadCsv}
-              h={6}
-              rounded="sm"
-              color="neutral.500"
-            >
-              <DownloadSimpleIcon size={14} />
-              Download
-              <CaretDownIcon size={12} />
-            </Button>
+            <Menu.Root positioning={{ placement: "bottom-start" }}>
+              <Menu.Trigger asChild>
+                <Button
+                  size="xs"
+                  variant="outline"
+                  h={6}
+                  rounded="sm"
+                  color="neutral.500"
+                  loading={exportingImage}
+                >
+                  <DownloadSimpleIcon size={14} />
+                  Download
+                  <CaretDownIcon size={12} />
+                </Button>
+              </Menu.Trigger>
+              <Portal>
+                <Menu.Positioner>
+                  <Menu.Content minW="180px" zIndex={1400}>
+                    <Menu.Item value="csv" onClick={handleDownloadCsv}>
+                      <FileCsvIcon size={14} />
+                      Data (CSV)
+                    </Menu.Item>
+                    {isChartType && !showAsTable && (
+                      <Menu.Item value="png" onClick={handleDownloadImage}>
+                        <ImageIcon size={14} />
+                        Chart image (PNG)
+                      </Menu.Item>
+                    )}
+                  </Menu.Content>
+                </Menu.Positioner>
+              </Portal>
+            </Menu.Root>
           </Flex>
         )}
         {showDisclaimer && !inWorkspace && <VisualizationDisclaimer />}
@@ -273,10 +372,72 @@ export default function WidgetMessage({
                     <CloseButton size="sm" />
                   </Dialog.CloseTrigger>
                 </Dialog.Header>
-                <Dialog.Body px={0} pb={0}>
-                  <WidgetErrorBoundary fallbackTitle="Unable to render chart">
-                    <ChartWidget widget={widget} expanded />
-                  </WidgetErrorBoundary>
+                <Dialog.Body
+                  px={0}
+                  pb={0}
+                  display="flex"
+                  flexDirection={{ base: "column", md: "row" }}
+                  gap={6}
+                  minH={0}
+                  overflow="auto"
+                >
+                  <Box flex="1" minW={0}>
+                    <WidgetErrorBoundary fallbackTitle="Unable to render chart">
+                      <ChartWidget
+                        widget={widget}
+                        expanded
+                        fitYAxis={fitYAxis}
+                      />
+                    </WidgetErrorBoundary>
+                  </Box>
+                  {(widget.description ||
+                    fullscreenChips.length > 0 ||
+                    widget.datasetName) && (
+                    <Flex
+                      direction="column"
+                      gap={4}
+                      w={{ base: "100%", md: "300px" }}
+                      flexShrink={0}
+                      borderLeftWidth={{ base: 0, md: "1px" }}
+                      borderTopWidth={{ base: "1px", md: 0 }}
+                      borderColor="border"
+                      pl={{ base: 0, md: 5 }}
+                      pt={{ base: 4, md: 1 }}
+                      overflowY="auto"
+                    >
+                      {widget.description && (
+                        <Box>
+                          <Heading size="xs" mb={1}>
+                            About this insight
+                          </Heading>
+                          <Text fontSize="sm" color="fg.muted">
+                            {widget.description}
+                          </Text>
+                        </Box>
+                      )}
+                      {fullscreenChips.length > 0 && (
+                        <Box>
+                          <Heading size="xs" mb={2}>
+                            Analysis parameters
+                          </Heading>
+                          <AnalysisParamsChips chips={fullscreenChips} />
+                        </Box>
+                      )}
+                      {widget.datasetName && (
+                        <Box>
+                          <Heading size="xs" mb={1}>
+                            Dataset
+                          </Heading>
+                          <Text fontSize="sm" color="fg.muted">
+                            {widget.datasetName}
+                          </Text>
+                        </Box>
+                      )}
+                      <Box mt="auto">
+                        <VisualizationDisclaimer />
+                      </Box>
+                    </Flex>
+                  )}
                 </Dialog.Body>
               </Dialog.Content>
             </Dialog.Positioner>

--- a/app/utils/exportChartImage.ts
+++ b/app/utils/exportChartImage.ts
@@ -1,0 +1,128 @@
+/**
+ * Exports a rendered chart (SVG plot + HTML legend) to a PNG download.
+ *
+ * The chart container mixes an HTML legend with the recharts SVG, so the
+ * whole container is rasterized via an SVG <foreignObject>: computed styles
+ * are inlined on a clone (CSS variables and classes don't survive
+ * serialization), the clone is serialized to a data-URL SVG, drawn onto a
+ * 2x canvas with the title and a white background, and downloaded.
+ */
+
+const EXPORT_SCALE = 2; // retina-quality raster
+const TITLE_BAND_PX = 40; // unscaled space reserved above the chart
+const PADDING_PX = 16; // unscaled padding around the chart
+
+/** Copy every computed style property onto the clone as inline style. */
+function inlineComputedStyles(source: Element, target: Element) {
+  const computed = window.getComputedStyle(source);
+  let cssText = "";
+  for (let i = 0; i < computed.length; i++) {
+    const property = computed[i];
+    cssText += `${property}:${computed.getPropertyValue(property)};`;
+  }
+  target.setAttribute("style", cssText);
+
+  const sourceChildren = source.children;
+  const targetChildren = target.children;
+  for (let i = 0; i < sourceChildren.length; i++) {
+    if (targetChildren[i]) {
+      inlineComputedStyles(sourceChildren[i], targetChildren[i]);
+    }
+  }
+}
+
+function loadImage(src: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const image = new Image();
+    image.onload = () => resolve(image);
+    image.onerror = () =>
+      reject(new Error("Failed to rasterize the chart snapshot."));
+    image.src = src;
+  });
+}
+
+function canvasToBlob(canvas: HTMLCanvasElement): Promise<Blob> {
+  return new Promise((resolve, reject) => {
+    canvas.toBlob((blob) => {
+      if (blob) resolve(blob);
+      else reject(new Error("Failed to encode the PNG."));
+    }, "image/png");
+  });
+}
+
+function drawTitle(
+  ctx: CanvasRenderingContext2D,
+  title: string,
+  maxWidth: number
+) {
+  ctx.fillStyle = "#13171A";
+  ctx.font = `600 ${15 * EXPORT_SCALE}px ui-sans-serif, system-ui, sans-serif`;
+  ctx.textBaseline = "middle";
+  let text = title;
+  while (text.length > 1 && ctx.measureText(text).width > maxWidth) {
+    text = `${text.slice(0, -2).trimEnd()}…`;
+  }
+  ctx.fillText(
+    text,
+    PADDING_PX * EXPORT_SCALE,
+    (PADDING_PX + TITLE_BAND_PX / 2) * EXPORT_SCALE
+  );
+}
+
+export function chartImageFilename(title: string | undefined): string {
+  return `${(title || "chart").replace(/[^a-z0-9]/gi, "_")}.png`;
+}
+
+export async function exportChartImage(
+  container: HTMLElement,
+  title?: string
+): Promise<void> {
+  const rect = container.getBoundingClientRect();
+  if (rect.width === 0 || rect.height === 0) {
+    throw new Error("Chart is not visible, so there is nothing to export.");
+  }
+
+  const clone = container.cloneNode(true) as HTMLElement;
+  inlineComputedStyles(container, clone);
+  clone.setAttribute("xmlns", "http://www.w3.org/1999/xhtml");
+
+  const width = Math.ceil(rect.width);
+  const height = Math.ceil(rect.height);
+  const svgString =
+    `<svg xmlns="http://www.w3.org/2000/svg" width="${width}" height="${height}">` +
+    `<foreignObject width="100%" height="100%">${new XMLSerializer().serializeToString(clone)}</foreignObject>` +
+    `</svg>`;
+
+  const image = await loadImage(
+    `data:image/svg+xml;charset=utf-8,${encodeURIComponent(svgString)}`
+  );
+
+  const canvas = document.createElement("canvas");
+  canvas.width = (width + PADDING_PX * 2) * EXPORT_SCALE;
+  canvas.height = (height + TITLE_BAND_PX + PADDING_PX * 2) * EXPORT_SCALE;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) {
+    throw new Error("Canvas 2D rendering is not available in this browser.");
+  }
+
+  ctx.fillStyle = "#FFFFFF";
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+  if (title) {
+    drawTitle(ctx, title, canvas.width - PADDING_PX * 2 * EXPORT_SCALE);
+  }
+  ctx.drawImage(
+    image,
+    PADDING_PX * EXPORT_SCALE,
+    (TITLE_BAND_PX + PADDING_PX) * EXPORT_SCALE,
+    width * EXPORT_SCALE,
+    height * EXPORT_SCALE
+  );
+
+  const blob = await canvasToBlob(canvas);
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = chartImageFilename(title);
+  link.click();
+  URL.revokeObjectURL(url);
+}


### PR DESCRIPTION
Part 5 of 6 — split from #537. Depends on #543 (chart-widget) — base branch set accordingly so the diff is clean.


<img width="720" height="720" alt="chrome-capture-2026-06-16" src="https://github.com/user-attachments/assets/a554ddf3-815c-47bb-a292-dedf127b510a" />

## Changes

**New `exportChartImage.ts` utility**
- Rasterizes the live chart (SVG + HTML legend) via `foreignObject` with inlined computed styles, drawn to a 2× canvas with the title; errors surface as a toast

**`WidgetMessage.tsx`**
- Fit y-axis toggle (axis-break icon, `aria-pressed`) for line/area/scatter; wires up the `fitYAxis` prop added in #543
- Download caret opens a real menu: Data (CSV) and Chart image (PNG via `exportChartImage`)
- Fullscreen dialog uses expanded real estate: chart alongside a side panel with the insight narrative, analysis parameter chips, dataset name, and AI disclaimer
- Chart/Table segmented control carries `aria-pressed`

## Merge order
Merge #540 → #543 first, then merge this. #E-insight-workspace (#544) is independent of this PR.