### PR TITLE
feat(insight-workspace): insight transitions, arrow-key navigation, live counter

### DIFF
--- a/app/components/InsightWorkspace.tsx
+++ b/app/components/InsightWorkspace.tsx
@@ -56,7 +56,8 @@ export default function InsightWorkspace() {
   if (total === 0) return null;
 
   // currentIndex 0 = newest, total-1 = oldest
-  const widget = insights[total - 1 - currentIndex];
+  const widgetIndex = total - 1 - currentIndex;
+  const widget = insights[widgetIndex];
   const chips = widget.analysisParams ? buildChips(widget.analysisParams) : [];
   const hasChips = chips.length > 0;
   // currentIndex 0 = newest (shown as "1 of N"). The Left/Prev arrow
@@ -64,6 +65,20 @@ export default function InsightWorkspace() {
   const canGoPrev = currentIndex > 0;
   const canGoNext = currentIndex < total - 1;
   const HeaderIcon = WidgetIconComponent[widget.type];
+
+  // Arrow keys page through insights while focus is anywhere in the card,
+  // mirroring the prev/next buttons. Charts/menus don't consume arrows, so
+  // this doesn't conflict with inner widgets.
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (total <= 1) return;
+    if (e.key === "ArrowLeft" && canGoPrev) {
+      e.preventDefault();
+      setCurrentIndex((i) => i - 1);
+    } else if (e.key === "ArrowRight" && canGoNext) {
+      e.preventDefault();
+      setCurrentIndex((i) => i + 1);
+    }
+  };
 
   return (
     /* Card is the scroll container: grows to content, scrolls when flex-shrunk */
@@ -79,6 +94,7 @@ export default function InsightWorkspace() {
       pointerEvents="all"
       display="flex"
       flexDirection="column"
+      onKeyDown={handleKeyDown}
     >
       {/* Header — sticky so it never scrolls away */}
       <Flex
@@ -156,43 +172,56 @@ export default function InsightWorkspace() {
 
       {!isCollapsed && (
         <>
-          {/* Title row */}
-          <Flex
-            px={4}
-            py={1}
-            justify="space-between"
-            align="flex-start"
-            borderBottom="1px solid"
-            borderColor="#DDE2F5"
+          {/* Keyed on the active insight so switching re-runs the entry
+              animation; the media query keeps it off under reduced motion. */}
+          <Box
+            key={widget.id ?? widgetIndex}
+            css={{
+              "@media (prefers-reduced-motion: no-preference)": {
+                animationName: "fadeSlideIn",
+                animationDuration: "240ms",
+                animationTimingFunction: "ease-out",
+              },
+            }}
           >
-            <Heading
-              size="sm"
-              fontWeight="semibold"
-              color="primary.fg"
-              flex={1}
-              mr={2}
-              mb={0}
+            {/* Title row */}
+            <Flex
+              px={4}
+              py={1}
+              justify="space-between"
+              align="flex-start"
+              borderBottom="1px solid"
+              borderColor="#DDE2F5"
             >
-              {widget.title}
-            </Heading>
-            {hasChips && (
-              <AnalysisParametersToggle
-                expanded={paramsExpanded}
-                onToggle={() => setParamsExpanded((v) => !v)}
-              />
+              <Heading
+                size="sm"
+                fontWeight="semibold"
+                color="primary.fg"
+                flex={1}
+                mr={2}
+                mb={0}
+              >
+                {widget.title}
+              </Heading>
+              {hasChips && (
+                <AnalysisParametersToggle
+                  expanded={paramsExpanded}
+                  onToggle={() => setParamsExpanded((v) => !v)}
+                />
+              )}
+            </Flex>
+
+            {/* Params chips section */}
+            {hasChips && paramsExpanded && (
+              <Box px={4} py={2} borderBottom="1px solid" borderColor="#DDE2F5">
+                <AnalysisParamsChips chips={chips} />
+              </Box>
             )}
-          </Flex>
 
-          {/* Params chips section */}
-          {hasChips && paramsExpanded && (
-            <Box px={4} py={2} borderBottom="1px solid" borderColor="#DDE2F5">
-              <AnalysisParamsChips chips={chips} />
+            {/* Inner chart card */}
+            <Box px={2} py={2}>
+              <WidgetMessage widget={widget} inWorkspace />
             </Box>
-          )}
-
-          {/* Inner chart card */}
-          <Box px={2} py={2}>
-            <WidgetMessage widget={widget} inWorkspace />
           </Box>
 
           {/* Navigation footer — sticky so it never scrolls away */}
@@ -209,31 +238,40 @@ export default function InsightWorkspace() {
               justify="space-between"
               align="center"
             >
-              <IconButton
-                size="xs"
-                variant="ghost"
-                border="1px solid"
-                borderColor="border.emphasized"
-                aria-label="Previous insight"
-                disabled={!canGoPrev}
-                onClick={() => setCurrentIndex((i) => i - 1)}
+              <Tooltip content="Previous insight (←)" openDelay={400}>
+                <IconButton
+                  size="xs"
+                  variant="ghost"
+                  border="1px solid"
+                  borderColor="border.emphasized"
+                  aria-label="Previous insight"
+                  disabled={!canGoPrev}
+                  onClick={() => setCurrentIndex((i) => i - 1)}
+                >
+                  <ArrowArcLeftIcon size={14} />
+                </IconButton>
+              </Tooltip>
+              <Text
+                fontSize="xs"
+                color="neutral.500"
+                aria-live="polite"
+                css={{ fontVariantNumeric: "tabular-nums" }}
               >
-                <ArrowArcLeftIcon size={14} />
-              </IconButton>
-              <Text fontSize="xs" color="neutral.500">
                 {currentIndex + 1} of {total} available analyses
               </Text>
-              <IconButton
-                size="xs"
-                variant="ghost"
-                border="1px solid"
-                borderColor="border.emphasized"
-                aria-label="Next insight"
-                disabled={!canGoNext}
-                onClick={() => setCurrentIndex((i) => i + 1)}
-              >
-                <ArrowArcRightIcon size={14} />
-              </IconButton>
+              <Tooltip content="Next insight (→)" openDelay={400}>
+                <IconButton
+                  size="xs"
+                  variant="ghost"
+                  border="1px solid"
+                  borderColor="border.emphasized"
+                  aria-label="Next insight"
+                  disabled={!canGoNext}
+                  onClick={() => setCurrentIndex((i) => i + 1)}
+                >
+                  <ArrowArcRightIcon size={14} />
+                </IconButton>
+              </Tooltip>
             </Flex>
           )}
         </>

--- a/app/theme/index.tsx
+++ b/app/theme/index.tsx
@@ -29,6 +29,10 @@ export const config = defineConfig({
         "0%": { backgroundPositionX: "100%" },
         "100%": { backgroundPositionX: "-100%" },
       },
+      fadeSlideIn: {
+        from: { opacity: 0, transform: "translateY(4px)" },
+        to: { opacity: 1, transform: "translateY(0)" },
+      },
       dynamicSlideLeft: {
         from: {
           transform: "translateX(var(--start-x))",


### PR DESCRIPTION
Part 6 of 6 — split from #537. Depends on #543 (chart-widget for `usePrefersReducedMotion`) — base branch set accordingly so the diff is clean.

## Changes

**`theme/index.tsx`**
- New `fadeSlideIn` keyframe for insight entry animation

**`InsightWorkspace.tsx`**
- Active insight fades/slides in on change (gated by `usePrefersReducedMotion` from #543)
- Left/right arrow keys page through insights while focus is in the card
- Nav buttons gain keyboard-hint tooltips
- Counter is an `aria-live` region with tabular numerals

## Merge order
Merge #540 → #543 first, then merge this. #D-widget-message (#544) is independent of this PR.