### PR TITLE
Onboarding debugger

### DIFF
--- a/app/components/DebugToastsPanel.tsx
+++ b/app/components/DebugToastsPanel.tsx
@@ -9,6 +9,7 @@ import {
   CaretDownIcon,
   CaretUpIcon,
   ChartBarIcon,
+  UserPlusIcon,
 } from "@phosphor-icons/react";
 import {
   showApiError,
@@ -292,7 +293,29 @@ function DebugToastsPanel({ enabled }: { enabled?: boolean }) {
         </Box>
       </Stack>
 
-      <Box borderTop="1px solid" borderColor="#E0E2E5" mt="2" pt="2">
+      <Stack
+        direction="column"
+        gap="1"
+        align="flex-start"
+        borderTop="1px solid"
+        borderColor="#E0E2E5"
+        mt="2"
+        pt="2"
+      >
+        {/* Offline mirror: real form with mock config, no API/auth. */}
+        <Link
+          as={NextLink}
+          href="/onboarding-debug"
+          fontSize="2xs"
+          color="gray.500"
+          _hover={{ color: "gray.800" }}
+          display="inline-flex"
+          alignItems="center"
+          gap="1"
+        >
+          <UserPlusIcon size={10} />
+          Go to Onboarding debugger →
+        </Link>
         <Link
           as={NextLink}
           href="/chart-debug"
@@ -306,7 +329,7 @@ function DebugToastsPanel({ enabled }: { enabled?: boolean }) {
           <ChartBarIcon size={10} />
           Go to Chart debugger →
         </Link>
-      </Box>
+      </Stack>
     </Box>
   );
 

--- a/app/onboarding-debug/page.tsx
+++ b/app/onboarding-debug/page.tsx
@@ -1,0 +1,70 @@
+import { Suspense } from "react";
+import { notFound } from "next/navigation";
+import OnboardingForm, { type ProfileConfig } from "@/app/onboarding/form";
+
+export const metadata = {
+  title: "Onboarding Debug",
+  robots: "noindex, nofollow",
+};
+
+// Representative mock so every control renders populated without the API.
+// Kept here (not fetched) so this page stays fully offline.
+const MOCK_PROFILE_CONFIG: ProfileConfig = {
+  sectors: {
+    government: "Government",
+    ngo: "NGO / Non-profit",
+    academia: "Academia / Research",
+    private: "Private sector",
+    media: "Media",
+  },
+  sector_roles: {
+    government: { analyst: "Analyst", policy_maker: "Policy maker" },
+    ngo: { program_manager: "Program manager", field_officer: "Field officer" },
+    academia: { researcher: "Researcher", student: "Student" },
+    private: { consultant: "Consultant", executive: "Executive" },
+    media: { journalist: "Journalist", editor: "Editor" },
+  },
+  countries: {
+    BRA: "Brazil",
+    COD: "Democratic Republic of the Congo",
+    IDN: "Indonesia",
+    KEN: "Kenya",
+    GBR: "United Kingdom",
+    USA: "United States",
+  },
+  languages: {
+    en: "English",
+    fr: "Français",
+    es: "Español",
+    pt: "Português",
+    id: "Bahasa Indonesia",
+  },
+  gis_expertise_levels: {
+    none: "No experience",
+    basic: "Basic",
+    intermediate: "Intermediate",
+    advanced: "Advanced",
+  },
+  topics: {
+    deforestation: "Deforestation",
+    fires: "Fires",
+    biodiversity: "Biodiversity",
+    carbon: "Carbon emissions",
+    water: "Water",
+    restoration: "Restoration",
+  },
+};
+
+// Debug-only mirror of /onboarding that renders the real form with mock data
+// and no API/auth — for visual review of the page, content, and form offline.
+export default function OnboardingDebugPage() {
+  if (process.env.NEXT_PUBLIC_ENABLE_DEBUG_TOOLS !== "true") {
+    notFound();
+  }
+
+  return (
+    <Suspense fallback={null}>
+      <OnboardingForm previewConfig={MOCK_PROFILE_CONFIG} />
+    </Suspense>
+  );
+}

--- a/app/onboarding/form.tsx
+++ b/app/onboarding/form.tsx
@@ -28,8 +28,9 @@ import { showApiError } from "@/app/hooks/useErrorHandler";
 import LclLogo from "../components/LclLogo";
 import { ArrowLeftIcon } from "@phosphor-icons/react";
 import { apiFetch } from "@/app/lib/api-client";
+import { toaster } from "@/app/components/ui/toaster";
 
-type ProfileConfig = {
+export type ProfileConfig = {
   sectors: Record<string, string>;
   sector_roles: Record<string, Record<string, string>>;
   countries: Record<string, string>;
@@ -57,11 +58,19 @@ type ProfileFormState = {
 
 type ValueChangeDetails = { value: string[] };
 
-export default function OnboardingForm() {
+export default function OnboardingForm({
+  // Debug-only: when provided, the form renders from this mock config instead
+  // of fetching from the API, and submit is disabled. See /onboarding-debug.
+  previewConfig,
+}: {
+  previewConfig?: ProfileConfig;
+}) {
   const router = useRouter();
   const searchParams = useSearchParams();
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const [config, setConfig] = useState<ProfileConfig | null>(null);
+  const [config, setConfig] = useState<ProfileConfig | null>(
+    previewConfig ?? null
+  );
   const fieldRequired = isOnboardingFieldRequired;
   const schema = useMemo(() => getOnboardingFormSchema(), []);
   const [form, setForm] = useState<ProfileFormState>({
@@ -83,6 +92,11 @@ export default function OnboardingForm() {
 
   // Prefill email if available from auth
   useEffect(() => {
+    // Offline preview: seed a sample email instead of calling the API.
+    if (previewConfig) {
+      setForm((prev) => ({ ...prev, email: "you@example.org" }));
+      return;
+    }
     const fetchMe = async () => {
       try {
         const res = await apiFetch("/api/auth/me");
@@ -98,12 +112,13 @@ export default function OnboardingForm() {
       }
     };
     fetchMe();
-  }, []);
+  }, [previewConfig]);
 
   // Opt-in fields are optional and not prefilled
 
   // Fetch dropdown configuration
   useEffect(() => {
+    if (previewConfig) return; // config is already seeded from the prop
     const fetchConfig = async () => {
       try {
         const res = await apiFetch("/api/profile/config");
@@ -116,7 +131,7 @@ export default function OnboardingForm() {
       }
     };
     fetchConfig();
-  }, []);
+  }, [previewConfig]);
 
   const sectors = useMemo(() => {
     const items = config
@@ -180,6 +195,16 @@ export default function OnboardingForm() {
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
+    if (previewConfig) {
+      toaster.create({
+        title: "Offline preview",
+        description: "Submitting is disabled in the offline preview.",
+        type: "info",
+        duration: 3000,
+        closable: true,
+      });
+      return;
+    }
     if (!isValid || isSubmitting) return;
     setIsSubmitting(true);
     try {


### PR DESCRIPTION
Adds a debug-only, offline view of the onboarding page for visual QA of the page, content, and form. No API or auth required, mirroring `/chart-debug`

## Changes
- New `/onboarding-debug` route — 404 unless `NEXT_PUBLIC_ENABLE_DEBUG_TOOLS=true`; renders the real `OnboardingForm` with mock config, no auth guard.
- `OnboardingForm` gains an optional `previewConfig` prop: when set, it skips the `/api/auth/me` and `/api/profile/config` fetches and disables submit. Default `undefined` → the live `/onboarding` page is unchanged.
- Adds a "Go to Onboarding debugger" link to the map debug panel. 

<img width="314" height="352" alt="Screenshot 2026-06-22 at 15 51 22" src="https://github.com/user-attachments/assets/c7d020e3-a2be-4e63-9258-5bb0f55a84c7" />
