### PR TITLE
User can explore Dataset catalogue

### DIFF
--- a/app/ChatPanelCompact.tsx
+++ b/app/ChatPanelCompact.tsx
@@ -9,8 +9,10 @@ import ChatPanelHeader from "./ChatPanelHeader";
 import ChatPanelDisclaimer from "./ChatPanelDisclaimer";
 import PromptQuotaNotice from "./PromptQuotaNotice";
 import { chatPanelCardStyle } from "./chatPanelShared";
+import { getCompactChatLeftPx } from "./explorationLayout";
 import { usePromptQuota } from "./hooks/usePromptQuota";
 import useChatStore from "./store/chatStore";
+import useSidebarStore from "./store/sidebarStore";
 import { useState, useEffect, useRef, useCallback } from "react";
 
 // Intentionally narrower than the full-size panel (see FULLSIZE_PANEL_WIDTH).
@@ -36,6 +38,8 @@ interface ChatPanelCompactProps {
 function ChatPanelCompact({ onToggleSize }: ChatPanelCompactProps) {
   const { promptsExhausted } = usePromptQuota();
   const { messages } = useChatStore();
+  const { dataCatalogOpen } = useSidebarStore();
+  const chatLeftPx = getCompactChatLeftPx(dataCatalogOpen);
   const hasConversation = messages.some(
     (m) => m.type === "user" || m.type === "assistant"
   );
@@ -97,7 +101,8 @@ function ChatPanelCompact({ onToggleSize }: ChatPanelCompactProps) {
       h="100%"
       pt={2}
       pb={1}
-      pl={{ base: 0, md: 3 }}
+      pl={{ base: 0, md: `${chatLeftPx}px` }}
+      transition="padding-left 0.2s ease-in-out"
       pointerEvents="none"
     >
       <Flex

--- a/app/ChatPanelCompact.tsx
+++ b/app/ChatPanelCompact.tsx
@@ -9,14 +9,16 @@ import ChatPanelHeader from "./ChatPanelHeader";
 import ChatPanelDisclaimer from "./ChatPanelDisclaimer";
 import PromptQuotaNotice from "./PromptQuotaNotice";
 import { chatPanelCardStyle } from "./chatPanelShared";
-import { getCompactChatLeftPx } from "./explorationLayout";
+import {
+  COMPACT_CHAT_PANEL_WIDTH_PX,
+  getCompactChatLeftPx,
+} from "./explorationLayout";
 import { usePromptQuota } from "./hooks/usePromptQuota";
 import useChatStore from "./store/chatStore";
 import useSidebarStore from "./store/sidebarStore";
 import { useState, useEffect, useRef, useCallback } from "react";
 
-// Intentionally narrower than the full-size panel (see FULLSIZE_PANEL_WIDTH).
-const PANEL_WIDTH = 400;
+// Intentionally narrower than the full-size panel (see FULLSIZE_CHAT_PANEL_WIDTH_PX).
 
 // Cap the scrollable message list at ~50vh per design (~440px on a 900px-tall
 // viewport). The compact panel is bottom-anchored and grows upward, so when the
@@ -27,7 +29,7 @@ const MESSAGES_MAX_VH = 0.5;
 const DISCLAIMER_CLEARANCE = 12; // px of breathing room below the disclaimer
 
 const cardStyle = {
-  w: { base: "full", md: `${PANEL_WIDTH}px` } as const,
+  w: { base: "full", md: `${COMPACT_CHAT_PANEL_WIDTH_PX}px` } as const,
   ...chatPanelCardStyle,
 };
 
@@ -108,7 +110,7 @@ function ChatPanelCompact({ onToggleSize }: ChatPanelCompactProps) {
       <Flex
         flexDir="column"
         gap="0.5"
-        w={{ base: "full", md: `${PANEL_WIDTH}px` }}
+        w={{ base: "full", md: `${COMPACT_CHAT_PANEL_WIDTH_PX}px` }}
         pointerEvents="auto"
       >
         {/* Top card: header + content */}

--- a/app/ChatPanelFullSize.tsx
+++ b/app/ChatPanelFullSize.tsx
@@ -8,11 +8,9 @@ import ChatPanelHeader from "./ChatPanelHeader";
 import ChatPanelDisclaimer from "./ChatPanelDisclaimer";
 import PromptQuotaNotice from "./PromptQuotaNotice";
 import { chatPanelCardStyle } from "./chatPanelShared";
+import { FULLSIZE_CHAT_PANEL_WIDTH_PX } from "./explorationLayout";
 import { usePromptQuota } from "./hooks/usePromptQuota";
 import useSidebarStore from "./store/sidebarStore";
-
-// Intentionally wider than the compact panel (see COMPACT_PANEL_WIDTH).
-const FULLSIZE_PANEL_WIDTH = 428;
 
 interface ChatPanelFullSizeProps {
   onToggleSize: () => void;
@@ -28,7 +26,7 @@ function ChatPanelFullSize({ onToggleSize }: ChatPanelFullSizeProps) {
       flex="1 1 auto"
       minH={0}
       h="100%"
-      w={{ base: "full", md: `${FULLSIZE_PANEL_WIDTH}px` }}
+      w={{ base: "full", md: `${FULLSIZE_CHAT_PANEL_WIDTH_PX}px` }}
       {...chatPanelCardStyle}
       borderRightWidth={{ base: 0, md: dataCatalogOpen ? 0 : "1px" }}
       pointerEvents="auto"

--- a/app/ChatPanelFullSize.tsx
+++ b/app/ChatPanelFullSize.tsx
@@ -9,6 +9,7 @@ import ChatPanelDisclaimer from "./ChatPanelDisclaimer";
 import PromptQuotaNotice from "./PromptQuotaNotice";
 import { chatPanelCardStyle } from "./chatPanelShared";
 import { usePromptQuota } from "./hooks/usePromptQuota";
+import useSidebarStore from "./store/sidebarStore";
 
 // Intentionally wider than the compact panel (see COMPACT_PANEL_WIDTH).
 const FULLSIZE_PANEL_WIDTH = 428;
@@ -19,6 +20,7 @@ interface ChatPanelFullSizeProps {
 
 function ChatPanelFullSize({ onToggleSize }: ChatPanelFullSizeProps) {
   const { promptsExhausted } = usePromptQuota();
+  const { dataCatalogOpen } = useSidebarStore();
 
   return (
     <Flex
@@ -28,6 +30,7 @@ function ChatPanelFullSize({ onToggleSize }: ChatPanelFullSizeProps) {
       h="100%"
       w={{ base: "full", md: `${FULLSIZE_PANEL_WIDTH}px` }}
       {...chatPanelCardStyle}
+      borderRightWidth={{ base: 0, md: dataCatalogOpen ? 0 : "1px" }}
       pointerEvents="auto"
     >
       <ChatPanelHeader

--- a/app/__tests__/explorationLayout.test.ts
+++ b/app/__tests__/explorationLayout.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect } from "vitest";
 import {
   getCompactChatLeftPx,
   getDataCatalogLeftPx,
+  getMapAreaToolsLeftPx,
   getMapControlsLeftPx,
 } from "@/app/explorationLayout";
 
@@ -29,6 +30,18 @@ describe("explorationLayout", () => {
 
   it("offsets map controls past the pushed compact chat when the catalog is open", () => {
     expect(getMapControlsLeftPx(false, true)).toBe(816);
+  });
+
+  it("offsets area tools beside the catalog when compact chat and catalog are open", () => {
+    expect(getMapAreaToolsLeftPx(false, true)).toBe(396);
+  });
+
+  it("keeps area tools flush left when compact chat is open without catalog", () => {
+    expect(getMapAreaToolsLeftPx(false, false)).toBe(0);
+  });
+
+  it("offsets area tools past the full-size chat when the catalog is closed", () => {
+    expect(getMapAreaToolsLeftPx(true, false)).toBe(436);
   });
 
   it("offsets map controls past the full-size chat when the catalog is closed", () => {

--- a/app/__tests__/explorationLayout.test.ts
+++ b/app/__tests__/explorationLayout.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  getCompactChatLeftPx,
+  getDataCatalogLeftPx,
+  getMapControlsLeftPx,
+} from "@/app/explorationLayout";
+
+describe("explorationLayout", () => {
+  it("docks the catalog flush left when chat is compact", () => {
+    expect(getDataCatalogLeftPx(false)).toBe(0);
+  });
+
+  it("docks the catalog flush against the full-size chat panel", () => {
+    expect(getDataCatalogLeftPx(true)).toBe(428);
+  });
+
+  it("keeps the compact chat inset when the catalog is closed", () => {
+    expect(getCompactChatLeftPx(false)).toBe(12);
+  });
+
+  it("pushes the compact chat right when the catalog is open", () => {
+    expect(getCompactChatLeftPx(true)).toBe(408);
+  });
+
+  it("offsets map controls past the compact chat panel when the catalog is closed", () => {
+    expect(getMapControlsLeftPx(false, false)).toBe(420);
+  });
+
+  it("offsets map controls past the pushed compact chat when the catalog is open", () => {
+    expect(getMapControlsLeftPx(false, true)).toBe(816);
+  });
+
+  it("offsets map controls past the full-size chat when the catalog is closed", () => {
+    expect(getMapControlsLeftPx(true, false)).toBe(436);
+  });
+
+  it("offsets map controls past chat and catalog in full-size mode", () => {
+    expect(getMapControlsLeftPx(true, true)).toBe(836);
+  });
+});

--- a/app/app/(chat)/layout.tsx
+++ b/app/app/(chat)/layout.tsx
@@ -13,6 +13,7 @@ import { useEffect, useState } from "react";
 import ChatPanel from "@/app/ChatPanel";
 import UploadAreaDialog from "@/app/components/UploadAreaDialog";
 import Map from "@/app/components/Map";
+import DataCatalogPanel from "@/app/components/DataCatalogPanel";
 import { Sidebar } from "@/app/sidebar";
 import PageHeader from "@/app/components/PageHeader";
 import WhatsNewModal from "@/app/components/WhatsNewModal";
@@ -47,6 +48,17 @@ export default function DashboardLayout({
       display={{ base: "none", md: "block" }}
     >
       <Map />
+      <Box
+        position="absolute"
+        top={0}
+        bottom={0}
+        left={0}
+        zIndex={1095}
+        pointerEvents="none"
+        display={{ base: "none", md: "block" }}
+      >
+        <DataCatalogPanel />
+      </Box>
       <Box
         position="absolute"
         top={0}

--- a/app/components/ChatInput.tsx
+++ b/app/components/ChatInput.tsx
@@ -16,6 +16,7 @@ import ContextButton, { ChatContextType } from "./ContextButton";
 import ContextTag from "./ContextTag";
 import ContextMenu from "./ContextMenu";
 import useContextStore from "../store/contextStore";
+import useSidebarStore from "../store/sidebarStore";
 import { useRouter } from "next/navigation";
 
 export default function ChatInput({
@@ -49,10 +50,19 @@ export default function ChatInput({
   const { sendMessage, isLoading, cancelRequest, abortController, messages } =
     useChatStore();
   const { context, removeContext } = useContextStore();
+  const { dataCatalogOpen, toggleDataCatalog } = useSidebarStore();
 
   const openContextMenu = (type: ChatContextType) => {
     setSelectedContextType(type);
     setContextModalOpen(true);
+  };
+
+  const openLayerPicker = () => {
+    if (isMobile) {
+      openContextMenu("layer");
+      return;
+    }
+    toggleDataCatalog();
   };
 
   const handleContextModalOpenChange = (e: { open: boolean }) => {
@@ -171,8 +181,11 @@ export default function ChatInput({
         <Flex gap="2">
           <ContextButton
             contextType="layer"
-            onClick={() => openContextMenu("layer")}
+            onClick={openLayerPicker}
             disabled={disabled}
+            borderColor={dataCatalogOpen ? "primary.solid" : "#E0E2E5"}
+            color={dataCatalogOpen ? "primary.solid" : undefined}
+            aria-expanded={dataCatalogOpen}
           />
           <ContextButton
             contextType="area"
@@ -280,9 +293,10 @@ export default function ChatInput({
               contextType="layer"
               onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
                 e.stopPropagation();
-                openContextMenu("layer");
+                openLayerPicker();
               }}
               disabled={disabled}
+              aria-expanded={dataCatalogOpen}
             />
             <ContextButton
               contextType="area"

--- a/app/components/ChatInput.tsx
+++ b/app/components/ChatInput.tsx
@@ -296,7 +296,11 @@ export default function ChatInput({
                 openLayerPicker();
               }}
               disabled={disabled}
-              aria-expanded={dataCatalogOpen}
+              aria-expanded={
+                isMobile
+                  ? contextModalOpen && selectedContextType === "layer"
+                  : dataCatalogOpen
+              }
             />
             <ContextButton
               contextType="area"

--- a/app/components/ContextMenu.tsx
+++ b/app/components/ContextMenu.tsx
@@ -42,10 +42,16 @@ const LAYER_CARDS = DATASET_CARDS;
 function ContextNav({
   selected,
   onSelect,
+  hiddenTypes = [],
 }: {
   selected: string;
   onSelect: (type: ChatContextType) => void;
+  hiddenTypes?: ChatContextType[];
 }) {
+  const navItems = CONTEXT_NAV.filter((nav) => !hiddenTypes.includes(nav.type));
+
+  if (navItems.length === 0) return null;
+
   return (
     <Stack
       direction={{ base: "row", md: "column" }}
@@ -58,7 +64,7 @@ function ContextNav({
       borderRightWidth={{ base: "none", md: "1px solid" }}
       borderRightColor="border.emphasized"
     >
-      {CONTEXT_NAV.map((nav) => (
+      {navItems.map((nav) => (
         <Button
           key={nav.type}
           size="xs"
@@ -167,6 +173,7 @@ function ContextMenu({
               <ContextNav
                 selected={selectedContextType}
                 onSelect={setSelectedContextType}
+                hiddenTypes={contextType === "area" ? ["layer"] : []}
               />
               {/* Modal Body */}
               {selectedContextType === "layer" && <LayerMenu />}

--- a/app/components/DataCatalogCard.tsx
+++ b/app/components/DataCatalogCard.tsx
@@ -1,0 +1,157 @@
+"use client";
+
+import { Box, Flex, IconButton, Switch, Text } from "@chakra-ui/react";
+import { InfoIcon } from "@phosphor-icons/react";
+import type { ReactNode } from "react";
+
+import {
+  DATA_CATALOG_CARD_HEIGHT_PX,
+  DATA_CATALOG_CARD_WIDTH_PX,
+} from "@/app/explorationLayout";
+
+import { Tooltip } from "./ui/tooltip";
+
+export interface DataCatalogCardProps {
+  thumbnail: ReactNode;
+  typeLabel?: string;
+  typeLabelColor?: string;
+  title: string;
+  description?: string;
+  selected?: boolean;
+  showOnMap: boolean;
+  onShowOnMapChange: (checked: boolean) => void;
+  onInfoClick: () => void;
+}
+
+/**
+ * Dataset card for the data-catalog panel — taller than the shared InfoCard,
+ * with metadata stacked above a divider and a labelled show-on-map toggle.
+ */
+export function DataCatalogCard({
+  thumbnail,
+  typeLabel = "DATA",
+  typeLabelColor = "#1AA915",
+  title,
+  description,
+  selected = false,
+  showOnMap,
+  onShowOnMapChange,
+  onInfoClick,
+}: DataCatalogCardProps) {
+  return (
+    <Flex
+      w={`${DATA_CATALOG_CARD_WIDTH_PX}px`}
+      maxW="100%"
+      h={`${DATA_CATALOG_CARD_HEIGHT_PX}px`}
+      flexShrink={0}
+      bg="#FFFFFF"
+      border={selected ? "2px solid" : "1px solid"}
+      borderColor={selected ? "primary.solid" : "rgba(19, 22, 25, 0.3)"}
+      borderRadius="4px"
+      overflow="hidden"
+      transition="border-color 0.16s ease"
+    >
+      <Flex
+        w="96px"
+        h="100%"
+        flexShrink={0}
+        bg="#FFFFFF"
+        borderRight="1px solid rgba(19, 22, 25, 0.1)"
+        overflow="hidden"
+      >
+        {thumbnail}
+      </Flex>
+      <Flex flex="1" flexDirection="column" minW={0} h="100%">
+        <Box flex="1" px="16px" pt="12px" pb="8px" minW={0} minH={0}>
+          {typeLabel && (
+            <Text
+              fontFamily="mono"
+              fontSize="10px"
+              fontWeight="normal"
+              lineHeight="16px"
+              letterSpacing="0.5px"
+              color={typeLabelColor}
+              textTransform="uppercase"
+            >
+              {typeLabel}
+            </Text>
+          )}
+          <Flex align="center" gap="8px" mt="2px" minW={0}>
+            <Text
+              flex="1"
+              minW={0}
+              fontFamily="body"
+              fontSize="12px"
+              fontWeight="semibold"
+              lineHeight="150%"
+              color="#3A4048"
+              whiteSpace="nowrap"
+              overflow="hidden"
+              textOverflow="ellipsis"
+            >
+              {title}
+            </Text>
+            <Tooltip
+              content="Show dataset info"
+              positioning={{ placement: "top" }}
+              showArrow
+              variant="dark"
+            >
+              <IconButton
+                aria-label={`Show ${title} info`}
+                size="2xs"
+                variant="ghost"
+                color="#656E7B"
+                flexShrink={0}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onInfoClick();
+                }}
+              >
+                <InfoIcon size={16} />
+              </IconButton>
+            </Tooltip>
+          </Flex>
+          {description && (
+            <Text
+              mt="2px"
+              fontFamily="mono"
+              fontSize="10px"
+              fontWeight="normal"
+              lineHeight="16px"
+              color="#656E7B"
+              whiteSpace="nowrap"
+              overflow="hidden"
+              textOverflow="ellipsis"
+            >
+              {description}
+            </Text>
+          )}
+        </Box>
+        <Box borderTop="1px solid" borderColor="rgba(19, 22, 25, 0.1)" />
+        <Flex align="center" gap="8px" px="16px" py="10px" flexShrink={0}>
+          <Switch.Root
+            size="sm"
+            checked={showOnMap}
+            onCheckedChange={(e: { checked: boolean }) =>
+              onShowOnMapChange(e.checked)
+            }
+            colorPalette="primary"
+            flexShrink={0}
+            aria-label={
+              showOnMap ? `Hide ${title} from map` : `Show ${title} on map`
+            }
+          >
+            <Switch.HiddenInput />
+            <Switch.Control>
+              <Switch.Thumb bg="white" />
+            </Switch.Control>
+          </Switch.Root>
+          <Text fontFamily="body" fontSize="12px" color="#656E7B">
+            Show on map
+          </Text>
+        </Flex>
+      </Flex>
+    </Flex>
+  );
+}

--- a/app/components/DataCatalogPanel.tsx
+++ b/app/components/DataCatalogPanel.tsx
@@ -13,11 +13,12 @@ import {
   Wrap,
   useDisclosure,
 } from "@chakra-ui/react";
+import { AnimatePresence, motion } from "framer-motion";
 import {
   CircleHalfIcon,
   EyeIcon,
   EyeSlashIcon,
-  StackSimpleIcon,
+  StackPlusIcon,
   XIcon,
 } from "@phosphor-icons/react";
 import { useShallow } from "zustand/react/shallow";
@@ -44,6 +45,12 @@ import { filterDatasetsByCategory } from "@/app/utils/filterDatasetsByCategory";
 import { DataCatalogCard } from "./DataCatalogCard";
 import { DatasetInfoModal } from "./DatasetInfoModal";
 import { Tooltip } from "./ui/tooltip";
+
+/** Matches ChatPanel compact/full-size enter & exit (slide from the left). */
+const catalogPanelSlideTransition = {
+  duration: 0.2,
+  ease: "easeInOut",
+} as const;
 
 /** Scrollable list chrome: vertical scroll without visible scrollbars. */
 const catalogListScrollStyle = {
@@ -93,106 +100,143 @@ export default function DataCatalogPanel() {
     [category, activeDatasetIds]
   );
 
-  if (!dataCatalogOpen) {
-    return null;
-  }
+  const compactSlide = !isChatFullSize;
 
   return (
-    <Flex
-      position="absolute"
-      top={0}
-      bottom={0}
-      left={`${leftPx}px`}
-      w={`${DATA_CATALOG_PANEL_WIDTH_PX}px`}
-      minW={`${DATA_CATALOG_PANEL_WIDTH_PX}px`}
-      maxW={`${DATA_CATALOG_PANEL_WIDTH_PX}px`}
-      flexShrink={0}
-      zIndex={1095}
-      flexDirection="column"
-      pointerEvents="auto"
-      display={{ base: "none", md: "flex" }}
-      {...chatPanelCardStyle}
-      borderLeftWidth={{ base: 0, md: isChatFullSize ? "1px" : 0 }}
-      borderLeftColor="border.emphasized"
-      borderRadius={{
-        base: 0,
-        md: isChatFullSize ? "0 sm sm 0" : "sm",
-      }}
-    >
-      <Flex
-        flexShrink={0}
-        justifyContent="space-between"
-        alignItems="center"
-        px={3}
-        pt={6}
-        pb={3}
-        gap={2}
-      >
-        <Flex align="center" gap={2} minW={0}>
-          <StackSimpleIcon size={18} />
-          <Text
-            fontWeight="semibold"
-            fontSize="xs"
-            letterSpacing="0.08em"
-            textTransform="uppercase"
-            m={0}
+    <AnimatePresence>
+      {dataCatalogOpen && (
+        <motion.div
+          key="data-catalog-panel"
+          initial={compactSlide ? { opacity: 0, x: -16 } : false}
+          animate={{ opacity: 1, x: 0 }}
+          exit={compactSlide ? { opacity: 0, x: -16 } : { opacity: 0 }}
+          transition={catalogPanelSlideTransition}
+          style={{
+            position: "absolute",
+            top: 0,
+            bottom: 0,
+            left: leftPx,
+            zIndex: 1095,
+            pointerEvents: "auto",
+          }}
+        >
+          <Flex
+            h="100%"
+            w={`${DATA_CATALOG_PANEL_WIDTH_PX}px`}
+            minW={`${DATA_CATALOG_PANEL_WIDTH_PX}px`}
+            maxW={`${DATA_CATALOG_PANEL_WIDTH_PX}px`}
+            flexShrink={0}
+            flexDirection="column"
+            display={{ base: "none", md: "flex" }}
+            {...chatPanelCardStyle}
+            borderLeftWidth={{ base: 0, md: isChatFullSize ? "1px" : 0 }}
+            borderLeftColor="border.emphasized"
+            borderRadius={{
+              base: 0,
+              md: isChatFullSize ? "0 sm sm 0" : "sm",
+            }}
           >
-            Data catalog
-          </Text>
-        </Flex>
-        <IconButton
-          aria-label="Close data catalog"
-          variant="ghost"
-          size="xs"
-          onClick={() => setDataCatalogOpen(false)}
-        >
-          <XIcon size={16} />
-        </IconButton>
-      </Flex>
-      <Flex
-        flex={1}
-        minH={0}
-        minW={0}
-        flexDirection="column"
-        gap={3}
-        px={3}
-        pb={6}
-        overflow="hidden"
-      >
-        <Wrap gap={2} flexShrink={0} overflow="hidden">
-          {DATASET_CATEGORIES.map((cat) => (
-            <Button
-              key={cat.id}
-              size="xs"
-              variant={category === cat.id ? "solid" : "outline"}
-              colorPalette="primary"
-              borderRadius="full"
-              onClick={() => setCategory(cat.id)}
+            <Flex
+              flexShrink={0}
+              h="40px"
+              py="4px"
+              px={3}
+              justifyContent="space-between"
+              alignItems="center"
+              borderBottom="1px solid"
+              borderColor="#E0E2E5"
             >
-              {cat.label}
-            </Button>
-          ))}
-        </Wrap>
-        <Stack
-          gap={3}
-          flex={1}
-          minH={0}
-          minW={0}
-          pb={2}
-          css={catalogListScrollStyle}
-        >
-          {cards.length === 0 ? (
-            <Text fontSize="sm" color="fg.muted" mt={4}>
-              No datasets in this category yet.
-            </Text>
-          ) : (
-            cards.map((card) => (
-              <DataCatalogCardRow key={card.dataset_id} card={card} />
-            ))
-          )}
-        </Stack>
-      </Flex>
-    </Flex>
+              <Flex alignItems="center" gap="8px" minW={0}>
+                <StackPlusIcon size={16} color="#0049AA" />
+                <Text
+                  fontSize="10px"
+                  fontWeight="400"
+                  fontFamily="mono"
+                  lineHeight="16px"
+                  letterSpacing="0.03em"
+                  textTransform="uppercase"
+                  color="#656E7B"
+                  m={0}
+                >
+                  Data catalog
+                </Text>
+              </Flex>
+              <IconButton
+                aria-label="Close data catalog"
+                variant="ghost"
+                size="2xs"
+                p={0}
+                minW="16px"
+                h="16px"
+                w="16px"
+                color="#656E7B"
+                onClick={() => setDataCatalogOpen(false)}
+              >
+                <XIcon size={12} />
+              </IconButton>
+            </Flex>
+            <Flex
+              flex={1}
+              minH={0}
+              minW={0}
+              flexDirection="column"
+              gap={4}
+              pt={4}
+              px={3}
+              pb={6}
+              overflow="hidden"
+            >
+              <Wrap gap={1} flexShrink={0} overflow="hidden">
+                {DATASET_CATEGORIES.map((cat) => {
+                  const isActive = category === cat.id;
+                  return (
+                    <Button
+                      key={cat.id}
+                      h="24px"
+                      minH="24px"
+                      py="4px"
+                      px="8px"
+                      borderRadius="full"
+                      fontSize="12px"
+                      fontWeight="400"
+                      lineHeight="16px"
+                      bg={isActive ? "fg.link" : "neutral.300"}
+                      color={isActive ? "white" : "fg"}
+                      border="1px solid"
+                      borderColor={isActive ? "fg.link" : "neutral.300"}
+                      _hover={{
+                        bg: isActive ? "fg.link" : "neutral.400",
+                      }}
+                      onClick={() => setCategory(cat.id)}
+                    >
+                      {cat.label}
+                    </Button>
+                  );
+                })}
+              </Wrap>
+              <Stack
+                gap={4}
+                flex={1}
+                minH={0}
+                minW={0}
+                pb={2}
+                css={catalogListScrollStyle}
+              >
+                {cards.length === 0 ? (
+                  <Text fontSize="sm" color="fg.muted" mt={4}>
+                    No datasets in this category yet.
+                  </Text>
+                ) : (
+                  cards.map((card) => (
+                    <DataCatalogCardRow key={card.dataset_id} card={card} />
+                  ))
+                )}
+              </Stack>
+            </Flex>
+          </Flex>
+        </motion.div>
+      )}
+    </AnimatePresence>
   );
 }
 

--- a/app/components/DataCatalogPanel.tsx
+++ b/app/components/DataCatalogPanel.tsx
@@ -1,0 +1,347 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import {
+  Box,
+  Button,
+  Flex,
+  IconButton,
+  Image,
+  Slider,
+  Stack,
+  Text,
+  Wrap,
+  useDisclosure,
+} from "@chakra-ui/react";
+import {
+  CircleHalfIcon,
+  EyeIcon,
+  EyeSlashIcon,
+  StackSimpleIcon,
+  XIcon,
+} from "@phosphor-icons/react";
+import { useShallow } from "zustand/react/shallow";
+
+import {
+  DATASET_CARDS,
+  DATASET_CATEGORIES,
+  type DatasetCardConfig,
+  type DatasetCategoryId,
+} from "@/app/constants/datasets";
+import { chatPanelCardStyle } from "@/app/chatPanelShared";
+import {
+  DATA_CATALOG_CARD_WIDTH_PX,
+  DATA_CATALOG_PANEL_WIDTH_PX,
+  getDataCatalogLeftPx,
+} from "@/app/explorationLayout";
+import useContextStore from "@/app/store/contextStore";
+import useMapStore from "@/app/store/mapStore";
+import useSidebarStore from "@/app/store/sidebarStore";
+import type { DatasetInfo } from "@/app/types/chat";
+import { getLayerContextFromDatasetCard } from "@/app/utils/datasetCardLayerContext";
+import { filterDatasetsByCategory } from "@/app/utils/filterDatasetsByCategory";
+
+import { DataCatalogCard } from "./DataCatalogCard";
+import { DatasetInfoModal } from "./DatasetInfoModal";
+import { Tooltip } from "./ui/tooltip";
+
+/** Scrollable list chrome: vertical scroll without visible scrollbars. */
+const catalogListScrollStyle = {
+  overflowY: "auto",
+  overflowX: "hidden",
+  scrollbarWidth: "none",
+  "&::-webkit-scrollbar": { display: "none" },
+} as const;
+
+/**
+ * Slide-out panel that lets users browse the dataset catalogue and add or
+ * remove layers from the map directly — without going through the chat agent.
+ *
+ * Wired into the exploration layout as a left-side column: flush left when the
+ * chat panel is compact, and docked immediately to the right of the full-size
+ * chat panel.
+ *
+ * Wiring:
+ *  - Show-on-map switch ↔ `contextStore.addContext` / `removeContext` (the
+ *    contextStore already drives `mapStore.addLayer` for dataset layers).
+ *  - Visibility / opacity controls ↔ `mapStore.setLayerVisibility` and
+ *    `setLayerOpacity` on `dataset-${dataset_id}`.
+ *
+ * The existing legend reads from the same `mapStore.layers`, so any layer
+ * toggled here automatically appears in the legend with full functionality.
+ */
+export default function DataCatalogPanel() {
+  const [category, setCategory] = useState<DatasetCategoryId>("all");
+  const { dataCatalogOpen, setDataCatalogOpen, isChatFullSize } =
+    useSidebarStore();
+  const leftPx = getDataCatalogLeftPx(isChatFullSize);
+
+  // Build the "in this conversation" set from the context store. `useShallow`
+  // keeps re-renders stable across unrelated context changes (e.g. AOI edits).
+  const activeDatasetIds = useContextStore(
+    useShallow((s) =>
+      s.context
+        .filter(
+          (c) => c.contextType === "layer" && typeof c.datasetId === "number"
+        )
+        .map((c) => c.datasetId as number)
+    )
+  );
+
+  const cards = useMemo(
+    () => filterDatasetsByCategory(DATASET_CARDS, category, activeDatasetIds),
+    [category, activeDatasetIds]
+  );
+
+  if (!dataCatalogOpen) {
+    return null;
+  }
+
+  return (
+    <Flex
+      position="absolute"
+      top={0}
+      bottom={0}
+      left={`${leftPx}px`}
+      w={`${DATA_CATALOG_PANEL_WIDTH_PX}px`}
+      minW={`${DATA_CATALOG_PANEL_WIDTH_PX}px`}
+      maxW={`${DATA_CATALOG_PANEL_WIDTH_PX}px`}
+      flexShrink={0}
+      zIndex={1095}
+      flexDirection="column"
+      pointerEvents="auto"
+      display={{ base: "none", md: "flex" }}
+      {...chatPanelCardStyle}
+      borderLeftWidth={{ base: 0, md: isChatFullSize ? "1px" : 0 }}
+      borderLeftColor="border.emphasized"
+      borderRadius={{
+        base: 0,
+        md: isChatFullSize ? "0 sm sm 0" : "sm",
+      }}
+    >
+      <Flex
+        flexShrink={0}
+        justifyContent="space-between"
+        alignItems="center"
+        px={3}
+        pt={6}
+        pb={3}
+        gap={2}
+      >
+        <Flex align="center" gap={2} minW={0}>
+          <StackSimpleIcon size={18} />
+          <Text
+            fontWeight="semibold"
+            fontSize="xs"
+            letterSpacing="0.08em"
+            textTransform="uppercase"
+            m={0}
+          >
+            Data catalog
+          </Text>
+        </Flex>
+        <IconButton
+          aria-label="Close data catalog"
+          variant="ghost"
+          size="xs"
+          onClick={() => setDataCatalogOpen(false)}
+        >
+          <XIcon size={16} />
+        </IconButton>
+      </Flex>
+      <Flex
+        flex={1}
+        minH={0}
+        minW={0}
+        flexDirection="column"
+        gap={3}
+        px={3}
+        pb={6}
+        overflow="hidden"
+      >
+        <Wrap gap={2} flexShrink={0} overflow="hidden">
+          {DATASET_CATEGORIES.map((cat) => (
+            <Button
+              key={cat.id}
+              size="xs"
+              variant={category === cat.id ? "solid" : "outline"}
+              colorPalette="primary"
+              borderRadius="full"
+              onClick={() => setCategory(cat.id)}
+            >
+              {cat.label}
+            </Button>
+          ))}
+        </Wrap>
+        <Stack
+          gap={3}
+          flex={1}
+          minH={0}
+          minW={0}
+          pb={2}
+          css={catalogListScrollStyle}
+        >
+          {cards.length === 0 ? (
+            <Text fontSize="sm" color="fg.muted" mt={4}>
+              No datasets in this category yet.
+            </Text>
+          ) : (
+            cards.map((card) => (
+              <DataCatalogCardRow key={card.dataset_id} card={card} />
+            ))
+          )}
+        </Stack>
+      </Flex>
+    </Flex>
+  );
+}
+
+/**
+ * Single dataset row inside the catalogue: thumbnail + metadata + show-on-map
+ * switch, with an expanded controls row (visibility + opacity slider) shown
+ * only while the layer is on the map.
+ */
+function DataCatalogCardRow({ card }: { card: DatasetCardConfig }) {
+  const {
+    open: infoOpen,
+    onOpen: onInfoOpen,
+    onClose: onInfoClose,
+  } = useDisclosure();
+
+  const ctx = useContextStore(
+    useShallow((s) =>
+      s.context.find(
+        (c) => c.contextType === "layer" && c.datasetId === card.dataset_id
+      )
+    )
+  );
+  const addContext = useContextStore((s) => s.addContext);
+  const removeContext = useContextStore((s) => s.removeContext);
+
+  const layer = useMapStore(
+    useShallow((s) =>
+      s.layers.find((l) => l.id === `dataset-${card.dataset_id}`)
+    )
+  );
+  const setLayerVisibility = useMapStore((s) => s.setLayerVisibility);
+  const setLayerOpacity = useMapStore((s) => s.setLayerOpacity);
+
+  const isActive = !!ctx;
+  const isVisible = layer?.visible ?? true;
+  const opacity = Math.round((layer?.opacity ?? 1) * 100);
+
+  function handleToggle(checked: boolean) {
+    if (!checked) {
+      if (ctx) removeContext(ctx.id);
+      return;
+    }
+    addContext({
+      contextType: "layer",
+      ...getLayerContextFromDatasetCard(card),
+      isAiContext: false,
+    });
+  }
+
+  const dataset = card as unknown as DatasetInfo;
+  const cardText =
+    [card.cadence, card.geographic_coverage, card.provider]
+      .filter(Boolean)
+      .join(" · ") || undefined;
+
+  return (
+    <Box w={`${DATA_CATALOG_CARD_WIDTH_PX}px`} maxW="100%" flexShrink={0}>
+      <DatasetInfoModal
+        isOpen={infoOpen}
+        onClose={onInfoClose}
+        dataset={dataset}
+      />
+      <DataCatalogCard
+        thumbnail={
+          <Image
+            objectFit="cover"
+            w="100%"
+            h="100%"
+            src={card.img ?? "/globe.svg"}
+            alt={card.dataset_name}
+          />
+        }
+        typeLabel={card.viewOnly ? "VIEW ONLY" : "DATA"}
+        typeLabelColor={card.viewOnly ? "#656E7B" : "#1AA915"}
+        title={card.dataset_name}
+        description={cardText}
+        selected={isActive}
+        showOnMap={isActive}
+        onShowOnMapChange={handleToggle}
+        onInfoClick={onInfoOpen}
+      />
+      {isActive && layer && (
+        <Flex
+          align="center"
+          gap={2}
+          mt={1}
+          px={2}
+          py={2}
+          w="100%"
+          minW={0}
+          bg="bg.subtle"
+          borderRadius="4px"
+          border="1px solid"
+          borderColor="border"
+        >
+          <Tooltip
+            content={isVisible ? "Hide layer" : "Show layer"}
+            positioning={{ placement: "top" }}
+            showArrow
+            variant="dark"
+          >
+            <IconButton
+              aria-label={
+                isVisible
+                  ? `Hide ${card.dataset_name} layer`
+                  : `Show ${card.dataset_name} layer`
+              }
+              size="xs"
+              variant="ghost"
+              onClick={() => setLayerVisibility(layer.id, !isVisible)}
+            >
+              {isVisible ? <EyeIcon size={16} /> : <EyeSlashIcon size={16} />}
+            </IconButton>
+          </Tooltip>
+          <CircleHalfIcon size={14} color="#656E7B" />
+          <Slider.Root
+            flex="1"
+            minW={0}
+            size="sm"
+            value={[opacity]}
+            min={0}
+            max={100}
+            onValueChange={(v: { value: number[] }) =>
+              setLayerOpacity(layer.id, v.value[0] / 100)
+            }
+            // Chakra's Slider.Root expects string[] (one label per thumb);
+            // this conflicts with jsx-a11y/aria-proptypes which expects a
+            // plain string, so we suppress the lint rule for this prop.
+            // eslint-disable-next-line jsx-a11y/aria-proptypes
+            aria-label={[`${card.dataset_name} opacity`]}
+          >
+            <Slider.Control>
+              <Slider.Track>
+                <Slider.Range />
+              </Slider.Track>
+              <Slider.Thumb index={0} />
+            </Slider.Control>
+          </Slider.Root>
+          <Text
+            fontFamily="mono"
+            fontSize="10px"
+            color="fg.muted"
+            w="4ch"
+            textAlign="right"
+          >
+            {opacity}%
+          </Text>
+        </Flex>
+      )}
+    </Box>
+  );
+}

--- a/app/components/MapAreaControls.tsx
+++ b/app/components/MapAreaControls.tsx
@@ -32,6 +32,7 @@ import useContextStore from "../store/contextStore";
 import { BasemapSelector } from "./map/BasemapSelector";
 import { ScaleBar } from "./map/ScaleBar";
 import useSidebarStore from "../store/sidebarStore";
+import { getMapControlsLeftPx } from "../explorationLayout";
 import { FeatureRef } from "../store/layerManagerSlice";
 
 function Wrapper({
@@ -87,7 +88,8 @@ function MapAreaControls({
     mapRef,
   } = useMapStore();
   const { addContext } = useContextStore();
-  const { isChatFullSize } = useSidebarStore();
+  const { isChatFullSize, dataCatalogOpen } = useSidebarStore();
+  const mapControlsLeft = `${getMapControlsLeftPx(isChatFullSize, dataCatalogOpen)}px`;
 
   const { createAreaAsync, isCreating } = useCustomAreasCreate();
   const [showTools, setShowTools] = useState(false);
@@ -174,7 +176,7 @@ function MapAreaControls({
         display={{ base: "none", md: "flex" }}
         position="absolute"
         bottom={8}
-        left={{ base: 2, md: isChatFullSize ? "436px" : "416px" }}
+        left={{ base: 2, md: mapControlsLeft }}
         flexDirection="column"
         gap={1}
         pointerEvents="auto"
@@ -226,7 +228,12 @@ function MapAreaControls({
       </Flex>
       {/* Area tools: in full-size mode, anchor just right of the chat panel
           (aligned with the zoom/basemap controls above); otherwise top-left. */}
-      <Flex ml={{ base: 0, md: isChatFullSize ? "436px" : 0 }}>
+      <Flex
+        ml={{
+          base: 0,
+          md: dataCatalogOpen || isChatFullSize ? mapControlsLeft : 0,
+        }}
+      >
         <Button
           position="relative"
           variant="subtle"

--- a/app/components/MapAreaControls.tsx
+++ b/app/components/MapAreaControls.tsx
@@ -32,7 +32,10 @@ import useContextStore from "../store/contextStore";
 import { BasemapSelector } from "./map/BasemapSelector";
 import { ScaleBar } from "./map/ScaleBar";
 import useSidebarStore from "../store/sidebarStore";
-import { getMapControlsLeftPx } from "../explorationLayout";
+import {
+  getMapAreaToolsLeftPx,
+  getMapControlsLeftPx,
+} from "../explorationLayout";
 import { FeatureRef } from "../store/layerManagerSlice";
 
 function Wrapper({
@@ -90,6 +93,7 @@ function MapAreaControls({
   const { addContext } = useContextStore();
   const { isChatFullSize, dataCatalogOpen } = useSidebarStore();
   const mapControlsLeft = `${getMapControlsLeftPx(isChatFullSize, dataCatalogOpen)}px`;
+  const mapAreaToolsLeft = `${getMapAreaToolsLeftPx(isChatFullSize, dataCatalogOpen)}px`;
 
   const { createAreaAsync, isCreating } = useCustomAreasCreate();
   const [showTools, setShowTools] = useState(false);
@@ -231,7 +235,7 @@ function MapAreaControls({
       <Flex
         ml={{
           base: 0,
-          md: dataCatalogOpen || isChatFullSize ? mapControlsLeft : 0,
+          md: dataCatalogOpen || isChatFullSize ? mapAreaToolsLeft : 0,
         }}
       >
         <Button

--- a/app/components/__tests__/DataCatalogPanel.test.ts
+++ b/app/components/__tests__/DataCatalogPanel.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// The mapStore import chain reaches the Chakra toaster (.tsx) which the node
+// test environment can't parse — stub it at the module boundary.
+vi.mock("@/app/components/ui/toaster", () => ({
+  toaster: { create: vi.fn() },
+  Toaster: () => null,
+}));
+
+import { filterDatasetsByCategory } from "@/app/utils/filterDatasetsByCategory";
+import {
+  DATASET_CARDS,
+  type DatasetCardConfig,
+} from "@/app/constants/datasets";
+import useContextStore from "@/app/store/contextStore";
+import useMapStore from "@/app/store/mapStore";
+import { getLayerContextFromDatasetCard } from "@/app/utils/datasetCardLayerContext";
+
+describe("filterDatasetsByCategory", () => {
+  it('returns every card when the category is "all"', () => {
+    const result = filterDatasetsByCategory(DATASET_CARDS, "all", []);
+    expect(result).toHaveLength(DATASET_CARDS.length);
+  });
+
+  it("filters by a thematic category via the card's `categories` array", () => {
+    const result = filterDatasetsByCategory(DATASET_CARDS, "land-use", []);
+    expect(result.length).toBeGreaterThan(0);
+    for (const card of result) {
+      expect(card.categories).toContain("land-use");
+    }
+  });
+
+  it("returns datasets matching multiple thematic categories", () => {
+    // TCL due to fires is tagged with both `disturbance` and `wildfires`.
+    const fires = filterDatasetsByCategory(DATASET_CARDS, "wildfires", []);
+    expect(fires.some((c) => c.dataset_id === 10)).toBe(true);
+    const disturbance = filterDatasetsByCategory(
+      DATASET_CARDS,
+      "disturbance",
+      []
+    );
+    expect(disturbance.some((c) => c.dataset_id === 10)).toBe(true);
+  });
+
+  it('returns only cards whose ids appear in `activeDatasetIds` for "in-conversation"', () => {
+    const sample: DatasetCardConfig[] = [
+      { dataset_id: 1, dataset_name: "A", description: "" },
+      { dataset_id: 2, dataset_name: "B", description: "" },
+      { dataset_id: 3, dataset_name: "C", description: "" },
+    ];
+    const result = filterDatasetsByCategory(sample, "in-conversation", [2]);
+    expect(result.map((c) => c.dataset_id)).toEqual([2]);
+  });
+
+  it('returns an empty list for "in-conversation" with no active layers', () => {
+    const sample: DatasetCardConfig[] = [
+      { dataset_id: 1, dataset_name: "A", description: "" },
+    ];
+    expect(filterDatasetsByCategory(sample, "in-conversation", [])).toEqual([]);
+  });
+});
+
+describe("data catalog show-on-map wiring (contextStore ↔ mapStore)", () => {
+  beforeEach(() => {
+    useContextStore.getState().reset();
+    // mapStore has no global reset; remove any leftover dataset layers.
+    const ids = useMapStore.getState().layers.map((l) => l.id);
+    ids.forEach((id) => useMapStore.getState().removeLayer(id));
+  });
+
+  it("adds a dataset layer to the map when a card is toggled on", () => {
+    const card = DATASET_CARDS.find((c) => c.dataset_id === 4)!;
+    useContextStore.getState().addContext({
+      contextType: "layer",
+      ...getLayerContextFromDatasetCard(card),
+      isAiContext: false,
+    });
+
+    const layers = useMapStore.getState().layers;
+    expect(layers.find((l) => l.id === "dataset-4")).toBeDefined();
+  });
+
+  it("supports multiple active layers simultaneously", () => {
+    const cardA = DATASET_CARDS.find((c) => c.dataset_id === 4)!;
+    const cardB = DATASET_CARDS.find((c) => c.dataset_id === 1)!;
+    useContextStore.getState().addContext({
+      contextType: "layer",
+      ...getLayerContextFromDatasetCard(cardA),
+      isAiContext: false,
+    });
+    useContextStore.getState().addContext({
+      contextType: "layer",
+      ...getLayerContextFromDatasetCard(cardB),
+      isAiContext: false,
+    });
+
+    const layerIds = useMapStore.getState().layers.map((l) => l.id);
+    expect(layerIds).toContain("dataset-4");
+    expect(layerIds).toContain("dataset-1");
+  });
+
+  it("removes the layer when the matching context entry is removed", () => {
+    const card = DATASET_CARDS.find((c) => c.dataset_id === 4)!;
+    useContextStore.getState().addContext({
+      contextType: "layer",
+      ...getLayerContextFromDatasetCard(card),
+      isAiContext: false,
+    });
+    const ctx = useContextStore
+      .getState()
+      .context.find((c) => c.datasetId === 4)!;
+    useContextStore.getState().removeContext(ctx.id);
+
+    expect(
+      useMapStore.getState().layers.find((l) => l.id === "dataset-4")
+    ).toBeUndefined();
+  });
+
+  it("setLayerVisibility toggles the layer's `visible` flag without removing it", () => {
+    const card = DATASET_CARDS.find((c) => c.dataset_id === 4)!;
+    useContextStore.getState().addContext({
+      contextType: "layer",
+      ...getLayerContextFromDatasetCard(card),
+      isAiContext: false,
+    });
+
+    useMapStore.getState().setLayerVisibility("dataset-4", false);
+    let layer = useMapStore.getState().layers.find((l) => l.id === "dataset-4");
+    expect(layer?.visible).toBe(false);
+
+    useMapStore.getState().setLayerVisibility("dataset-4", true);
+    layer = useMapStore.getState().layers.find((l) => l.id === "dataset-4");
+    expect(layer?.visible).toBe(true);
+  });
+
+  it("setLayerOpacity updates the layer's opacity value", () => {
+    const card = DATASET_CARDS.find((c) => c.dataset_id === 4)!;
+    useContextStore.getState().addContext({
+      contextType: "layer",
+      ...getLayerContextFromDatasetCard(card),
+      isAiContext: false,
+    });
+
+    useMapStore.getState().setLayerOpacity("dataset-4", 0.3);
+    const layer = useMapStore
+      .getState()
+      .layers.find((l) => l.id === "dataset-4");
+    expect(layer?.opacity).toBeCloseTo(0.3);
+  });
+});

--- a/app/components/__tests__/DataCatalogPanel.test.ts
+++ b/app/components/__tests__/DataCatalogPanel.test.ts
@@ -63,9 +63,7 @@ describe("filterDatasetsByCategory", () => {
 describe("data catalog show-on-map wiring (contextStore ↔ mapStore)", () => {
   beforeEach(() => {
     useContextStore.getState().reset();
-    // mapStore has no global reset; remove any leftover dataset layers.
-    const ids = useMapStore.getState().layers.map((l) => l.id);
-    ids.forEach((id) => useMapStore.getState().removeLayer(id));
+    useMapStore.getState().reset();
   });
 
   it("adds a dataset layer to the map when a card is toggled on", () => {

--- a/app/constants/datasets.ts
+++ b/app/constants/datasets.ts
@@ -18,6 +18,33 @@ export type DatasetLegendConfig = {
   unit?: string | null;
 };
 
+/**
+ * Thematic groupings used to filter the Data Catalog panel.
+ * `all` and `in-conversation` are virtual (not assigned per card).
+ */
+export type DatasetCategoryId =
+  | "all"
+  | "in-conversation"
+  | "land-use"
+  | "disturbance"
+  | "wildfires"
+  | "near-real-time";
+
+export const DATASET_CATEGORIES: { id: DatasetCategoryId; label: string }[] = [
+  { id: "all", label: "All datasets" },
+  { id: "in-conversation", label: "In this conversation" },
+  { id: "land-use", label: "Land use" },
+  { id: "disturbance", label: "Disturbance" },
+  { id: "wildfires", label: "Wildfires" },
+  { id: "near-real-time", label: "Near-real time" },
+];
+
+/** Categories assigned to dataset cards (excludes virtual ones above). */
+export type AssignableDatasetCategoryId = Exclude<
+  DatasetCategoryId,
+  "all" | "in-conversation"
+>;
+
 export type DatasetCardConfig = {
   dataset_id: number;
   dataset_name: string;
@@ -42,6 +69,12 @@ export type DatasetCardConfig = {
   viewOnly?: boolean;
   defaultStartYear?: number;
   defaultEndYear?: number;
+  /**
+   * Thematic categories used by the Data Catalog panel filter chips.
+   * A dataset may belong to multiple categories (e.g. fire-driven loss is
+   * both `disturbance` and `wildfires`).
+   */
+  categories?: AssignableDatasetCategoryId[];
 };
 
 export type VectorStyleSpec = {
@@ -117,6 +150,7 @@ export const DATASET_CARDS: (DatasetCardConfig & { img?: string })[] = [
     resolution: "30 m",
     geographic_coverage: "global",
     provider: "UMD",
+    categories: ["disturbance", "near-real-time"],
     description:
       "This dataset provides near-real-time alerts of vegetation disturbance at 30-meter resolution from December 2023 to present.",
     tile_url:
@@ -140,6 +174,7 @@ export const DATASET_CARDS: (DatasetCardConfig & { img?: string })[] = [
     resolution: "30 m",
     geographic_coverage: "global",
     provider: "GLAD / GPW",
+    categories: ["land-use"],
     description:
       "This Global Land Cover dataset is a combination of two global datasets: the GLAD Land Cover and Land Use Change annual data and the Global Pasture Watch Grassland Class Collection 2 Cultivated Grasslands annual data. This combination is annual from 2015 through 2024. This dataset shows land covers and uses including: bare ground and sparsevegetation, short vegetation, tree cover, wetlands, water, snow/ice, cropland, cultivated grasslands, and built-up land.",
     tile_url: `${EOAPI_HOST}/raster/collections/global-land-cover-v-2/items/global-land-cover-2024/tiles/WebMercatorQuad/{z}/{x}/{y}.png?colormap=%7B%221%22%3A%20%5B254%2C%20254%2C%20204%5D%2C%222%22%3A%20%5B185%2C%20185%2C%2030%5D%2C%223%22%3A%20%5B36%2C%20110%2C%2036%5D%2C%224%22%3A%20%5B116%2C%20214%2C%20180%5D%2C%225%22%3A%20%5B107%2C%20174%2C%20214%5D%2C%226%22%3A%20%5B172%2C%20209%2C%20232%5D%2C%227%22%3A%20%5B255%2C%20241%2C%20131%5D%2C%228%22%3A%20%5B232%2C%20118%2C%2093%5D%2C%229%22%3A%20%5B255%2C%20205%2C%20115%5D%7D&assets=asset&expression=asset%2A%28asset%3C10%29%2A%28asset%3E0%29&asset_as_band=True`,
@@ -172,6 +207,7 @@ export const DATASET_CARDS: (DatasetCardConfig & { img?: string })[] = [
     resolution: "30 m",
     geographic_coverage: "global",
     provider: "GPW Consortium, LCL",
+    categories: ["land-use"],
     description:
       "Annual 30 m maps of global natural/semi-natural grassland extent from 2000 to 2022. This dataset defines grasslands very broadly such that they encompass grasslands, shrublands, and savannas by including any land cover type which contains at least 30% of dry or wet low vegetation, dominated by grasses and forbs (less than 3 meters) and a: maximum of 50% tree canopy cover (greater than 5 meters), a maximum of 70% of other woody vegetation (scrubs and open shrubland), and a maximum of 50% active cropland cover in mosaic landscapes of cropland & other vegetation.",
     tile_url: `${EOAPI_HOST}/raster/collections/grasslands-v-1/items/grasslands-2022/tiles/WebMercatorQuad/{z}/{x}/{y}.png?colormap=%7B%220%22%3A%20%5B0%2C%200%2C%200%2C%200%5D%2C%20%221%22%3A%20%5B0%2C%200%2C%200%2C%200%5D%2C%20%222%22%3A%20%5B255%2C%20153%2C%2022%2C%20255%5D%2C%20%223%22%3A%20%5B0%2C%200%2C%200%2C%200%5D%7D&assets=asset&expression=asset%2A%28asset%3C4%29%2A%28asset%3E%3D0%29&asset_as_band=True`,
@@ -195,6 +231,7 @@ export const DATASET_CARDS: (DatasetCardConfig & { img?: string })[] = [
     resolution: "30 m",
     geographic_coverage: "global",
     provider: "SBTN, WRI",
+    categories: ["land-use"],
     description:
       "The SBTN Natural Lands Map v1.1 is a 2020 baseline map of natural and non-natural land covers intended for use by companies setting science-based targets for nature, specifically the SBTN Land target #1: no conversion of natural ecosystems. This map is global with 30m resolution and was made by compiling existing global and regional data including the GLAD Global Land Cover and Change data, ESA WorldCover, and many other land cover and use datasets.",
     tile_url: `${EOAPI_HOST}/raster/collections/natural-lands-v-1-1/tiles/WebMercatorQuad/{z}/{x}/{y}.png?colormap=%7B%222%22%3A%20%5B36%2C%20110%2C%2036%2C%20255%5D%2C%20%223%22%3A%20%5B185%2C%20185%2C%2030%2C%20255%5D%2C%20%224%22%3A%20%5B107%2C%20174%2C%20214%2C%20255%5D%2C%20%225%22%3A%20%5B6%2C%20162%2C%20133%2C%20255%5D%2C%20%226%22%3A%20%5B254%2C%20254%2C%20204%2C%20255%5D%2C%20%227%22%3A%20%5B172%2C%20209%2C%20232%2C%20255%5D%2C%20%228%22%3A%20%5B88%2C%20149%2C%2088%2C%20255%5D%2C%20%229%22%3A%20%5B9%2C%2061%2C%209%2C%20255%5D%2C%20%2210%22%3A%20%5B219%2C%20219%2C%20123%2C%20255%5D%2C%20%2211%22%3A%20%5B153%2C%20153%2C%2026%2C%20255%5D%2C%20%2212%22%3A%20%5B211%2C%20211%2C%20211%2C%20255%5D%2C%20%2213%22%3A%20%5B211%2C%20211%2C%20211%2C%20255%5D%2C%20%2214%22%3A%20%5B211%2C%20211%2C%20211%2C%20255%5D%2C%20%2215%22%3A%20%5B211%2C%20211%2C%20211%2C%20255%5D%2C%20%2216%22%3A%20%5B211%2C%20211%2C%20211%2C%20255%5D%2C%20%2217%22%3A%20%5B211%2C%20211%2C%20211%2C%20255%5D%2C%20%2218%22%3A%20%5B211%2C%20211%2C%20211%2C%20255%5D%2C%20%2219%22%3A%20%5B211%2C%20211%2C%20211%2C%20255%5D%2C%20%2220%22%3A%20%5B211%2C%20211%2C%20211%2C%20255%5D%2C%20%2221%22%3A%20%5B211%2C%20211%2C%20211%2C%20255%5D%7D&assets=asset&expression=asset%2A%28asset%3C22%29%2A%28asset%3E1%29&asset_as_band=True`,
@@ -232,6 +269,7 @@ export const DATASET_CARDS: (DatasetCardConfig & { img?: string })[] = [
     provider: "UMD",
     defaultStartYear: 2001,
     defaultEndYear: 2025,
+    categories: ["disturbance"],
     description:
       "Tree Cover Loss (Hansen/UMD/GLAD) maps annual global forest loss from 2001 to 2025 at 30-meter resolution using Landsat satellite imagery. It detects stand-replacement disturbances in vegetation over 5 meters tall, including natural forests and plantations. The dataset supports monitoring annual tree cover loss and deforestation trends, fire impacts, and forestry practices, and is widely used for conservation, land-use planning, and environmental policy analysis.",
     tile_url:
@@ -258,6 +296,7 @@ export const DATASET_CARDS: (DatasetCardConfig & { img?: string })[] = [
     resolution: "1 km",
     geographic_coverage: "global",
     provider: "WRI / Google",
+    categories: ["disturbance"],
     description:
       "Shows the primary driver or cause of tree cover loss over the entire range 2001-2025. Driver classes are permanent agriculture, hard commodities, shifting cultivation, logging, wildfire, settlements & infrastructure, and other natural disturbances.",
     tile_url:
@@ -290,6 +329,7 @@ export const DATASET_CARDS: (DatasetCardConfig & { img?: string })[] = [
     resolution: "30 m",
     geographic_coverage: "global",
     provider: "UMD",
+    categories: ["land-use"],
     description:
       "Tree Cover Gain (Hansen/UMD/GLAD) identifies areas where new tree canopy was established between 2000 and 2012 at 30-meter resolution, using Landsat 7 imagery. It captures both  natural forest regrowth and tree plantation cycles, and is useful for tracking large-scale forest recovery trends. Users should note that it is a cumulative layer and should not be combined directly with loss or tree cover data to calculate net change.",
     tile_url:
@@ -315,6 +355,7 @@ export const DATASET_CARDS: (DatasetCardConfig & { img?: string })[] = [
     resolution: "30 m",
     geographic_coverage: "global",
     provider: "UMD",
+    categories: ["land-use"],
     description:
       "Tree Cover provides global percent tree canopy cover at 30-meter resolution for the year 2000 based on Landsat 7 imagery. It represents the density of vegetation over 5 meters tall, including both natural forests and plantations. This dataset is useful for establishing historical baselines and comparing tree cover density across different landscapes.",
     tile_url:
@@ -343,6 +384,7 @@ export const DATASET_CARDS: (DatasetCardConfig & { img?: string })[] = [
     provider: "UMD",
     defaultStartYear: 2001,
     defaultEndYear: 2025,
+    categories: ["disturbance", "wildfires"],
     description:
       "Tree Cover Loss due to Fires (Hansen/UMD/GLAD) maps annual global tree cover loss attributed to fire from 2001 to 2025 at 30-meter resolution. This subset of the broader Tree Cover Loss dataset isolates fire-driven stand-replacement disturbances in vegetation over 5 meters tall, helping users understand where fire is a dominant driver of forest loss.",
     tile_url:
@@ -373,6 +415,7 @@ export const DATASET_CARDS: (DatasetCardConfig & { img?: string })[] = [
     resolution: "30 m",
     geographic_coverage: "global",
     provider: "WRI",
+    categories: ["disturbance"],
     description:
       "Maps the balance between emissions from forest disturbances and carbon removals from forest growth between 2001 and 2025, using a globally consistent model. This dataset supports climate reporting, forest-based mitigation strategies, and greenhouse gas inventories by identifying where forests are contributing to or helping mitigate climate change.",
     tile_url:

--- a/app/explorationLayout.ts
+++ b/app/explorationLayout.ts
@@ -1,0 +1,44 @@
+/** Shared geometry for the desktop exploration layout (chat + catalog + map). */
+
+export const COMPACT_CHAT_INSET_PX = 12;
+export const COMPACT_CHAT_PANEL_WIDTH_PX = 400;
+export const FULLSIZE_CHAT_PANEL_WIDTH_PX = 428;
+export const DATA_CATALOG_PANEL_WIDTH_PX = 400;
+export const DATA_CATALOG_CARD_WIDTH_PX = 376;
+export const DATA_CATALOG_CARD_HEIGHT_PX = 115;
+/** Gap between adjacent exploration panels (chat ↔ catalog, catalog ↔ map controls). */
+export const EXPLORATION_PANEL_GAP_PX = 8;
+
+/** Left offset of the data-catalog column. Flush left when chat is compact; flush against chat when full-size. */
+export function getDataCatalogLeftPx(isChatFullSize: boolean): number {
+  return isChatFullSize ? FULLSIZE_CHAT_PANEL_WIDTH_PX : 0;
+}
+
+/** Left inset for the compact chat column — shifts right when the catalog is open. */
+export function getCompactChatLeftPx(isDataCatalogOpen: boolean): number {
+  if (!isDataCatalogOpen) return COMPACT_CHAT_INSET_PX;
+  return DATA_CATALOG_PANEL_WIDTH_PX + EXPLORATION_PANEL_GAP_PX;
+}
+
+/** Left offset for map chrome (zoom, basemap) beside the chat and/or catalog panels. */
+export function getMapControlsLeftPx(
+  isChatFullSize: boolean,
+  isDataCatalogOpen: boolean
+): number {
+  if (isChatFullSize) {
+    if (!isDataCatalogOpen) {
+      return FULLSIZE_CHAT_PANEL_WIDTH_PX + EXPLORATION_PANEL_GAP_PX;
+    }
+    return (
+      getDataCatalogLeftPx(true) +
+      DATA_CATALOG_PANEL_WIDTH_PX +
+      EXPLORATION_PANEL_GAP_PX
+    );
+  }
+
+  return (
+    getCompactChatLeftPx(isDataCatalogOpen) +
+    COMPACT_CHAT_PANEL_WIDTH_PX +
+    EXPLORATION_PANEL_GAP_PX
+  );
+}

--- a/app/explorationLayout.ts
+++ b/app/explorationLayout.ts
@@ -42,3 +42,29 @@ export function getMapControlsLeftPx(
     EXPLORATION_PANEL_GAP_PX
   );
 }
+
+/**
+ * Left margin for the top area-tool buttons (upload, select, draw).
+ * In compact mode the chat is bottom-anchored, so when the catalog is open
+ * these tools sit beside the catalog column — not past the shifted chat panel.
+ * `MapAreaControls` applies `COMPACT_CHAT_INSET_PX` via wrapper padding in
+ * compact mode, so this value is net of that inset.
+ */
+export function getMapAreaToolsLeftPx(
+  isChatFullSize: boolean,
+  isDataCatalogOpen: boolean
+): number {
+  if (!isChatFullSize && isDataCatalogOpen) {
+    return (
+      DATA_CATALOG_PANEL_WIDTH_PX +
+      EXPLORATION_PANEL_GAP_PX -
+      COMPACT_CHAT_INSET_PX
+    );
+  }
+
+  if (isChatFullSize || isDataCatalogOpen) {
+    return getMapControlsLeftPx(isChatFullSize, isDataCatalogOpen);
+  }
+
+  return 0;
+}

--- a/app/store/sidebarStore.ts
+++ b/app/store/sidebarStore.ts
@@ -20,6 +20,9 @@ interface SidebarState {
   apiStatus: "Idle" | "OK" | "Error";
   isChatFullSize: boolean;
   setChatFullSize: (value: boolean) => void;
+  dataCatalogOpen: boolean;
+  setDataCatalogOpen: (open: boolean) => void;
+  toggleDataCatalog: () => void;
 }
 
 function updateThreadInCache(
@@ -43,6 +46,13 @@ const useSidebarStore = create<SidebarState>(() => ({
   isChatFullSize: false,
   setChatFullSize: (value) =>
     useSidebarStore.setState({ isChatFullSize: value }),
+  dataCatalogOpen: false,
+  setDataCatalogOpen: (open) =>
+    useSidebarStore.setState({ dataCatalogOpen: open }),
+  toggleDataCatalog: () =>
+    useSidebarStore.setState((state) => ({
+      dataCatalogOpen: !state.dataCatalogOpen,
+    })),
 
   toggleSidebar: () =>
     useSidebarStore.setState((state) => ({

--- a/app/utils/filterDatasetsByCategory.ts
+++ b/app/utils/filterDatasetsByCategory.ts
@@ -1,0 +1,29 @@
+import {
+  type DatasetCardConfig,
+  type DatasetCategoryId,
+} from "@/app/constants/datasets";
+
+/**
+ * Filters dataset cards for the Data Catalog panel by category.
+ *
+ * - `all` → every card
+ * - `in-conversation` → cards whose `dataset_id` currently has a `layer`
+ *   context entry (covers both AI-picked and user-toggled layers).
+ * - thematic ids (`land-use`, `disturbance`, ...) → cards whose `categories`
+ *   list includes that id.
+ *
+ * Kept in its own non-JSX module so the test environment (vitest in `node`
+ * mode, no JSX transform) can import it without pulling React.
+ */
+export function filterDatasetsByCategory(
+  cards: DatasetCardConfig[],
+  category: DatasetCategoryId,
+  activeDatasetIds: number[]
+): DatasetCardConfig[] {
+  if (category === "all") return cards;
+  if (category === "in-conversation") {
+    const idSet = new Set(activeDatasetIds);
+    return cards.filter((c) => idSet.has(c.dataset_id));
+  }
+  return cards.filter((c) => c.categories?.includes(category));
+}


### PR DESCRIPTION
## Pull request type

- [x] Feature

## What is the current behavior?
On desktop, users browse and add dataset layers through the chat input’s Data catalog button, which opens a centered modal (ContextMenu) with side tabs for Data catalog and Area tools. Layers can also be added by asking the assistant. There is no dedicated catalog panel in the map/exploration layout — dataset picking lives inside that modal alongside area selection. Map controls (zoom, basemap) are positioned relative to the chat panel only, and the Area tools flow shares the same modal navigation as the dataset catalogue.

## What is the new behavior?
Users can browse and add dataset layers from a dedicated Data catalog panel (400px wide) in the desktop exploration layout, without going through the assistant.

- Opening the panel: The existing Data catalog button in the chat tool row toggles the panel on desktop. On mobile, the button still opens the legacy modal.
- Layout: In compact chat mode, the catalog sits on the far left and pushes the chat panel right so they don’t overlap. In full-size chat mode, the catalog docks immediately beside the chat panel with a gray divider between them. Map controls shift right when the catalog is open.
- Catalog contents: Category filter chips (All datasets, In this conversation, Land use, etc.) narrow the list. Each dataset is shown as a 376×115px card with thumbnail, DATA label, title, metadata (cadence · extent · source), info affordance, and a Show on map toggle.
- Map integration: Toggling Show on map adds/removes layers via the existing contextStore → mapStore wiring. Active cards expose inline visibility and opacity controls. Layers still appear in the existing legend panel with full functionality.
- Area tools: The Area tools modal no longer shows the Data catalog tab — area selection is isolated from the new side panel.
- Polish: The card list scrolls without visible scrollbars, and horizontal overflow in the panel is suppressed.
## Does this introduce a breaking change?

- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Demo
<img width="1896" height="1281" alt="Screenshot 2026-06-23 at 14 59 31" src="https://github.com/user-attachments/assets/39d503c0-08c6-4a84-9911-fe99a53fdd07" />

---

<img width="1929" height="1280" alt="Screenshot 2026-06-23 at 14 59 42" src="https://github.com/user-attachments/assets/eb72c8ea-8cdf-4031-be24-8a2d57f0a693" />
