### PR TITLE
Insight workspace loading

### DIFF
--- a/app/components/InsightWorkspace.tsx
+++ b/app/components/InsightWorkspace.tsx
@@ -101,7 +101,12 @@ function WorkspaceSkeleton() {
 
 export default function InsightWorkspace() {
   const { insights } = useInsightStore();
-  const isLoading = useChatStore((state) => state.isLoading);
+  // Drive the loading affordances off the insight-specific flag, not the
+  // request-wide isLoading: the skeleton/spinner should appear only while an
+  // insight is actually being generated, not for every prompt.
+  const isGeneratingInsight = useChatStore(
+    (state) => state.isGeneratingInsight
+  );
   const [currentIndex, setCurrentIndex] = useState(0);
   const [isCollapsed, setIsCollapsed] = useState(false);
   const [paramsExpanded, setParamsExpanded] = useState(false);
@@ -114,9 +119,11 @@ export default function InsightWorkspace() {
   // First analysis still generating: no chart to show yet, so present a
   // skeleton card instead of an empty gap. Once a chart lands (total > 0),
   // the normal card renders and the header "INSIGHTS LOADING" indicator
-  // covers any subsequent regeneration.
+  // covers any subsequent regeneration. Gated on isGeneratingInsight so the
+  // skeleton appears only once the agent commits to generate_insights — not
+  // immediately on every prompt.
   if (total === 0) {
-    if (!isLoading) return null;
+    if (!isGeneratingInsight) return null;
     return <WorkspaceSkeleton />;
   }
 
@@ -196,7 +203,7 @@ export default function InsightWorkspace() {
           </Text>
         </Flex>
         <Flex align="center" gap="8px" flexShrink={0}>
-          {isLoading && (
+          {isGeneratingInsight && (
             <Flex align="center" gap="4px">
               <Box
                 animation="spin 1s infinite"

--- a/app/lib/__tests__/parse-stream-message.test.ts
+++ b/app/lib/__tests__/parse-stream-message.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from "vitest";
+import { parseStreamMessage } from "@/app/lib/parse-stream-message";
+import { LangChainUpdate } from "@/app/types/chat";
+
+const TS = new Date("2026-06-02T00:00:00.000Z");
+
+/**
+ * Build a minimal agent (AI) LangChainUpdate. `content` is the message text
+ * (empty string => pure tool-call turn) and `toolCalls` are the tool-call
+ * descriptors the model emitted.
+ */
+function agentUpdate(
+  content: unknown,
+  toolCalls: Array<{ name?: unknown }> = []
+): LangChainUpdate {
+  return {
+    messages: [
+      {
+        lc: 1,
+        type: "constructor",
+        id: ["x"],
+        kwargs: {
+          content,
+          response_metadata: {},
+          type: "ai",
+          id: "msg-1",
+          usage_metadata: {},
+          tool_calls: toolCalls,
+          invalid_tool_calls: [],
+        },
+      },
+    ],
+  } as unknown as LangChainUpdate;
+}
+
+describe("parseStreamMessage — agent tool_calls", () => {
+  it("attaches tool_calls names to a text message", () => {
+    const msg = parseStreamMessage(
+      agentUpdate("Let me analyse that for you.", [
+        { name: "generate_insights" },
+      ]),
+      "agent",
+      TS
+    );
+    expect(msg).toMatchObject({
+      type: "text",
+      text: "Let me analyse that for you.",
+      tool_calls: ["generate_insights"],
+    });
+  });
+
+  it("surfaces a pure tool-call turn as an 'other' message", () => {
+    const msg = parseStreamMessage(
+      agentUpdate("", [{ name: "generate_insights" }]),
+      "agent",
+      TS
+    );
+    expect(msg).toMatchObject({
+      type: "other",
+      name: "tool_calls",
+      tool_calls: ["generate_insights"],
+    });
+  });
+
+  it("omits tool_calls when the agent only emits text", () => {
+    const msg = parseStreamMessage(
+      agentUpdate("Here are the results.", []),
+      "agent",
+      TS
+    );
+    expect(msg?.type).toBe("text");
+    expect(msg?.tool_calls).toBeUndefined();
+  });
+
+  it("returns null when there is neither text nor tool calls", () => {
+    const msg = parseStreamMessage(agentUpdate("", []), "agent", TS);
+    expect(msg).toBeNull();
+  });
+
+  it("ignores malformed tool-call entries without a name", () => {
+    const msg = parseStreamMessage(
+      agentUpdate("", [{ args: {} } as { name?: unknown }]),
+      "agent",
+      TS
+    );
+    // No usable names => behaves like a no-content, no-tool-call turn.
+    expect(msg).toBeNull();
+  });
+
+  it("preserves multiple tool-call names in order", () => {
+    const msg = parseStreamMessage(
+      agentUpdate("", [
+        { name: "pick_dataset" },
+        { name: "generate_insights" },
+      ]),
+      "agent",
+      TS
+    );
+    expect(msg?.tool_calls).toEqual(["pick_dataset", "generate_insights"]);
+  });
+});

--- a/app/lib/parse-stream-message.ts
+++ b/app/lib/parse-stream-message.ts
@@ -103,6 +103,19 @@ export function parseStreamMessage(
       textContent = (content as { text: string }).text;
     }
 
+    // Names of the tools this AI message is announcing. The agent emits the
+    // tool call before the tool result streams back, so this is the earliest
+    // signal that a given tool (e.g. generate_insights) is about to run.
+    const toolCalls = Array.isArray(kwargs.tool_calls)
+      ? kwargs.tool_calls
+          .map((tc) =>
+            tc && typeof tc === "object" && "name" in tc
+              ? (tc as { name?: unknown }).name
+              : undefined
+          )
+          .filter((n): n is string => typeof n === "string")
+      : [];
+
     // Only return a message if we have valid text content
     // TODO: This function emits StreamMessage.type = "text" for assistant messages.
     // Consider renaming to "assistant" for clarity and updating client handling
@@ -111,6 +124,21 @@ export function parseStreamMessage(
       return {
         type: "text",
         text: textContent.trim(),
+        timestamp: timestamp.toISOString(),
+        trace_id: traceId,
+        ...(toolCalls.length ? { tool_calls: toolCalls } : {}),
+      };
+    }
+
+    // No text, but the agent announced tool calls (a pure tool-call turn).
+    // Surface them so the UI can reflect pending work — without this, the
+    // message would be dropped and the insight skeleton would never know an
+    // analysis is on the way.
+    if (toolCalls.length) {
+      return {
+        type: "other",
+        name: "tool_calls",
+        tool_calls: toolCalls,
         timestamp: timestamp.toISOString(),
         trace_id: traceId,
       };

--- a/app/store/chatStore.ts
+++ b/app/store/chatStore.ts
@@ -38,6 +38,11 @@ import useInsightStore from "./insightStore";
 interface ChatState {
   messages: ChatMessage[];
   isLoading: boolean;
+  // True only while the agent is actively generating an insight — i.e. between
+  // the agent announcing a generate_insights tool call and that tool's result
+  // arriving. Distinct from isLoading (true for the whole request) so the
+  // insight workspace loading state surfaces only when an insight is on the way.
+  isGeneratingInsight: boolean;
   abortController: AbortController | null;
   currentThreadId: string | null;
   toolSteps: ToolStepData[];
@@ -57,6 +62,7 @@ interface ChatActions {
     queryType?: QueryType
   ) => Promise<{ isNew: boolean; id: string }>;
   setLoading: (loading: boolean) => void;
+  setGeneratingInsight: (generating: boolean) => void;
   generateNewThread: () => string;
   fetchThread: (
     threadId: string,
@@ -82,6 +88,7 @@ You can ask me about land cover change, forest loss, or biodiversity risks in pl
     },
   ],
   isLoading: false,
+  isGeneratingInsight: false,
   abortController: null,
   currentThreadId: null,
   toolSteps: [],
@@ -141,7 +148,8 @@ async function processStreamMessage(
   setPendingTraceId: (traceId: string | null) => void,
   attachTraceToLastAssistant: (traceId: string) => boolean,
   getPendingNudge: () => SuggestedDataset[] | null,
-  setPendingNudge: (datasets: SuggestedDataset[] | null) => void
+  setPendingNudge: (datasets: SuggestedDataset[] | null) => void,
+  setGeneratingInsight: (generating: boolean) => void
 ) {
   // Capture standalone trace metadata sent as a separate stream message
   if (streamMessage.type === "other" && streamMessage.name === "trace") {
@@ -155,7 +163,21 @@ async function processStreamMessage(
     }
     return;
   }
+  // A pure tool-call turn (AI message with no text). If the agent is about to
+  // run generate_insights, flag it so the insight workspace can show its
+  // loading state now — before the chart data arrives.
+  if (streamMessage.type === "other" && streamMessage.name === "tool_calls") {
+    if (streamMessage.tool_calls?.includes("generate_insights")) {
+      setGeneratingInsight(true);
+    }
+    return;
+  }
   if (streamMessage.type === "error") {
+    // A generate_insights error means no chart is coming — clear the loading
+    // state so the workspace skeleton doesn't linger while the agent recovers.
+    if (streamMessage.name === "generate_insights") {
+      setGeneratingInsight(false);
+    }
     // Handle timeout errors specifically
     if (streamMessage.name === "timeout") {
       addMessage({
@@ -181,6 +203,12 @@ async function processStreamMessage(
     // Consider renaming server-emitted type to "assistant" and updating this
     // branch accordingly, keeping temporary backward compatibility for "text".
   } else if (streamMessage.type === "text" && streamMessage.text) {
+    // The agent can narrate ("Let me analyse…") and call generate_insights in
+    // the same turn — flag the pending insight so its loading state appears
+    // while the chart is computed.
+    if (streamMessage.tool_calls?.includes("generate_insights")) {
+      setGeneratingInsight(true);
+    }
     const pending = getPendingTraceId();
     const traceToUse = streamMessage.trace_id || pending || undefined;
 
@@ -219,10 +247,13 @@ async function processStreamMessage(
 
     // Special handling for generate_insights tool
     if (streamMessage.name === "generate_insights" && streamMessage.insights) {
-      // Non-blocking: do not await tool side-effects
-      void Promise.resolve().then(() =>
-        generateInsightsTool(streamMessage, addMessage)
-      );
+      // Non-blocking: do not await tool side-effects. Clear the generating
+      // flag in the same microtask that adds the insights, so the workspace
+      // swaps skeleton → chart in a single render (no empty flash).
+      void Promise.resolve().then(() => {
+        generateInsightsTool(streamMessage, addMessage);
+        setGeneratingInsight(false);
+      });
       return;
     }
     // Special handling for pick_aoi tool (previously location-tool)
@@ -323,6 +354,7 @@ const useChatStore = create<ChatState & ChatActions>((set, get) => ({
     const {
       addMessage,
       setLoading,
+      setGeneratingInsight,
       currentThreadId,
       generateNewThread,
       addToolStep,
@@ -344,6 +376,9 @@ const useChatStore = create<ChatState & ChatActions>((set, get) => ({
     clearToolSteps();
     set({ reasoningStartTime: Date.now() });
     setLoading(true);
+    // Reset any stale insight-generating flag from a prior turn; it is set
+    // true only once this turn's agent announces a generate_insights call.
+    setGeneratingInsight(false);
 
     // Build ui_context from current context
     const newContext = context.filter((ctx) => !ctx.isAiContext);
@@ -471,7 +506,8 @@ const useChatStore = create<ChatState & ChatActions>((set, get) => ({
               () => pendingNudge,
               (datasets) => {
                 pendingNudge = datasets;
-              }
+              },
+              setGeneratingInsight
             );
           } catch (err) {
             if (isFinal) {
@@ -580,6 +616,9 @@ const useChatStore = create<ChatState & ChatActions>((set, get) => ({
       attachToolStepsToLastUserMessage();
 
       setLoading(false);
+      // Safety net: clear the insight-generating flag in case generate_insights
+      // was announced but never produced a result (error, abort, timeout).
+      setGeneratingInsight(false);
 
       queryClient.invalidateQueries({ queryKey: ["threads"] });
       return { isNew: !currentThreadId, id: threadId };
@@ -587,6 +626,9 @@ const useChatStore = create<ChatState & ChatActions>((set, get) => ({
   },
 
   setLoading: (loading) => set({ isLoading: loading }),
+
+  setGeneratingInsight: (generating) =>
+    set({ isGeneratingInsight: generating }),
 
   cancelRequest: () => {
     const controller = get().abortController;
@@ -647,13 +689,20 @@ const useChatStore = create<ChatState & ChatActions>((set, get) => ({
   },
 
   fetchThread: async (threadId: string, abort?: AbortController) => {
-    const { setLoading, addMessage, addToolStep, clearToolSteps } = get();
+    const {
+      setLoading,
+      setGeneratingInsight,
+      addMessage,
+      addToolStep,
+      clearToolSteps,
+    } = get();
     const { upsertContextByType } = useContextStore.getState();
 
     // Clear any previous tool steps and start loading
     clearToolSteps();
     set({ reasoningStartTime: Date.now() });
     setLoading(true);
+    setGeneratingInsight(false);
     // Set up abort controller for client-side timeout
     const abortController = abort || new AbortController();
     const timeoutId = setTimeout(() => {
@@ -760,7 +809,8 @@ const useChatStore = create<ChatState & ChatActions>((set, get) => ({
               () => pendingNudgeThread,
               (datasets) => {
                 pendingNudgeThread = datasets;
-              }
+              },
+              setGeneratingInsight
             );
           } catch (err) {
             if (isFinal) {
@@ -824,6 +874,7 @@ const useChatStore = create<ChatState & ChatActions>((set, get) => ({
       }
 
       setLoading(false);
+      setGeneratingInsight(false);
     }
   },
 }));

--- a/app/types/chat.ts
+++ b/app/types/chat.ts
@@ -141,6 +141,10 @@ export interface StreamMessage {
   codeact_parts?: CodeActPart[];
   source_urls?: string[];
   insight_count?: number;
+  // Names of the tools an AI message is about to call. The agent announces a
+  // tool call before its result streams back, so this is the earliest signal
+  // that e.g. an insight is being generated.
+  tool_calls?: string[];
   timestamp: string;
   start_date?: string;
   end_date?: string;


### PR DESCRIPTION
I noticed that the Insight loading state was being triggered by any prompt, even ones that don't need generate an insight e.g. `What datasets related to fires do you have?`

I introduced an `isGeneratingInsight` flag that is true only between the agent message contains a `generate_insights` tool call, which signals that an insight is loading. The agent emits its tool-call decision as a separate stream event before the chart data streams back, so this is the earliest correct moment to surface the loading state.

### Changes

- `types/chat.ts` adds `tool_calls?: string[]` to StreamMessage.
- `parse-stream-message.ts` now surfaces the agent's announced tool_calls names: attached to the text message when the turn includes narration, or emitted as a lightweight other/tool_calls message for a pure tool-call turn (previously dropped entirely).
- `chatStore.ts` adds isGeneratingInsight state + setGeneratingInsight action. Set true when
generate_insights is announced; cleared in the same task that adds the chart (skeleton → chart swap in a single render, no empty flash), on a generate_insights error, at send-start, and in both sendMessage/fetchThread finally blocks as a safety net.
- `InsightWorkspace.tsx` gates both the skeleton and the "INSIGHTS LOADING" header on isGeneratingInsight instead of isLoading.

### New Behaviour

- The skeleton/spinner appear only once generate_insights is announced.
- The workspace stays empty (null) for non-insight prompts.
- The "INSIGHTS LOADING" header no longer fires on follow-up non-insight prompts when an insight card already exists.
- Thread replay unaffected: the backend filters empty-content AI messages on replay, but replay doesn't need the skeleton charts are already populated when the generate_insights result lands.