### PR TITLE
Fix/all countries

### DIFF
--- a/app/store/chat-tools/__tests__/pickAoi.test.ts
+++ b/app/store/chat-tools/__tests__/pickAoi.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi } from "vitest";
+
+// isGlobalQuery lives in pickAoi.ts, whose import chain reaches mapStore
+// (MapLibre/terra-draw) and the Chakra toaster (.tsx) — none of which load in
+// the node test environment. Stub those module boundaries so the pure helper
+// can be imported in isolation.
+vi.mock("@/app/store/mapStore", () => ({
+  default: { getState: () => ({}) },
+}));
+
+vi.mock("@/app/store/contextStore", () => ({
+  default: { getState: () => ({ context: [], addContext: vi.fn() }) },
+}));
+
+vi.mock("@/app/utils/geometryClient", () => ({
+  fetchGeometry: vi.fn(),
+}));
+
+import { isGlobalQuery } from "../pickAoi";
+
+describe("isGlobalQuery", () => {
+  it("matches the backend's canonical global selection name", () => {
+    // Regression guard: the backend resolves a worldwide query to the selection
+    // name "All countries in the world". A prior exact match against
+    // "all countries" never matched it, so the FE fell through to fetching and
+    // rendering ~250 country polygons — an out-of-memory renderer crash.
+    expect(isGlobalQuery("All countries in the world")).toBe(true);
+  });
+
+  it("accepts the bare 'all countries' alias, case- and space-insensitively", () => {
+    expect(isGlobalQuery("all countries")).toBe(true);
+    expect(isGlobalQuery("  All Countries  ")).toBe(true);
+    expect(isGlobalQuery("ALL COUNTRIES IN THE WORLD")).toBe(true);
+  });
+
+  it("does not treat a sub-global or single-country selection as global", () => {
+    // Must stay an exact match — a substring check would wrongly route these
+    // through the global GADM vector layer instead of their real geometry.
+    expect(isGlobalQuery("All countries in the EU")).toBe(false);
+    expect(isGlobalQuery("Brazil")).toBe(false);
+    expect(isGlobalQuery("Pará, Brazil")).toBe(false);
+    expect(isGlobalQuery("")).toBe(false);
+  });
+});

--- a/app/store/chat-tools/pickAoi.ts
+++ b/app/store/chat-tools/pickAoi.ts
@@ -15,8 +15,24 @@ import { selectLayerOptions } from "@/app/types/map";
 const GLOBAL_LAYER_ID = "Global Layer";
 const GLOBAL_LAYER_NAME = "Global Layer";
 
-function isGlobalQuery(name: string): boolean {
-  return name.toLowerCase() === "all countries";
+/**
+ * A global query selects every country on the planet, which the backend renders
+ * as a single GADM vector-tile layer instead of ~250 per-country GeoJSON fetches.
+ * The backend's canonical selection name is "All countries in the world" (see the
+ * DebugToastsPanel fixture); the bare "all countries" is accepted for resilience.
+ *
+ * Matching is exact (not substring) on purpose: a sub-global selection such as
+ * "All countries in the EU" must NOT be treated as the whole world — doing so
+ * would swap its real geometry for the global GADM layer. Previously this checked
+ * `=== "all countries"`, which never matched the canonical name and caused the FE
+ * to fetch and render all ~250 country polygons — an out-of-memory renderer crash.
+ */
+export function isGlobalQuery(name: string): boolean {
+  const normalized = name.toLowerCase().trim();
+  return (
+    normalized === "all countries" ||
+    normalized === "all countries in the world"
+  );
 }
 
 /**


### PR DESCRIPTION
An OOM error was occurring when the FE failed to capture the Global AOI ("all countries in the world"), instead adding all country shapes and bboxes to the map.

Adds a test to capture regressions and ensures both "all countries" and "all countries in the world" are captured