### PR TITLE
Differentiate generative vs. non-generative nudges

### DIFF
--- a/app/components/AnalyseNudge.tsx
+++ b/app/components/AnalyseNudge.tsx
@@ -24,7 +24,7 @@ export default function AnalyseNudge({
 
   // Matches the agent prompt wording (buildAnalysisPrompt) so the message the
   // user sends on accept reads identically to the button they clicked.
-  const label = `Analyse ${suggestion.datasetName} in ${suggestion.areaName}`;
+  const label = `Generate ${suggestion.datasetName} Insight in ${suggestion.areaName}`;
 
   return (
     <Button

--- a/app/components/AnalyseNudge.tsx
+++ b/app/components/AnalyseNudge.tsx
@@ -24,7 +24,7 @@ export default function AnalyseNudge({
 
   // Matches the agent prompt wording (buildAnalysisPrompt) so the message the
   // user sends on accept reads identically to the button they clicked.
-  const label = `Generate ${suggestion.datasetName} Insight in ${suggestion.areaName}`;
+  const label = `Generate ${suggestion.datasetName} Insight for ${suggestion.areaName}`;
 
   return (
     <Button

--- a/src/features/analysis/ui/ViewAnalysisNudge.tsx
+++ b/src/features/analysis/ui/ViewAnalysisNudge.tsx
@@ -39,7 +39,7 @@ export default function ViewAnalysisNudge({
     });
   };
 
-  const label = `View Analysis for ${suggestion.datasetName} in ${suggestion.area.name}`;
+  const label = `View ${suggestion.datasetName} Analysis in ${suggestion.area.name}`;
 
   return (
     <>

--- a/src/features/analysis/ui/ViewAnalysisNudge.tsx
+++ b/src/features/analysis/ui/ViewAnalysisNudge.tsx
@@ -39,7 +39,7 @@ export default function ViewAnalysisNudge({
     });
   };
 
-  const label = `View ${suggestion.datasetName} Analysis in ${suggestion.area.name}`;
+  const label = `View ${suggestion.datasetName} Analysis for ${suggestion.area.name}`;
 
   return (
     <>


### PR DESCRIPTION
Aligning analysis nudge labels with designs based on feedback during the demo - we need to differentiate whats happening more for users

<img width="382" height="106" alt="Screenshot 2026-07-03 at 7 50 30 AM" src="https://github.com/user-attachments/assets/b4fc562b-d7c6-426e-a232-44cb2131bba2" />
