### PR TITLE
feat(chat): pin active user prompt to top of message list

### DIFF
--- a/app/ChatPanelCompact.tsx
+++ b/app/ChatPanelCompact.tsx
@@ -133,15 +133,16 @@ function ChatPanelCompact({ onToggleSize }: ChatPanelCompactProps) {
                 transition={{ duration: 0.22, ease: "easeInOut" }}
                 style={{ overflow: "hidden" }}
               >
+                {/* Top padding is passed to ChatMessages instead of set on
+                    this scroller — see ChatMessagesProps.pt. */}
                 <Box
                   ref={messagesRef}
                   overflowY="auto"
                   px={4}
-                  pt={4}
                   pb={4}
                   maxH={messagesMaxH}
                 >
-                  <ChatMessages />
+                  <ChatMessages pt={4} />
                 </Box>
               </motion.div>
             )}

--- a/app/ChatPanelFullSize.tsx
+++ b/app/ChatPanelFullSize.tsx
@@ -37,9 +37,10 @@ function ChatPanelFullSize({ onToggleSize }: ChatPanelFullSizeProps) {
         onToggleSize={onToggleSize}
       />
 
-      {/* Scrollable message area */}
-      <Box flex="1" overflowY="auto" px={3} pt={3} pb={0} minH={0}>
-        <ChatMessages />
+      {/* Scrollable message area. Top padding is passed to ChatMessages
+          instead of set on this scroller — see ChatMessagesProps.pt. */}
+      <Box flex="1" overflowY="auto" px={3} pb={0} minH={0}>
+        <ChatMessages pt={3} />
       </Box>
 
       {/* Input area — rounded bordered box. pb matches ChatPanelCompact so the

--- a/app/components/ChatMessages.tsx
+++ b/app/components/ChatMessages.tsx
@@ -119,7 +119,7 @@ function ChatMessages({ pt }: ChatMessagesProps) {
           <Fragment key={message.id}>
             {isLastUserMessage && <Box ref={lastUserMessageRef} />}
             <MessageBubble
-              ref={
+              bubbleRef={
                 message.type === "user"
                   ? registerPromptNode(message.id)
                   : undefined

--- a/app/components/ChatMessages.tsx
+++ b/app/components/ChatMessages.tsx
@@ -1,17 +1,31 @@
 "use client";
 import { Fragment, useEffect, useRef } from "react";
-import { Box } from "@chakra-ui/react";
+import { Box, BoxProps } from "@chakra-ui/react";
 import useChatStore from "@/app/store/chatStore";
+import { usePinnedPrompt } from "@/app/hooks/usePinnedPrompt";
 import MessageBubble from "./MessageBubble";
+import PinnedPrompt from "./PinnedPrompt";
 import Reasoning from "./Reasoning";
 import SamplePrompts from "./SamplePrompts";
 
-function ChatMessages() {
+interface ChatMessagesProps {
+  /**
+   * Top padding of the message list. Lives here (inside the scroll container)
+   * rather than as `pt` on the scroller itself because scroll-container
+   * padding is added to `position: sticky` offsets, which would push the
+   * PinnedPrompt overlay down by the padding amount.
+   */
+  pt?: BoxProps["pt"];
+}
+
+function ChatMessages({ pt }: ChatMessagesProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const lastUserMessageRef = useRef<HTMLDivElement>(null);
   const spacerRef = useRef<HTMLDivElement>(null);
   const { messages, isLoading, toolSteps: currentToolSteps } = useChatStore();
   const shouldAutoScroll = useRef(true);
+  const { pinnedMessage, registerPromptNode, jumpToPinnedPrompt } =
+    usePinnedPrompt(containerRef, messages);
 
   // Scroll to the bottom of real content, ignoring the blank spacer.
   const scrollToBottom = () => {
@@ -89,7 +103,10 @@ function ChatMessages() {
   );
 
   return (
-    <Box ref={containerRef} fontSize="sm">
+    <Box ref={containerRef} fontSize="sm" pt={pt}>
+      {pinnedMessage && (
+        <PinnedPrompt message={pinnedMessage} onJump={jumpToPinnedPrompt} />
+      )}
       {messages.map((message, index) => {
         // Check if this message is consecutive to the previous one of the same type
         const previousMessage = index > 0 ? messages[index - 1] : null;
@@ -102,6 +119,11 @@ function ChatMessages() {
           <Fragment key={message.id}>
             {isLastUserMessage && <Box ref={lastUserMessageRef} />}
             <MessageBubble
+              ref={
+                message.type === "user"
+                  ? registerPromptNode(message.id)
+                  : undefined
+              }
               message={message}
               isConsecutive={isConsecutive}
               isFirst={isFirst}

--- a/app/components/MessageBubble.tsx
+++ b/app/components/MessageBubble.tsx
@@ -43,7 +43,7 @@ interface MessageBubbleProps {
   isFirst?: boolean;
   isLast?: boolean;
   /** Attached to the bubble's root so ChatMessages can track its position. */
-  ref?: React.Ref<HTMLDivElement>;
+  bubbleRef?: React.Ref<HTMLDivElement>;
 }
 
 function MessageBubble({
@@ -51,7 +51,7 @@ function MessageBubble({
   isConsecutive = false,
   isFirst = false,
   isLast = false,
-  ref,
+  bubbleRef,
 }: MessageBubbleProps) {
   const [formattedTimestamp, setFormattedTimestamp] = useState("");
   const clipboard = useClipboard({ value: message.message });
@@ -259,7 +259,7 @@ function MessageBubble({
 
   return (
     <Box
-      ref={ref}
+      ref={bubbleRef}
       display="flex"
       justifyContent={isUser ? "flex-end" : "flex-start"}
       mb={isConsecutive || message.suppressFooter ? 1 : 4}

--- a/app/components/MessageBubble.tsx
+++ b/app/components/MessageBubble.tsx
@@ -42,6 +42,8 @@ interface MessageBubbleProps {
   isConsecutive?: boolean; // Whether this message is consecutive to the previous one of the same type
   isFirst?: boolean;
   isLast?: boolean;
+  /** Attached to the bubble's root so ChatMessages can track its position. */
+  ref?: React.Ref<HTMLDivElement>;
 }
 
 function MessageBubble({
@@ -49,6 +51,7 @@ function MessageBubble({
   isConsecutive = false,
   isFirst = false,
   isLast = false,
+  ref,
 }: MessageBubbleProps) {
   const [formattedTimestamp, setFormattedTimestamp] = useState("");
   const clipboard = useClipboard({ value: message.message });
@@ -256,10 +259,14 @@ function MessageBubble({
 
   return (
     <Box
+      ref={ref}
       display="flex"
       justifyContent={isUser ? "flex-end" : "flex-start"}
       mb={isConsecutive || message.suppressFooter ? 1 : 4}
-      _first={{ base: { mt: 3 }, md: { mt: 6 } }}
+      // Driven by the isFirst prop rather than a :first-child selector so the
+      // PinnedPrompt overlay (rendered as the list's first child) can't
+      // disturb the spacing.
+      mt={isFirst ? { base: 3, md: 6 } : undefined}
     >
       <Box
         display="flex"

--- a/app/components/PinnedPrompt.tsx
+++ b/app/components/PinnedPrompt.tsx
@@ -1,0 +1,53 @@
+"use client";
+import { Box, Text } from "@chakra-ui/react";
+import { ChatMessage } from "@/app/types/chat";
+import { PIN_TOP_OFFSET_PX } from "@/app/utils/pinnedPrompt";
+import usePrefersReducedMotion from "@/app/hooks/usePrefersReducedMotion";
+
+interface PinnedPromptProps {
+  message: ChatMessage;
+  onJump: () => void;
+}
+
+/**
+ * Floating recap of the prompt whose answer is scrolled past the top of the
+ * chat. Rendered inside a zero-height sticky wrapper so it overlays the
+ * scroll area without taking part in the message flow — this keeps it
+ * working in both chat panel variants, which each own their scroll
+ * container. Clicking it scrolls the original bubble back into view.
+ */
+function PinnedPrompt({ message, onJump }: PinnedPromptProps) {
+  const prefersReducedMotion = usePrefersReducedMotion();
+
+  return (
+    <Box position="sticky" top={`${PIN_TOP_OFFSET_PX}px`} zIndex={5} h={0}>
+      <Box
+        key={message.id}
+        as="button"
+        onClick={onJump}
+        title="Scroll back to this message"
+        display="block"
+        w="100%"
+        textAlign="left"
+        cursor="pointer"
+        bg="primary.50"
+        color="fg"
+        px={3}
+        py={3}
+        borderRadius="lg"
+        boxShadow="lg"
+        animationName={prefersReducedMotion ? undefined : "fadeSlideIn"}
+        animationDuration="0.2s"
+        animationTimingFunction="ease-out"
+        transition="background 0.2s ease"
+        _hover={{ bg: "primary.100" }}
+      >
+        <Text fontSize="xs" lineHeight="1.5" lineClamp={2}>
+          {message.message}
+        </Text>
+      </Box>
+    </Box>
+  );
+}
+
+export default PinnedPrompt;

--- a/app/components/PinnedPrompt.tsx
+++ b/app/components/PinnedPrompt.tsx
@@ -24,8 +24,8 @@ function PinnedPrompt({ message, onJump }: PinnedPromptProps) {
       <Box
         key={message.id}
         as="button"
+        type="button"
         onClick={onJump}
-        title="Scroll back to this message"
         display="block"
         w="100%"
         textAlign="left"

--- a/app/components/PinnedPrompt.tsx
+++ b/app/components/PinnedPrompt.tsx
@@ -1,8 +1,9 @@
 "use client";
-import { Box, Text } from "@chakra-ui/react";
+import { Box, Text, chakra } from "@chakra-ui/react";
 import { ChatMessage } from "@/app/types/chat";
 import { PIN_TOP_OFFSET_PX } from "@/app/utils/pinnedPrompt";
 import usePrefersReducedMotion from "@/app/hooks/usePrefersReducedMotion";
+import { Tooltip } from "./ui/tooltip";
 
 interface PinnedPromptProps {
   message: ChatMessage;
@@ -21,31 +22,32 @@ function PinnedPrompt({ message, onJump }: PinnedPromptProps) {
 
   return (
     <Box position="sticky" top={`${PIN_TOP_OFFSET_PX}px`} zIndex={5} h={0}>
-      <Box
-        key={message.id}
-        as="button"
-        type="button"
-        onClick={onJump}
-        display="block"
-        w="100%"
-        textAlign="left"
-        cursor="pointer"
-        bg="primary.50"
-        color="fg"
-        px={3}
-        py={3}
-        borderRadius="lg"
-        boxShadow="lg"
-        animationName={prefersReducedMotion ? undefined : "fadeSlideIn"}
-        animationDuration="0.2s"
-        animationTimingFunction="ease-out"
-        transition="background 0.2s ease"
-        _hover={{ bg: "primary.100" }}
-      >
-        <Text fontSize="xs" lineHeight="1.5" lineClamp={2}>
-          {message.message}
-        </Text>
-      </Box>
+      <Tooltip content="Click to jump to message">
+        <chakra.button
+          key={message.id}
+          type="button"
+          onClick={onJump}
+          display="block"
+          w="100%"
+          textAlign="left"
+          cursor="pointer"
+          bg="primary.50"
+          color="fg"
+          px={3}
+          py={3}
+          borderRadius="lg"
+          boxShadow="lg"
+          animationName={prefersReducedMotion ? undefined : "fadeSlideIn"}
+          animationDuration="0.2s"
+          animationTimingFunction="ease-out"
+          transition="background 0.2s ease"
+          _hover={{ bg: "primary.100" }}
+        >
+          <Text fontSize="xs" lineHeight="1.5" lineClamp={2}>
+            {message.message}
+          </Text>
+        </chakra.button>
+      </Tooltip>
     </Box>
   );
 }

--- a/app/hooks/usePinnedPrompt.ts
+++ b/app/hooks/usePinnedPrompt.ts
@@ -1,0 +1,126 @@
+"use client";
+import { RefObject, useCallback, useEffect, useRef, useState } from "react";
+import { ChatMessage } from "@/app/types/chat";
+import { PromptRect, resolvePinnedPromptId } from "@/app/utils/pinnedPrompt";
+
+/**
+ * Offset used when scrolling a prompt bubble back into view. Matches the
+ * pin-on-send offset in ChatMessages so a jumped-to prompt lands exactly
+ * where a freshly sent one does.
+ */
+const JUMP_OFFSET_PX = 16;
+
+/**
+ * Tracks which user prompt should be pinned above the chat scroll area and
+ * exposes the plumbing ChatMessages needs to drive the PinnedPrompt overlay.
+ *
+ * ChatMessages renders inside a scrollable parent it does not own (each chat
+ * panel variant provides its own scroller), so geometry is measured against
+ * `containerRef.current.parentElement` — the same contract the existing
+ * auto-scroll logic in ChatMessages relies on.
+ */
+export function usePinnedPrompt(
+  containerRef: RefObject<HTMLDivElement | null>,
+  messages: ChatMessage[]
+) {
+  const [pinnedId, setPinnedId] = useState<string | null>(null);
+  const promptNodesRef = useRef(new Map<string, HTMLElement>());
+  const refCallbacksRef = useRef(
+    new Map<string, (node: HTMLElement | null) => void>()
+  );
+  const frameRef = useRef<number | null>(null);
+  // Read through a ref so scroll/resize subscriptions stay stable across the
+  // frequent message appends that happen while a response streams in.
+  const messagesRef = useRef(messages);
+  messagesRef.current = messages;
+
+  const computePinned = useCallback(() => {
+    const parent = containerRef.current?.parentElement;
+    if (!parent) {
+      setPinnedId(null);
+      return;
+    }
+    const containerTop = parent.getBoundingClientRect().top;
+    const prompts: PromptRect[] = [];
+    for (const message of messagesRef.current) {
+      if (message.type !== "user") continue;
+      const node = promptNodesRef.current.get(message.id);
+      if (!node) continue;
+      const rect = node.getBoundingClientRect();
+      prompts.push({ id: message.id, top: rect.top, bottom: rect.bottom });
+    }
+    setPinnedId(resolvePinnedPromptId(prompts, containerTop));
+  }, [containerRef]);
+
+  const schedulePinnedUpdate = useCallback(() => {
+    if (frameRef.current !== null) return;
+    frameRef.current = requestAnimationFrame(() => {
+      frameRef.current = null;
+      computePinned();
+    });
+  }, [computePinned]);
+
+  // Follow scroll position.
+  useEffect(() => {
+    const parent = containerRef.current?.parentElement;
+    if (!parent) return;
+    parent.addEventListener("scroll", schedulePinnedUpdate, { passive: true });
+    return () => {
+      parent.removeEventListener("scroll", schedulePinnedUpdate);
+      if (frameRef.current !== null) {
+        cancelAnimationFrame(frameRef.current);
+        frameRef.current = null;
+      }
+    };
+  }, [containerRef, schedulePinnedUpdate]);
+
+  // Follow layout shifts from streamed content growing below the fold.
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+    const observer = new ResizeObserver(schedulePinnedUpdate);
+    observer.observe(container);
+    return () => observer.disconnect();
+  }, [containerRef, schedulePinnedUpdate]);
+
+  // Recompute when the message list itself changes (send, stream, replay).
+  useEffect(() => {
+    schedulePinnedUpdate();
+  }, [messages, schedulePinnedUpdate]);
+
+  /**
+   * Stable per-id ref callback for a user message's root node. Returning a
+   * cached callback keeps React from detaching/re-attaching refs on every
+   * render (and from misreading a non-void return as a React 19 ref cleanup).
+   */
+  const registerPromptNode = useCallback((id: string) => {
+    const cached = refCallbacksRef.current.get(id);
+    if (cached) return cached;
+    const callback = (node: HTMLElement | null) => {
+      if (node) {
+        promptNodesRef.current.set(id, node);
+      } else {
+        promptNodesRef.current.delete(id);
+      }
+    };
+    refCallbacksRef.current.set(id, callback);
+    return callback;
+  }, []);
+
+  /** Scroll the pinned prompt's original bubble back to the top of the view. */
+  const jumpToPinnedPrompt = useCallback(() => {
+    const parent = containerRef.current?.parentElement;
+    const node = pinnedId ? promptNodesRef.current.get(pinnedId) : undefined;
+    if (!parent || !node) return;
+    const delta =
+      node.getBoundingClientRect().top -
+      parent.getBoundingClientRect().top -
+      JUMP_OFFSET_PX;
+    parent.scrollTo({ top: parent.scrollTop + delta, behavior: "smooth" });
+  }, [containerRef, pinnedId]);
+
+  const pinnedMessage =
+    messages.find((message) => message.id === pinnedId) ?? null;
+
+  return { pinnedMessage, registerPromptNode, jumpToPinnedPrompt };
+}

--- a/app/hooks/usePinnedPrompt.ts
+++ b/app/hooks/usePinnedPrompt.ts
@@ -48,6 +48,10 @@ export function usePinnedPrompt(
       if (!node) continue;
       const rect = node.getBoundingClientRect();
       prompts.push({ id: message.id, top: rect.top, bottom: rect.bottom });
+      // resolvePinnedPromptId stops at the first prompt still crossing or below
+      // the container top, so measuring any further prompts is wasted layout
+      // work — bail as soon as we've collected that boundary prompt.
+      if (rect.bottom > containerTop) break;
     }
     setPinnedId(resolvePinnedPromptId(prompts, containerTop));
   }, [containerRef]);

--- a/app/utils/__tests__/pinnedPrompt.test.ts
+++ b/app/utils/__tests__/pinnedPrompt.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from "vitest";
+import {
+  resolvePinnedPromptId,
+  PIN_CONTEXT_ZONE_PX,
+  PromptRect,
+} from "../pinnedPrompt";
+
+const CONTAINER_TOP = 100;
+
+function rect(id: string, top: number, bottom: number): PromptRect {
+  return { id, top, bottom };
+}
+
+describe("resolvePinnedPromptId", () => {
+  it("returns null when there are no prompts", () => {
+    expect(resolvePinnedPromptId([], CONTAINER_TOP)).toBeNull();
+  });
+
+  it("returns null when no prompt has scrolled above the container top", () => {
+    const prompts = [rect("a", 300, 350)];
+    expect(resolvePinnedPromptId(prompts, CONTAINER_TOP)).toBeNull();
+  });
+
+  it("pins a prompt once it has fully scrolled above the container top", () => {
+    const prompts = [rect("a", -50, 60)];
+    expect(resolvePinnedPromptId(prompts, CONTAINER_TOP)).toBe("a");
+  });
+
+  it("treats a prompt whose bottom sits exactly at the container top as scrolled out", () => {
+    const prompts = [rect("a", 40, CONTAINER_TOP)];
+    expect(resolvePinnedPromptId(prompts, CONTAINER_TOP)).toBe("a");
+  });
+
+  it("pins the most recent prompt when several have scrolled out", () => {
+    const prompts = [
+      rect("a", -400, -300),
+      rect("b", -200, -100),
+      rect("c", 400, 460),
+    ];
+    expect(resolvePinnedPromptId(prompts, CONTAINER_TOP)).toBe("b");
+  });
+
+  it("yields (returns null) while a prompt bubble is visible inside the context zone", () => {
+    const inZone = CONTAINER_TOP + PIN_CONTEXT_ZONE_PX / 2;
+    const prompts = [rect("a", -200, -100), rect("b", inZone, inZone + 50)];
+    expect(resolvePinnedPromptId(prompts, CONTAINER_TOP)).toBeNull();
+  });
+
+  it("yields while a tall prompt bubble straddles the container top edge", () => {
+    const prompts = [rect("a", CONTAINER_TOP - 40, CONTAINER_TOP + 200)];
+    expect(resolvePinnedPromptId(prompts, CONTAINER_TOP)).toBeNull();
+  });
+
+  it("keeps the previous prompt pinned once the next bubble is below the context zone", () => {
+    const belowZone = CONTAINER_TOP + PIN_CONTEXT_ZONE_PX;
+    const prompts = [
+      rect("a", -200, -100),
+      rect("b", belowZone, belowZone + 50),
+    ];
+    expect(resolvePinnedPromptId(prompts, CONTAINER_TOP)).toBe("a");
+  });
+
+  it("ignores prompts after the first one still on screen", () => {
+    const prompts = [
+      rect("a", -200, -100),
+      rect("b", 500, 560),
+      rect("c", 700, 760),
+    ];
+    expect(resolvePinnedPromptId(prompts, CONTAINER_TOP)).toBe("a");
+  });
+
+  it("measures against the provided container top, not the viewport origin", () => {
+    const prompts = [rect("a", 10, 40)];
+    // Above a container whose top edge is at y=50 → pinned.
+    expect(resolvePinnedPromptId(prompts, 50)).toBe("a");
+    // Same rect inside a container starting at y=0 → visible in zone → yields.
+    expect(resolvePinnedPromptId(prompts, 0)).toBeNull();
+  });
+});

--- a/app/utils/pinnedPrompt.ts
+++ b/app/utils/pinnedPrompt.ts
@@ -1,0 +1,46 @@
+/**
+ * Geometry for one user-prompt bubble in viewport coordinates (as returned by
+ * getBoundingClientRect). Arrays passed to the resolver must be in document
+ * order (oldest prompt first).
+ */
+export interface PromptRect {
+  id: string;
+  top: number;
+  bottom: number;
+}
+
+/** Gap between the scroll container's top edge and the pinned card. */
+export const PIN_TOP_OFFSET_PX = 8;
+
+/**
+ * Height of the strip below the container's top edge where the pinned card
+ * floats (top offset + max card height + breathing room). While a prompt
+ * bubble is visible inside this strip it provides its own context, so the
+ * card yields to it instead of covering it — this is what keeps the card
+ * from duplicating or occluding a freshly sent prompt that the send handler
+ * has just scroll-locked to the top of the panel.
+ */
+export const PIN_CONTEXT_ZONE_PX = 72;
+
+/**
+ * Pick the prompt whose turn owns the content at the top of the viewport:
+ * the most recent prompt scrolled fully above the container's top edge.
+ *
+ * Returns null when no prompt has scrolled out yet, or when a prompt bubble
+ * is visible inside the context zone (the bubble itself is the context).
+ */
+export function resolvePinnedPromptId(
+  prompts: PromptRect[],
+  containerTop: number
+): string | null {
+  let pinnedId: string | null = null;
+  for (const prompt of prompts) {
+    if (prompt.bottom <= containerTop) {
+      pinnedId = prompt.id;
+      continue;
+    }
+    if (prompt.top < containerTop + PIN_CONTEXT_ZONE_PX) return null;
+    break;
+  }
+  return pinnedId;
+}


### PR DESCRIPTION
## Summary
- Adds a sticky `PinnedPrompt` overlay that keeps the in-flight user prompt visible while the response streams in, with a jump-back affordance to scroll to the original message.
- New `usePinnedPrompt` hook tracks the last user message's position via `IntersectionObserver` and derives pinned state.
- Pure helpers in `app/utils/pinnedPrompt.ts` with unit tests.
- Moves scroller top padding into `ChatMessages` (sticky offsets would otherwise include the scroll container's padding).
- `MessageBubble` accepts a ref and drives first-child top margin off the `isFirst` prop so the overlay doesn't disturb spacing.

Originally landed directly on `develop` as c7a3c9d without a PR; that commit has been reverted on `develop` and reapplied here via cherry-pick for review.

<img width="860" height="1112" alt="image" src="https://github.com/user-attachments/assets/24c5eb94-86b7-4489-8e16-39a3960aafa9" />

## Test plan
- [ ] `pnpm test` passes (includes `app/utils/__tests__/pinnedPrompt.test.ts`)
- [ ] `pnpm typecheck` / `pnpm lint` / `pnpm format:check` pass
- [ ] Manually verify in the full-size and compact chat panels: send a message, confirm it pins to the top while the response streams, and the jump-back affordance scrolls to the original message