### PR TITLE
feat(chat): add voice-to-text (dictation) input flagged begind ff=voice

### DIFF
--- a/app/components/ChatInput.tsx
+++ b/app/components/ChatInput.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useState } from "react";
+import { useRef, useState } from "react";
 import {
   Button,
   Flex,
@@ -10,7 +10,12 @@ import {
   Text,
   Portal,
 } from "@chakra-ui/react";
-import { ArrowBendRightUpIcon, StopIcon } from "@phosphor-icons/react";
+import {
+  ArrowBendRightUpIcon,
+  MicrophoneIcon,
+  MicrophoneSlashIcon,
+  StopIcon,
+} from "@phosphor-icons/react";
 import { format } from "date-fns";
 import useChatStore from "@/app/store/chatStore";
 import ContextButton, { ChatContextType } from "./ContextButton";
@@ -19,6 +24,7 @@ import ContextMenu from "./ContextMenu";
 import useMapStore from "../store/mapStore";
 import { isAreaLayer } from "../store/layerManagerSlice";
 import useSidebarStore from "../store/sidebarStore";
+import useSpeechInput from "../hooks/useSpeechInput";
 import { useRouter } from "next/navigation";
 
 export default function ChatInput({
@@ -70,6 +76,20 @@ export default function ChatInput({
   const excludedLayerIds = useChatStore((s) => s.excludedContextLayerIds);
   const excludedSet = new Set(excludedLayerIds);
 
+  // Voice dictation. `speech` is null when the browser lacks the Web Speech
+  // API, in which case the mic button is not rendered. Dictation appends to
+  // whatever is already typed, so we snapshot that text when a session starts.
+  const dictationBaseRef = useRef("");
+  const speech = useSpeechInput({
+    onStart: () => {
+      dictationBaseRef.current = inputValue.trim()
+        ? `${inputValue.trim()} `
+        : "";
+    },
+    onResult: (transcript) =>
+      setInputValue(dictationBaseRef.current + transcript),
+  });
+
   // Pills reflect layers/dates active in chat context. Dismissing a pill
   // removes it from context only; the map layer stays visible.
   const datasetPillLayers = layers.filter(
@@ -111,6 +131,7 @@ export default function ChatInput({
   const submitPrompt = async () => {
     if (!inputValue.trim() || isLoading) return;
 
+    speech?.stop();
     const message = inputValue.trim();
     setInputValue("");
     onAfterSend?.();
@@ -252,40 +273,62 @@ export default function ChatInput({
             aria-expanded={areasPanelOpen}
           />
         </Flex>
-        {canCancelRequest ? (
-          <Button
-            p="0"
-            ml="auto"
-            borderRadius="full"
-            variant="solid"
-            colorPalette="primary"
-            type="button"
-            size="xs"
-            aria-label="Cancel request"
-            onClick={cancelRequest}
-            title="Cancel request"
-          >
-            <StopIcon weight="fill" />
-          </Button>
-        ) : (
-          <Button
-            p="0"
-            ml="auto"
-            borderRadius="full"
-            variant="solid"
-            colorPalette="primary"
-            _disabled={{
-              opacity: 0.36,
-            }}
-            type="button"
-            size="xs"
-            aria-label="Send prompt"
-            onClick={submitPrompt}
-            disabled={isButtonDisabled}
-          >
-            <ArrowBendRightUpIcon weight="bold" />
-          </Button>
-        )}
+        <Flex gap="2" ml="auto" alignItems="center">
+          {speech && (
+            <Button
+              p="0"
+              borderRadius="full"
+              variant={speech.listening ? "solid" : "ghost"}
+              colorPalette={speech.listening ? "red" : "gray"}
+              type="button"
+              size="xs"
+              aria-label={
+                speech.listening ? "Stop dictation" : "Dictate message"
+              }
+              title={speech.listening ? "Stop dictation" : "Dictate message"}
+              onClick={speech.toggle}
+              disabled={disabled}
+            >
+              {speech.listening ? (
+                <MicrophoneSlashIcon weight="fill" />
+              ) : (
+                <MicrophoneIcon weight="bold" />
+              )}
+            </Button>
+          )}
+          {canCancelRequest ? (
+            <Button
+              p="0"
+              borderRadius="full"
+              variant="solid"
+              colorPalette="primary"
+              type="button"
+              size="xs"
+              aria-label="Cancel request"
+              onClick={cancelRequest}
+              title="Cancel request"
+            >
+              <StopIcon weight="fill" />
+            </Button>
+          ) : (
+            <Button
+              p="0"
+              borderRadius="full"
+              variant="solid"
+              colorPalette="primary"
+              _disabled={{
+                opacity: 0.36,
+              }}
+              type="button"
+              size="xs"
+              aria-label="Send prompt"
+              onClick={submitPrompt}
+              disabled={isButtonDisabled}
+            >
+              <ArrowBendRightUpIcon weight="bold" />
+            </Button>
+          )}
+        </Flex>
       </Flex>
     </Flex>
   );

--- a/app/components/ChatInput.tsx
+++ b/app/components/ChatInput.tsx
@@ -13,7 +13,6 @@ import {
 import {
   ArrowBendRightUpIcon,
   MicrophoneIcon,
-  MicrophoneSlashIcon,
   StopIcon,
 } from "@phosphor-icons/react";
 import { format } from "date-fns";
@@ -21,11 +20,14 @@ import useChatStore from "@/app/store/chatStore";
 import ContextButton, { ChatContextType } from "./ContextButton";
 import ContextTag from "./ContextTag";
 import ContextMenu from "./ContextMenu";
+import VoiceListeningPanel from "./voice/VoiceListeningPanel";
+import VoiceErrorPanel from "./voice/VoiceErrorPanel";
 import useMapStore from "../store/mapStore";
 import { isAreaLayer } from "../store/layerManagerSlice";
 import useSidebarStore from "../store/sidebarStore";
 import useAuthStore from "../store/authStore";
 import useSpeechInput from "../hooks/useSpeechInput";
+import usePrefersReducedMotion from "../hooks/usePrefersReducedMotion";
 import { resolveSpeechLang } from "../utils/speechLang";
 import { useRouter } from "next/navigation";
 
@@ -79,14 +81,16 @@ export default function ChatInput({
   const excludedSet = new Set(excludedLayerIds);
 
   // Voice dictation. `speech` is null when the browser lacks the Web Speech
-  // API, in which case the mic button is not rendered. Dictation appends to
-  // whatever is already typed, so we snapshot that text when a session starts.
-  // The Web Speech API can't detect the spoken language, so we default it from
-  // the user's onboarding preference, then the browser language, then en-US.
+  // API, in which case the mic control is not rendered. The committed
+  // transcript is appended to whatever is already typed, so we snapshot that
+  // text when a session starts. The Web Speech API can't detect the spoken
+  // language, so we default it from the user's onboarding preference, then the
+  // browser language, then en-US — with an in-listening override menu.
   const preferredLanguageCode = useAuthStore((s) => s.preferredLanguageCode);
+  const prefersReducedMotion = usePrefersReducedMotion();
   const dictationBaseRef = useRef("");
   const speech = useSpeechInput({
-    lang: resolveSpeechLang(
+    initialLang: resolveSpeechLang(
       preferredLanguageCode,
       typeof navigator !== "undefined" ? navigator.language : null
     ),
@@ -95,7 +99,7 @@ export default function ChatInput({
         ? `${inputValue.trim()} `
         : "";
     },
-    onResult: (transcript) =>
+    onCommit: (transcript) =>
       setInputValue(dictationBaseRef.current + transcript),
   });
 
@@ -140,7 +144,6 @@ export default function ChatInput({
   const submitPrompt = async () => {
     if (!inputValue.trim() || isLoading) return;
 
-    speech?.stop();
     const message = inputValue.trim();
     setInputValue("");
     onAfterSend?.();
@@ -244,101 +247,118 @@ export default function ChatInput({
           )}
         </Flex>
       )}
-      <Textarea
-        ref={setFocusEl}
-        aria-label="Ask a question..."
-        placeholder={message}
-        // 16px on mobile — iOS Safari auto-zooms focused inputs below 16px.
-        fontSize={{ base: "md", md: "sm" }}
-        minH="20px"
-        autoresize
-        maxH="10lh"
-        border="none"
-        p={0}
-        value={inputValue}
-        onChange={(e) => setInputValue(e.target.value)}
-        onKeyDown={handleKeyDown}
-        disabled={disabled}
-        _disabled={{ opacity: 1 }}
-        _focus={{ outline: "none", boxShadow: "none" }}
-        _placeholder={{ color: disabled ? "gray.400" : "gray.600" }}
-      />
-      <Flex justifyContent="space-between" alignItems="center" w="full">
-        <Flex gap="2">
-          <ContextButton
-            contextType="layer"
-            onClick={openLayerPicker}
+      {speech && speech.phase === "listening" ? (
+        <VoiceListeningPanel
+          seconds={speech.seconds}
+          committed={speech.committed}
+          interim={speech.interim}
+          lang={speech.lang}
+          onLangChange={speech.setLang}
+          onStop={speech.stop}
+          reducedMotion={prefersReducedMotion}
+        />
+      ) : speech && speech.phase === "error" && speech.errorType ? (
+        <VoiceErrorPanel
+          errorType={speech.errorType}
+          onRetry={speech.retry}
+          onDismiss={speech.dismissError}
+          reducedMotion={prefersReducedMotion}
+        />
+      ) : (
+        <>
+          <Textarea
+            ref={setFocusEl}
+            aria-label="Ask a question..."
+            placeholder={message}
+            // 16px on mobile — iOS Safari auto-zooms focused inputs below 16px.
+            fontSize={{ base: "md", md: "sm" }}
+            minH="20px"
+            autoresize
+            maxH="10lh"
+            border="none"
+            p={0}
+            value={inputValue}
+            onChange={(e) => setInputValue(e.target.value)}
+            onKeyDown={handleKeyDown}
             disabled={disabled}
-            borderColor={dataCatalogOpen ? "primary.solid" : "#E0E2E5"}
-            color={dataCatalogOpen ? "primary.solid" : undefined}
-            aria-expanded={dataCatalogOpen}
+            _disabled={{ opacity: 1 }}
+            _focus={{ outline: "none", boxShadow: "none" }}
+            _placeholder={{ color: disabled ? "gray.400" : "gray.600" }}
           />
-          <ContextButton
-            contextType="area"
-            onClick={openAreaPicker}
-            disabled={disabled}
-            borderColor={areasPanelOpen ? "primary.solid" : "#E0E2E5"}
-            color={areasPanelOpen ? "primary.solid" : undefined}
-            aria-expanded={areasPanelOpen}
-          />
-        </Flex>
-        <Flex gap="2" ml="auto" alignItems="center">
-          {speech && (
-            <Button
-              p="0"
-              borderRadius="full"
-              variant={speech.listening ? "solid" : "ghost"}
-              colorPalette={speech.listening ? "red" : "gray"}
-              type="button"
-              size="xs"
-              aria-label={
-                speech.listening ? "Stop dictation" : "Dictate message"
-              }
-              title={speech.listening ? "Stop dictation" : "Dictate message"}
-              onClick={speech.toggle}
-              disabled={disabled}
-            >
-              {speech.listening ? (
-                <MicrophoneSlashIcon weight="fill" />
-              ) : (
-                <MicrophoneIcon weight="bold" />
+          <Flex justifyContent="space-between" alignItems="center" w="full">
+            <Flex gap="2">
+              <ContextButton
+                contextType="layer"
+                onClick={openLayerPicker}
+                disabled={disabled}
+                borderColor={dataCatalogOpen ? "primary.solid" : "#E0E2E5"}
+                color={dataCatalogOpen ? "primary.solid" : undefined}
+                aria-expanded={dataCatalogOpen}
+              />
+              <ContextButton
+                contextType="area"
+                onClick={openAreaPicker}
+                disabled={disabled}
+                borderColor={areasPanelOpen ? "primary.solid" : "#E0E2E5"}
+                color={areasPanelOpen ? "primary.solid" : undefined}
+                aria-expanded={areasPanelOpen}
+              />
+            </Flex>
+            <Flex gap="2" ml="auto" alignItems="center">
+              {speech && (
+                <Button
+                  p="0"
+                  borderRadius="full"
+                  variant="outline"
+                  bg="white"
+                  borderColor="#E0E2E5"
+                  color="gray.700"
+                  type="button"
+                  size="xs"
+                  aria-label="Start voice input"
+                  title="Start voice input"
+                  onClick={speech.start}
+                  disabled={disabled}
+                >
+                  <MicrophoneIcon />
+                </Button>
               )}
-            </Button>
-          )}
-          {canCancelRequest ? (
-            <Button
-              p="0"
-              borderRadius="full"
-              variant="solid"
-              colorPalette="primary"
-              type="button"
-              size="xs"
-              aria-label="Cancel request"
-              onClick={cancelRequest}
-              title="Cancel request"
-            >
-              <StopIcon weight="fill" />
-            </Button>
-          ) : (
-            <Button
-              p="0"
-              borderRadius="full"
-              variant="solid"
-              colorPalette="primary"
-              _disabled={{
-                opacity: 0.36,
-              }}
-              type="button"
-              size="xs"
-              aria-label="Send prompt"
-              onClick={submitPrompt}
-              disabled={isButtonDisabled}
-            >
-              <ArrowBendRightUpIcon weight="bold" />
-            </Button>
-          )}
-        </Flex>
-      </Flex>
+              {canCancelRequest ? (
+                <Button
+                  p="0"
+                  borderRadius="full"
+                  variant="solid"
+                  colorPalette="primary"
+                  type="button"
+                  size="xs"
+                  aria-label="Cancel request"
+                  onClick={cancelRequest}
+                  title="Cancel request"
+                >
+                  <StopIcon weight="fill" />
+                </Button>
+              ) : (
+                <Button
+                  p="0"
+                  borderRadius="full"
+                  variant="solid"
+                  colorPalette="primary"
+                  _disabled={{
+                    opacity: 0.36,
+                  }}
+                  type="button"
+                  size="xs"
+                  aria-label="Send prompt"
+                  onClick={submitPrompt}
+                  disabled={isButtonDisabled}
+                >
+                  <ArrowBendRightUpIcon weight="bold" />
+                </Button>
+              )}
+            </Flex>
+          </Flex>
+        </>
+      )}
     </Flex>
   );
 

--- a/app/components/ChatInput.tsx
+++ b/app/components/ChatInput.tsx
@@ -24,7 +24,9 @@ import ContextMenu from "./ContextMenu";
 import useMapStore from "../store/mapStore";
 import { isAreaLayer } from "../store/layerManagerSlice";
 import useSidebarStore from "../store/sidebarStore";
+import useAuthStore from "../store/authStore";
 import useSpeechInput from "../hooks/useSpeechInput";
+import { resolveSpeechLang } from "../utils/speechLang";
 import { useRouter } from "next/navigation";
 
 export default function ChatInput({
@@ -79,8 +81,15 @@ export default function ChatInput({
   // Voice dictation. `speech` is null when the browser lacks the Web Speech
   // API, in which case the mic button is not rendered. Dictation appends to
   // whatever is already typed, so we snapshot that text when a session starts.
+  // The Web Speech API can't detect the spoken language, so we default it from
+  // the user's onboarding preference, then the browser language, then en-US.
+  const preferredLanguageCode = useAuthStore((s) => s.preferredLanguageCode);
   const dictationBaseRef = useRef("");
   const speech = useSpeechInput({
+    lang: resolveSpeechLang(
+      preferredLanguageCode,
+      typeof navigator !== "undefined" ? navigator.language : null
+    ),
     onStart: () => {
       dictationBaseRef.current = inputValue.trim()
         ? `${inputValue.trim()} `

--- a/app/components/ChatInput.tsx
+++ b/app/components/ChatInput.tsx
@@ -29,6 +29,7 @@ import useAuthStore from "../store/authStore";
 import useSpeechInput from "../hooks/useSpeechInput";
 import usePrefersReducedMotion from "../hooks/usePrefersReducedMotion";
 import { resolveSpeechLang } from "../utils/speechLang";
+import { useFeatureFlag } from "@/src/shared/lib/feature-flags";
 import { useRouter } from "next/navigation";
 
 export default function ChatInput({
@@ -80,12 +81,14 @@ export default function ChatInput({
   const excludedLayerIds = useChatStore((s) => s.excludedContextLayerIds);
   const excludedSet = new Set(excludedLayerIds);
 
-  // Voice dictation. `speech` is null when the browser lacks the Web Speech
-  // API, in which case the mic control is not rendered. The committed
+  // Voice dictation, gated behind the `ff=voice` hidden-feature flag while it's
+  // still being rolled out. `speech` is null when the browser lacks the Web
+  // Speech API, in which case the mic control is not rendered. The committed
   // transcript is appended to whatever is already typed, so we snapshot that
   // text when a session starts. The Web Speech API can't detect the spoken
   // language, so we default it from the user's onboarding preference, then the
   // browser language, then en-US — with an in-listening override menu.
+  const voiceInputEnabled = useFeatureFlag("voice");
   const preferredLanguageCode = useAuthStore((s) => s.preferredLanguageCode);
   const prefersReducedMotion = usePrefersReducedMotion();
   const dictationBaseRef = useRef("");
@@ -247,7 +250,7 @@ export default function ChatInput({
           )}
         </Flex>
       )}
-      {speech && speech.phase === "listening" ? (
+      {voiceInputEnabled && speech && speech.phase === "listening" ? (
         <VoiceListeningPanel
           seconds={speech.seconds}
           committed={speech.committed}
@@ -257,7 +260,10 @@ export default function ChatInput({
           onStop={speech.stop}
           reducedMotion={prefersReducedMotion}
         />
-      ) : speech && speech.phase === "error" && speech.errorType ? (
+      ) : voiceInputEnabled &&
+        speech &&
+        speech.phase === "error" &&
+        speech.errorType ? (
         <VoiceErrorPanel
           errorType={speech.errorType}
           onRetry={speech.retry}
@@ -305,7 +311,7 @@ export default function ChatInput({
               />
             </Flex>
             <Flex gap="2" ml="auto" alignItems="center">
-              {speech && (
+              {voiceInputEnabled && speech && (
                 <Button
                   p="0"
                   borderRadius="full"

--- a/app/components/providers/index.tsx
+++ b/app/components/providers/index.tsx
@@ -68,8 +68,18 @@ function AuthBootstrapper() {
         const id = data?.id as string | undefined;
         const hasProfile = Boolean(data?.hasProfile);
         const userType = coerceUserType(data?.userType);
+        const preferredLanguageCode =
+          typeof data?.preferredLanguageCode === "string"
+            ? data.preferredLanguageCode
+            : null;
         if (email) {
-          setAuthStatus({ email, id: id ?? "", hasProfile, userType });
+          setAuthStatus({
+            email,
+            id: id ?? "",
+            hasProfile,
+            userType,
+            preferredLanguageCode,
+          });
         } else {
           setAuthLoaded();
         }

--- a/app/components/voice/ShortlistLanguagePicker.tsx
+++ b/app/components/voice/ShortlistLanguagePicker.tsx
@@ -1,0 +1,293 @@
+"use client";
+import { useMemo, useState } from "react";
+import { Box, Button, Flex, Input, Text } from "@chakra-ui/react";
+import {
+  CaretDownIcon,
+  CheckIcon,
+  MagnifyingGlassIcon,
+  TranslateIcon,
+  XCircleIcon,
+} from "@phosphor-icons/react";
+import {
+  VOICE_LANGUAGE_FAMILIES,
+  type VoiceLanguageFamily,
+} from "@/app/utils/speechLang";
+
+const TOTAL_COUNT = VOICE_LANGUAGE_FAMILIES.reduce(
+  (n, f) => n + (f.variants ? f.variants.length : 1),
+  0
+);
+
+const COMMON_FAMILIES = VOICE_LANGUAGE_FAMILIES.filter((f) => f.common);
+const SORTED_FAMILIES = [...VOICE_LANGUAGE_FAMILIES].sort((a, b) =>
+  a.base.localeCompare(b.base)
+);
+
+function familyMatches(f: VoiceLanguageFamily, q: string): boolean {
+  const haystack = [
+    f.base,
+    f.native,
+    ...(f.variants?.flatMap((v) => [v.name, v.tag]) ?? []),
+  ];
+  return haystack.some((s) => s.toLowerCase().includes(q));
+}
+
+function SectionLabel({ children }: { children: React.ReactNode }) {
+  return (
+    <Text
+      fontFamily="mono"
+      fontSize="9.5px"
+      letterSpacing="0.5px"
+      textTransform="uppercase"
+      color="gray.500"
+      px="2.5"
+      pt="1.5"
+      pb="1"
+    >
+      {children}
+    </Text>
+  );
+}
+
+function LanguageIcon({ children }: { children: React.ReactNode }) {
+  return (
+    <Box as="span" display="inline-flex" color="gray.500">
+      {children}
+    </Box>
+  );
+}
+
+/**
+ * Searchable language picker: a "Common" shortlist (with regional variant
+ * chips) shown first, an expander to the full alphabetical list, live search,
+ * and an empty state. Selecting a language calls `onChange` with its BCP-47 tag.
+ */
+export default function ShortlistLanguagePicker({
+  value,
+  onChange,
+}: {
+  value: string;
+  onChange: (code: string) => void;
+}) {
+  const [query, setQuery] = useState("");
+  const [expanded, setExpanded] = useState(false);
+  const q = query.trim().toLowerCase();
+  const hasQuery = q.length > 0;
+  const showCommon = !hasQuery && !expanded;
+
+  const filtered = useMemo(
+    () =>
+      hasQuery
+        ? SORTED_FAMILIES.filter((f) => familyMatches(f, q))
+        : SORTED_FAMILIES,
+    [hasQuery, q]
+  );
+
+  const renderFamily = (f: VoiceLanguageFamily) => {
+    if (f.variants) {
+      const anyActive = f.variants.some((v) => v.code === value);
+      return (
+        <Flex key={f.base} flexDir="column" gap="1.5" px="2.5" py="1.5">
+          <Button
+            type="button"
+            variant="plain"
+            h="auto"
+            p="0"
+            justifyContent="space-between"
+            gap="2"
+            onClick={() => onChange(f.variants![0].code)}
+          >
+            <Text as="span" fontSize="12.5px" color="fg" whiteSpace="nowrap">
+              {f.base}
+            </Text>
+            <Flex align="center" gap="1.5">
+              <Text
+                as="span"
+                fontSize="11.5px"
+                color="gray.500"
+                whiteSpace="nowrap"
+              >
+                {f.native}
+              </Text>
+              {anyActive && (
+                <Box as="span" color="primary.solid" display="inline-flex">
+                  <CheckIcon size={13} weight="bold" />
+                </Box>
+              )}
+            </Flex>
+          </Button>
+          <Flex wrap="wrap" gap="1.5">
+            {f.variants.map((v) => {
+              const on = v.code === value;
+              return (
+                <Button
+                  key={v.code}
+                  type="button"
+                  variant="plain"
+                  h="auto"
+                  px="2"
+                  py="0.5"
+                  borderRadius="full"
+                  borderWidth="1px"
+                  borderColor={on ? "primary.solid" : "border.emphasized"}
+                  bg={on ? "primary.solid" : "white"}
+                  color={on ? "white" : "fg.muted"}
+                  fontSize="11px"
+                  fontWeight="normal"
+                  onClick={() => onChange(v.code)}
+                >
+                  {v.tag}
+                </Button>
+              );
+            })}
+          </Flex>
+        </Flex>
+      );
+    }
+
+    const on = f.code === value;
+    return (
+      <Button
+        key={f.base}
+        type="button"
+        variant="plain"
+        w="full"
+        h="auto"
+        justifyContent="space-between"
+        gap="2"
+        px="2.5"
+        py="1.5"
+        borderRadius="md"
+        bg={on ? "primary.25" : "transparent"}
+        _hover={{ bg: "gray.100" }}
+        onClick={() => onChange(f.code as string)}
+      >
+        <Text as="span" fontSize="12.5px" color="fg" whiteSpace="nowrap">
+          {f.base}
+        </Text>
+        <Flex align="center" gap="1.5">
+          <Text
+            as="span"
+            fontSize="11.5px"
+            color="gray.500"
+            whiteSpace="nowrap"
+          >
+            {f.native}
+          </Text>
+          {on && (
+            <Box as="span" color="primary.solid" display="inline-flex">
+              <CheckIcon size={13} weight="bold" />
+            </Box>
+          )}
+        </Flex>
+      </Button>
+    );
+  };
+
+  return (
+    <Box w="262px" maxW="100%">
+      {/* Search */}
+      <Box p="1.5" borderBottomWidth="1px" borderColor="gray.100">
+        <Flex
+          align="center"
+          gap="1.5"
+          px="2"
+          py="1.5"
+          bg="gray.50"
+          borderWidth="1px"
+          borderColor="gray.100"
+          borderRadius="md"
+        >
+          <LanguageIcon>
+            <MagnifyingGlassIcon size={13} />
+          </LanguageIcon>
+          <Input
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder={`Search ${TOTAL_COUNT} languages`}
+            aria-label="Search languages"
+            autoFocus
+            flex="1"
+            minW="0"
+            border="none"
+            bg="transparent"
+            h="auto"
+            p="0"
+            fontSize="12.5px"
+            _focus={{ outline: "none", boxShadow: "none" }}
+            _focusVisible={{ outline: "none", boxShadow: "none" }}
+          />
+          {hasQuery && (
+            <Button
+              type="button"
+              variant="plain"
+              p="0"
+              h="auto"
+              minW="0"
+              color="gray.500"
+              aria-label="Clear search"
+              onClick={() => setQuery("")}
+            >
+              <XCircleIcon size={14} />
+            </Button>
+          )}
+        </Flex>
+      </Box>
+
+      {/* List */}
+      <Box maxH="280px" overflowY="auto" p="1">
+        {showCommon ? (
+          <>
+            <SectionLabel>Common</SectionLabel>
+            {COMMON_FAMILIES.map(renderFamily)}
+            <Button
+              type="button"
+              variant="plain"
+              w="full"
+              h="auto"
+              justifyContent="space-between"
+              gap="2"
+              mt="0.5"
+              px="2.5"
+              py="1.5"
+              borderTopWidth="1px"
+              borderColor="gray.100"
+              borderRadius="0"
+              onClick={() => setExpanded(true)}
+            >
+              <Text
+                as="span"
+                fontSize="12px"
+                fontWeight="medium"
+                color="primary.solid"
+              >
+                Show all {TOTAL_COUNT} languages
+              </Text>
+              <Box as="span" color="primary.solid" display="inline-flex">
+                <CaretDownIcon size={12} />
+              </Box>
+            </Button>
+          </>
+        ) : filtered.length > 0 ? (
+          <>
+            <SectionLabel>
+              {hasQuery
+                ? `${filtered.length} result${filtered.length === 1 ? "" : "s"}`
+                : "All languages"}
+            </SectionLabel>
+            {filtered.map(renderFamily)}
+          </>
+        ) : (
+          <Flex flexDir="column" align="center" py="5" px="3">
+            <Box as="span" color="gray.400">
+              <TranslateIcon size={18} />
+            </Box>
+            <Text fontSize="12px" color="fg.muted" mt="1.5" textAlign="center">
+              No languages match “{query}”
+            </Text>
+          </Flex>
+        )}
+      </Box>
+    </Box>
+  );
+}

--- a/app/components/voice/VoiceErrorPanel.tsx
+++ b/app/components/voice/VoiceErrorPanel.tsx
@@ -1,0 +1,130 @@
+"use client";
+import { Box, Button, Flex, Text } from "@chakra-ui/react";
+import {
+  ArrowClockwiseIcon,
+  MicrophoneIcon,
+  MicrophoneSlashIcon,
+  PlugsIcon,
+  WaveformIcon,
+} from "@phosphor-icons/react";
+import type { VoiceErrorType } from "@/app/hooks/useSpeechInput";
+
+interface ErrorSpec {
+  title: string;
+  body: string;
+  Icon: typeof MicrophoneSlashIcon;
+  RetryIcon: typeof ArrowClockwiseIcon;
+  retryLabel: string;
+  tintBg: string;
+  tintFg: string;
+}
+
+const ERROR_SPECS: Record<VoiceErrorType, ErrorSpec> = {
+  denied: {
+    title: "Microphone access blocked",
+    body: "Zeno can't hear you. Allow microphone access in your browser's site settings to use voice input.",
+    Icon: MicrophoneSlashIcon,
+    RetryIcon: ArrowClockwiseIcon,
+    retryLabel: "Try again",
+    tintBg: "#FDECEA",
+    tintFg: "red.500",
+  },
+  "no-speech": {
+    title: "No speech detected",
+    body: "I didn't catch anything. Check that your microphone is working and try again.",
+    Icon: WaveformIcon,
+    RetryIcon: MicrophoneIcon,
+    retryLabel: "Try again",
+    tintBg: "#FFF4E5",
+    tintFg: "#C2410C",
+  },
+  "no-mic": {
+    title: "No microphone found",
+    body: "Connect a microphone to use voice input, or type your question instead.",
+    Icon: PlugsIcon,
+    RetryIcon: ArrowClockwiseIcon,
+    retryLabel: "Try again",
+    tintBg: "#FDECEA",
+    tintFg: "red.500",
+  },
+  other: {
+    title: "Voice input unavailable",
+    body: "Something went wrong with voice input. Try again, or type your question instead.",
+    Icon: MicrophoneSlashIcon,
+    RetryIcon: ArrowClockwiseIcon,
+    retryLabel: "Try again",
+    tintBg: "#FDECEA",
+    tintFg: "red.500",
+  },
+};
+
+/**
+ * Error state of the voice prompt box, wired to real SpeechRecognition error
+ * types. Offers a retry and a "Type instead" escape back to the text box.
+ */
+export default function VoiceErrorPanel({
+  errorType,
+  onRetry,
+  onDismiss,
+  reducedMotion,
+}: {
+  errorType: VoiceErrorType;
+  onRetry: () => void;
+  onDismiss: () => void;
+  reducedMotion: boolean;
+}) {
+  const spec = ERROR_SPECS[errorType];
+  const { Icon, RetryIcon } = spec;
+
+  return (
+    <Flex
+      gap="3"
+      animation={reducedMotion ? undefined : "vpFadeUp 0.22s ease both"}
+    >
+      <Box
+        as="span"
+        flex="none"
+        w="34px"
+        h="34px"
+        borderRadius="full"
+        bg={spec.tintBg}
+        color={spec.tintFg}
+        display="inline-flex"
+        alignItems="center"
+        justifyContent="center"
+      >
+        <Icon size={18} />
+      </Box>
+      <Box flex="1">
+        <Text fontSize="sm" fontWeight="semibold" color="fg">
+          {spec.title}
+        </Text>
+        <Text fontSize="xs" lineHeight="1.5" color="fg.muted" mt="1">
+          {spec.body}
+        </Text>
+        <Flex gap="2" mt="3">
+          <Button
+            type="button"
+            onClick={onRetry}
+            size="xs"
+            colorPalette="primary"
+            gap="1.5"
+          >
+            <RetryIcon size={14} />
+            {spec.retryLabel}
+          </Button>
+          <Button
+            type="button"
+            onClick={onDismiss}
+            size="xs"
+            variant="outline"
+            borderColor="#E0E2E5"
+            color="fg.muted"
+          >
+            Type instead
+          </Button>
+        </Flex>
+      </Box>
+    </Flex>
+  );
+}

--- a/app/components/voice/VoiceErrorPanel.tsx
+++ b/app/components/voice/VoiceErrorPanel.tsx
@@ -14,7 +14,7 @@ interface ErrorSpec {
   body: string;
   Icon: typeof MicrophoneSlashIcon;
   RetryIcon: typeof ArrowClockwiseIcon;
-  retryLabel: string;
+  /** Semantic background/foreground tokens for the icon badge. */
   tintBg: string;
   tintFg: string;
 }
@@ -25,36 +25,32 @@ const ERROR_SPECS: Record<VoiceErrorType, ErrorSpec> = {
     body: "Zeno can't hear you. Allow microphone access in your browser's site settings to use voice input.",
     Icon: MicrophoneSlashIcon,
     RetryIcon: ArrowClockwiseIcon,
-    retryLabel: "Try again",
-    tintBg: "#FDECEA",
-    tintFg: "red.500",
+    tintBg: "bg.error",
+    tintFg: "fg.error",
   },
   "no-speech": {
     title: "No speech detected",
     body: "I didn't catch anything. Check that your microphone is working and try again.",
     Icon: WaveformIcon,
     RetryIcon: MicrophoneIcon,
-    retryLabel: "Try again",
-    tintBg: "#FFF4E5",
-    tintFg: "#C2410C",
+    tintBg: "bg.warning",
+    tintFg: "fg.warning",
   },
   "no-mic": {
     title: "No microphone found",
     body: "Connect a microphone to use voice input, or type your question instead.",
     Icon: PlugsIcon,
     RetryIcon: ArrowClockwiseIcon,
-    retryLabel: "Try again",
-    tintBg: "#FDECEA",
-    tintFg: "red.500",
+    tintBg: "bg.error",
+    tintFg: "fg.error",
   },
   other: {
     title: "Voice input unavailable",
     body: "Something went wrong with voice input. Try again, or type your question instead.",
     Icon: MicrophoneSlashIcon,
     RetryIcon: ArrowClockwiseIcon,
-    retryLabel: "Try again",
-    tintBg: "#FDECEA",
-    tintFg: "red.500",
+    tintBg: "bg.error",
+    tintFg: "fg.error",
   },
 };
 
@@ -79,7 +75,7 @@ export default function VoiceErrorPanel({
   return (
     <Flex
       gap="3"
-      animation={reducedMotion ? undefined : "vpFadeUp 0.22s ease both"}
+      animation={reducedMotion ? undefined : "fadeSlideIn 0.22s ease both"}
     >
       <Box
         as="span"
@@ -111,7 +107,7 @@ export default function VoiceErrorPanel({
             gap="1.5"
           >
             <RetryIcon size={14} />
-            {spec.retryLabel}
+            Try again
           </Button>
           <Button
             type="button"

--- a/app/components/voice/VoiceLanguageMenu.tsx
+++ b/app/components/voice/VoiceLanguageMenu.tsx
@@ -1,0 +1,102 @@
+"use client";
+import { useState } from "react";
+import { Box, Button, Text } from "@chakra-ui/react";
+import { CaretDownIcon, CheckIcon, TranslateIcon } from "@phosphor-icons/react";
+import { VOICE_LANGUAGES, labelForLang } from "@/app/utils/speechLang";
+
+/**
+ * Compact language override shown in the listening footer. Opens upward (the
+ * prompt box sits at the bottom of the panel). A full-screen click-catcher
+ * closes it on outside click.
+ */
+export default function VoiceLanguageMenu({
+  value,
+  onChange,
+}: {
+  value: string;
+  onChange: (code: string) => void;
+}) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <Box position="relative" display="inline-flex">
+      <Button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        aria-label="Change dictation language"
+        aria-expanded={open}
+        variant="plain"
+        p="1"
+        h="auto"
+        minW="0"
+        gap="1.5"
+        fontFamily="mono"
+        fontSize="10px"
+        letterSpacing="0.5px"
+        textTransform="uppercase"
+        color="gray.500"
+      >
+        <TranslateIcon size={13} />
+        {labelForLang(value)}
+        <CaretDownIcon size={11} />
+      </Button>
+
+      {open && (
+        <>
+          <Box
+            position="fixed"
+            inset="0"
+            zIndex={29}
+            onClick={() => setOpen(false)}
+          />
+          <Box
+            position="absolute"
+            bottom="calc(100% + 8px)"
+            left="0"
+            zIndex={30}
+            minW="184px"
+            bg="white"
+            borderWidth="1px"
+            borderColor="#E1E2E6"
+            borderRadius="md"
+            boxShadow="0 4px 16px rgba(19,22,25,.16)"
+            p="1"
+            animation="vpFadeUp 0.22s ease both"
+          >
+            {VOICE_LANGUAGES.map((l) => (
+              <Button
+                key={l.code}
+                type="button"
+                onClick={() => {
+                  onChange(l.code);
+                  setOpen(false);
+                }}
+                variant="plain"
+                w="full"
+                justifyContent="space-between"
+                gap="2"
+                px="2"
+                py="1.5"
+                h="auto"
+                borderRadius="sm"
+                fontSize="12.5px"
+                fontWeight="normal"
+                color="fg"
+                _hover={{ bg: "gray.100" }}
+              >
+                <Text as="span" whiteSpace="nowrap">
+                  {l.label}
+                </Text>
+                {l.code === value && (
+                  <Box as="span" color="primary.solid" display="inline-flex">
+                    <CheckIcon size={13} weight="bold" />
+                  </Box>
+                )}
+              </Button>
+            ))}
+          </Box>
+        </>
+      )}
+    </Box>
+  );
+}

--- a/app/components/voice/VoiceLanguageMenu.tsx
+++ b/app/components/voice/VoiceLanguageMenu.tsx
@@ -1,13 +1,12 @@
 "use client";
-import { useState } from "react";
-import { Box, Button, Text } from "@chakra-ui/react";
+import { Box, Button, Menu, Portal, Text } from "@chakra-ui/react";
 import { CaretDownIcon, CheckIcon, TranslateIcon } from "@phosphor-icons/react";
 import { VOICE_LANGUAGES, labelForLang } from "@/app/utils/speechLang";
 
 /**
- * Compact language override shown in the listening footer. Opens upward (the
- * prompt box sits at the bottom of the panel). A full-screen click-catcher
- * closes it on outside click.
+ * Compact language override shown in the listening footer. Built on the app's
+ * Chakra Menu so outside-click, Escape, focus management, keyboard navigation,
+ * and ARIA roles come for free. Opens upward since the prompt box sits low.
  */
 export default function VoiceLanguageMenu({
   value,
@@ -16,75 +15,42 @@ export default function VoiceLanguageMenu({
   value: string;
   onChange: (code: string) => void;
 }) {
-  const [open, setOpen] = useState(false);
-
   return (
-    <Box position="relative" display="inline-flex">
-      <Button
-        type="button"
-        onClick={() => setOpen((o) => !o)}
-        aria-label="Change dictation language"
-        aria-expanded={open}
-        variant="plain"
-        p="1"
-        h="auto"
-        minW="0"
-        gap="1.5"
-        fontFamily="mono"
-        fontSize="10px"
-        letterSpacing="0.5px"
-        textTransform="uppercase"
-        color="gray.500"
-      >
-        <TranslateIcon size={13} />
-        {labelForLang(value)}
-        <CaretDownIcon size={11} />
-      </Button>
-
-      {open && (
-        <>
-          <Box
-            position="fixed"
-            inset="0"
-            zIndex={29}
-            onClick={() => setOpen(false)}
-          />
-          <Box
-            position="absolute"
-            bottom="calc(100% + 8px)"
-            left="0"
-            zIndex={30}
-            minW="184px"
-            bg="white"
-            borderWidth="1px"
-            borderColor="#E1E2E6"
-            borderRadius="md"
-            boxShadow="0 4px 16px rgba(19,22,25,.16)"
-            p="1"
-            animation="vpFadeUp 0.22s ease both"
-          >
+    <Menu.Root
+      positioning={{ placement: "top-start" }}
+      onSelect={({ value: code }) => onChange(code)}
+    >
+      <Menu.Trigger asChild>
+        <Button
+          type="button"
+          aria-label="Change dictation language"
+          variant="plain"
+          p="1"
+          h="auto"
+          minW="0"
+          gap="1.5"
+          fontFamily="mono"
+          fontSize="10px"
+          letterSpacing="0.5px"
+          textTransform="uppercase"
+          color="gray.500"
+        >
+          <TranslateIcon size={13} />
+          {labelForLang(value)}
+          <CaretDownIcon size={11} />
+        </Button>
+      </Menu.Trigger>
+      <Portal>
+        <Menu.Positioner>
+          <Menu.Content minW="184px" zIndex={1500}>
             {VOICE_LANGUAGES.map((l) => (
-              <Button
+              <Menu.Item
                 key={l.code}
-                type="button"
-                onClick={() => {
-                  onChange(l.code);
-                  setOpen(false);
-                }}
-                variant="plain"
-                w="full"
+                value={l.code}
                 justifyContent="space-between"
                 gap="2"
-                px="2"
-                py="1.5"
-                h="auto"
-                borderRadius="sm"
-                fontSize="12.5px"
-                fontWeight="normal"
-                color="fg"
-                _hover={{ bg: "gray.100" }}
               >
-                <Text as="span" whiteSpace="nowrap">
+                <Text as="span" whiteSpace="nowrap" fontSize="12.5px">
                   {l.label}
                 </Text>
                 {l.code === value && (
@@ -92,11 +58,11 @@ export default function VoiceLanguageMenu({
                     <CheckIcon size={13} weight="bold" />
                   </Box>
                 )}
-              </Button>
+              </Menu.Item>
             ))}
-          </Box>
-        </>
-      )}
-    </Box>
+          </Menu.Content>
+        </Menu.Positioner>
+      </Portal>
+    </Menu.Root>
   );
 }

--- a/app/components/voice/VoiceLanguageMenu.tsx
+++ b/app/components/voice/VoiceLanguageMenu.tsx
@@ -1,12 +1,14 @@
 "use client";
-import { Box, Button, Menu, Portal, Text } from "@chakra-ui/react";
-import { CaretDownIcon, CheckIcon, TranslateIcon } from "@phosphor-icons/react";
-import { VOICE_LANGUAGES, labelForLang } from "@/app/utils/speechLang";
+import { useState } from "react";
+import { Button, Popover, Portal } from "@chakra-ui/react";
+import { CaretDownIcon, TranslateIcon } from "@phosphor-icons/react";
+import { labelForLang } from "@/app/utils/speechLang";
+import ShortlistLanguagePicker from "./ShortlistLanguagePicker";
 
 /**
- * Compact language override shown in the listening footer. Built on the app's
- * Chakra Menu so outside-click, Escape, focus management, keyboard navigation,
- * and ARIA roles come for free. Opens upward since the prompt box sits low.
+ * Language override shown in the listening footer. The trigger opens a
+ * searchable shortlist picker (Chakra Popover) anchored upward, since the
+ * prompt box sits low on screen.
  */
 export default function VoiceLanguageMenu({
   value,
@@ -15,12 +17,15 @@ export default function VoiceLanguageMenu({
   value: string;
   onChange: (code: string) => void;
 }) {
+  const [open, setOpen] = useState(false);
+
   return (
-    <Menu.Root
-      positioning={{ placement: "top-start" }}
-      onSelect={({ value: code }) => onChange(code)}
+    <Popover.Root
+      open={open}
+      onOpenChange={(e) => setOpen(e.open)}
+      positioning={{ placement: "top-start", strategy: "fixed" }}
     >
-      <Menu.Trigger asChild>
+      <Popover.Trigger asChild>
         <Button
           type="button"
           aria-label="Change dictation language"
@@ -39,30 +44,20 @@ export default function VoiceLanguageMenu({
           {labelForLang(value)}
           <CaretDownIcon size={11} />
         </Button>
-      </Menu.Trigger>
+      </Popover.Trigger>
       <Portal>
-        <Menu.Positioner>
-          <Menu.Content minW="184px" zIndex={1500}>
-            {VOICE_LANGUAGES.map((l) => (
-              <Menu.Item
-                key={l.code}
-                value={l.code}
-                justifyContent="space-between"
-                gap="2"
-              >
-                <Text as="span" whiteSpace="nowrap" fontSize="12.5px">
-                  {l.label}
-                </Text>
-                {l.code === value && (
-                  <Box as="span" color="primary.solid" display="inline-flex">
-                    <CheckIcon size={13} weight="bold" />
-                  </Box>
-                )}
-              </Menu.Item>
-            ))}
-          </Menu.Content>
-        </Menu.Positioner>
+        <Popover.Positioner>
+          <Popover.Content w="262px" p="0" borderRadius="md" overflow="hidden">
+            <ShortlistLanguagePicker
+              value={value}
+              onChange={(code) => {
+                onChange(code);
+                setOpen(false);
+              }}
+            />
+          </Popover.Content>
+        </Popover.Positioner>
       </Portal>
-    </Menu.Root>
+    </Popover.Root>
   );
 }

--- a/app/components/voice/VoiceListeningPanel.tsx
+++ b/app/components/voice/VoiceListeningPanel.tsx
@@ -36,7 +36,7 @@ export default function VoiceListeningPanel({
   return (
     <Flex
       flexDir="column"
-      animation={reducedMotion ? undefined : "vpFadeUp 0.22s ease both"}
+      animation={reducedMotion ? undefined : "fadeSlideIn 0.22s ease both"}
     >
       {/* Visual: red dot + "Listening" + timer */}
       <Flex align="center" gap="2" minH="34px" mb="2.5">

--- a/app/components/voice/VoiceListeningPanel.tsx
+++ b/app/components/voice/VoiceListeningPanel.tsx
@@ -1,0 +1,117 @@
+"use client";
+import { Box, Button, Flex, Text } from "@chakra-ui/react";
+import { StopIcon } from "@phosphor-icons/react";
+import VoiceLanguageMenu from "./VoiceLanguageMenu";
+
+function formatTimer(seconds: number): string {
+  const mm = Math.floor(seconds / 60);
+  const ss = seconds % 60;
+  return `${mm}:${ss < 10 ? "0" : ""}${ss}`;
+}
+
+/**
+ * The "listening" state of the voice prompt box: a red pulsing dot + timer,
+ * the live transcript (finalised text plus greyed interim words), a language
+ * override, and a "Stop & use" action that commits the transcript.
+ */
+export default function VoiceListeningPanel({
+  seconds,
+  committed,
+  interim,
+  lang,
+  onLangChange,
+  onStop,
+  reducedMotion,
+}: {
+  seconds: number;
+  committed: string;
+  interim: string;
+  lang: string;
+  onLangChange: (code: string) => void;
+  onStop: () => void;
+  reducedMotion: boolean;
+}) {
+  const hasTranscript = committed.length > 0 || interim.length > 0;
+
+  return (
+    <Flex
+      flexDir="column"
+      animation={reducedMotion ? undefined : "vpFadeUp 0.22s ease both"}
+    >
+      {/* Visual: red dot + "Listening" + timer */}
+      <Flex align="center" gap="2" minH="34px" mb="2.5">
+        <Flex flex="1" align="center" gap="2">
+          <Box
+            w="9px"
+            h="9px"
+            borderRadius="full"
+            bg="red.500"
+            animation={reducedMotion ? undefined : "vpDotBlink 1s infinite"}
+          />
+          <Text fontSize="xs" color="fg.muted">
+            Listening
+          </Text>
+        </Flex>
+        <Text
+          fontFamily="mono"
+          fontSize="xs"
+          color="gray.500"
+          css={{ fontVariantNumeric: "tabular-nums" }}
+        >
+          {formatTimer(seconds)}
+        </Text>
+      </Flex>
+
+      {/* Transcript */}
+      <Box minH="42px" fontSize="sm" lineHeight="1.5" color="fg">
+        {hasTranscript ? (
+          <>
+            <Text as="span">{committed}</Text>
+            <Text as="span" color="gray.400">
+              {interim ? `${committed ? " " : ""}${interim}` : ""}
+            </Text>
+          </>
+        ) : (
+          <Text as="span" color="gray.400">
+            Listening…
+          </Text>
+        )}
+      </Box>
+
+      {/* Footer: language override + stop */}
+      <Flex justify="space-between" align="center" mt="3">
+        <VoiceLanguageMenu value={lang} onChange={onLangChange} />
+        <Button
+          type="button"
+          onClick={onStop}
+          aria-label="Stop and use transcript"
+          borderRadius="full"
+          bg="red.500"
+          color="white"
+          _hover={{ bg: "red.600" }}
+          pl="2"
+          pr="3"
+          py="1.5"
+          h="auto"
+          gap="2"
+          fontSize="xs"
+          fontWeight="semibold"
+        >
+          <Box
+            as="span"
+            w="22px"
+            h="22px"
+            borderRadius="full"
+            bg="whiteAlpha.300"
+            display="inline-flex"
+            alignItems="center"
+            justifyContent="center"
+          >
+            <StopIcon size={11} weight="fill" />
+          </Box>
+          Stop &amp; use
+        </Button>
+      </Flex>
+    </Flex>
+  );
+}

--- a/app/hooks/useSpeechInput.ts
+++ b/app/hooks/useSpeechInput.ts
@@ -220,19 +220,15 @@ export default function useSpeechInput(
     [phase, openRecognition]
   );
 
-  const retry = useCallback(() => {
-    if (errorType === "no-speech") {
-      start();
-    } else {
-      setErrorType(null);
-      setPhase("idle");
-    }
-  }, [errorType, start]);
-
   const dismissError = useCallback(() => {
     setErrorType(null);
     setPhase("idle");
   }, []);
+
+  const retry = useCallback(() => {
+    if (errorType === "no-speech") start();
+    else dismissError();
+  }, [errorType, start, dismissError]);
 
   // Tear down any in-flight recognition and timer on unmount.
   useEffect(() => {

--- a/app/hooks/useSpeechInput.ts
+++ b/app/hooks/useSpeechInput.ts
@@ -1,0 +1,115 @@
+"use client";
+import { useCallback, useEffect, useRef, useState } from "react";
+
+interface UseSpeechInputOptions {
+  /** Called with the full transcript of the current dictation session as it grows. */
+  onResult: (transcript: string) => void;
+  /** Called when a dictation session begins (mic granted, listening started). */
+  onStart?: () => void;
+  /** BCP-47 language tag for recognition, e.g. "en-US", "pt-BR". Defaults to "en-US". */
+  lang?: string;
+}
+
+export interface SpeechInput {
+  listening: boolean;
+  /** Start listening if idle, stop if already listening. */
+  toggle: () => void;
+  /** Stop listening (no-op if idle). */
+  stop: () => void;
+}
+
+/**
+ * Wraps the browser-native Web Speech API (SpeechRecognition) so the chat input
+ * can be dictated. Runs entirely client-side — the browser's own speech service
+ * does the transcription and no backend call is involved.
+ *
+ * Returns `null` when the API is unavailable (e.g. Firefox, or during SSR) so
+ * callers can hide the mic affordance rather than render a dead control. Support
+ * is resolved in an effect to keep the server and first client render identical
+ * and avoid a hydration mismatch.
+ */
+export default function useSpeechInput(
+  options: UseSpeechInputOptions
+): SpeechInput | null {
+  const { onResult, onStart, lang } = options;
+  const [supported, setSupported] = useState(false);
+  const [listening, setListening] = useState(false);
+  const recognitionRef = useRef<SpeechRecognition | null>(null);
+
+  // Keep the latest callbacks in refs so the live recognition instance always
+  // calls the current closures without needing `toggle` to be re-created (which
+  // would otherwise churn on every parent render).
+  const onResultRef = useRef(onResult);
+  const onStartRef = useRef(onStart);
+  onResultRef.current = onResult;
+  onStartRef.current = onStart;
+
+  useEffect(() => {
+    setSupported(
+      typeof window !== "undefined" &&
+        Boolean(window.SpeechRecognition ?? window.webkitSpeechRecognition)
+    );
+  }, []);
+
+  const stop = useCallback(() => {
+    recognitionRef.current?.stop();
+  }, []);
+
+  const toggle = useCallback(() => {
+    // A live instance means we're recording — toggling stops it. Teardown
+    // happens in `onend`, which fires for both stop() and a natural end.
+    if (recognitionRef.current) {
+      recognitionRef.current.stop();
+      return;
+    }
+    const Ctor =
+      typeof window !== "undefined"
+        ? (window.SpeechRecognition ?? window.webkitSpeechRecognition)
+        : undefined;
+    if (!Ctor) return;
+
+    const recognition = new Ctor();
+    recognition.lang = lang ?? "en-US";
+    recognition.interimResults = true;
+    recognition.continuous = false;
+
+    recognition.onstart = () => {
+      setListening(true);
+      onStartRef.current?.();
+    };
+    recognition.onresult = (event) => {
+      let transcript = "";
+      for (let i = 0; i < event.results.length; i++) {
+        transcript += event.results[i][0].transcript;
+      }
+      onResultRef.current(transcript);
+    };
+    recognition.onend = () => {
+      recognitionRef.current = null;
+      setListening(false);
+    };
+    recognition.onerror = () => {
+      recognitionRef.current = null;
+      setListening(false);
+    };
+
+    recognitionRef.current = recognition;
+    try {
+      recognition.start();
+    } catch {
+      // start() throws if invoked while a prior session is still winding down;
+      // reset so the UI doesn't get stuck showing a listening state.
+      recognitionRef.current = null;
+      setListening(false);
+    }
+  }, [lang]);
+
+  // Stop any in-flight recognition when the component unmounts.
+  useEffect(() => {
+    return () => {
+      recognitionRef.current?.stop();
+    };
+  }, []);
+
+  return supported ? { listening, toggle, stop } : null;
+}

--- a/app/hooks/useSpeechInput.ts
+++ b/app/hooks/useSpeechInput.ts
@@ -1,115 +1,265 @@
 "use client";
-import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from "react";
+
+export type VoicePhase = "idle" | "listening" | "error";
+export type VoiceErrorType = "denied" | "no-speech" | "no-mic" | "other";
 
 interface UseSpeechInputOptions {
-  /** Called with the full transcript of the current dictation session as it grows. */
-  onResult: (transcript: string) => void;
-  /** Called when a dictation session begins (mic granted, listening started). */
+  /** Resolved BCP-47 language tag to start from (from profile / browser). */
+  initialLang: string;
+  /**
+   * Called with the final transcript when a listening session ends (the user
+   * pressed stop, or recognition ended on its own). Not called on error.
+   */
+  onCommit: (transcript: string) => void;
+  /** Called when a listening session begins, before any transcript arrives. */
   onStart?: () => void;
-  /** BCP-47 language tag for recognition, e.g. "en-US", "pt-BR". Defaults to "en-US". */
-  lang?: string;
 }
 
 export interface SpeechInput {
-  listening: boolean;
-  /** Start listening if idle, stop if already listening. */
-  toggle: () => void;
-  /** Stop listening (no-op if idle). */
+  phase: VoicePhase;
+  /** Finalised transcript so far. */
+  committed: string;
+  /** In-flight (interim) words, shown greyed. */
+  interim: string;
+  /** Elapsed listening time in whole seconds. */
+  seconds: number;
+  errorType: VoiceErrorType | null;
+  /** Active recognition language (BCP-47). */
+  lang: string;
+  /** Override the language; restarts recognition in place if listening. */
+  setLang: (code: string) => void;
+  /** Begin a fresh listening session. */
+  start: () => void;
+  /** Stop listening and commit the transcript. */
   stop: () => void;
+  /** Recover from an error (restart on no-speech, otherwise return to idle). */
+  retry: () => void;
+  /** Dismiss an error and return to idle (e.g. "Type instead"). */
+  dismissError: () => void;
 }
 
+function getCtor(): SpeechRecognitionConstructor | undefined {
+  if (typeof window === "undefined") return undefined;
+  return window.SpeechRecognition ?? window.webkitSpeechRecognition;
+}
+
+function mapError(error: string): VoiceErrorType {
+  switch (error) {
+    case "not-allowed":
+    case "service-not-allowed":
+      return "denied";
+    case "no-speech":
+      return "no-speech";
+    case "audio-capture":
+      return "no-mic";
+    default:
+      return "other";
+  }
+}
+
+// API support never changes after load, so a no-op subscription is enough; the
+// server snapshot is false, matching the first client render (avoids hydration
+// mismatch) before the real value resolves.
+const noopSubscribe = () => () => {};
+const getSupported = () => Boolean(getCtor());
+const getSupportedServer = () => false;
+
 /**
- * Wraps the browser-native Web Speech API (SpeechRecognition) so the chat input
- * can be dictated. Runs entirely client-side — the browser's own speech service
- * does the transcription and no backend call is involved.
+ * Drives voice dictation via the browser-native Web Speech API as a small
+ * state machine (idle → listening → idle, or → error). Transcription runs
+ * entirely client-side; no audio or transcript touches our backend.
  *
  * Returns `null` when the API is unavailable (e.g. Firefox, or during SSR) so
- * callers can hide the mic affordance rather than render a dead control. Support
- * is resolved in an effect to keep the server and first client render identical
- * and avoid a hydration mismatch.
+ * callers can hide the mic affordance. Support is resolved in an effect to keep
+ * the server and first client render identical and avoid a hydration mismatch.
  */
 export default function useSpeechInput(
   options: UseSpeechInputOptions
 ): SpeechInput | null {
-  const { onResult, onStart, lang } = options;
-  const [supported, setSupported] = useState(false);
-  const [listening, setListening] = useState(false);
-  const recognitionRef = useRef<SpeechRecognition | null>(null);
+  const { initialLang, onCommit, onStart } = options;
 
-  // Keep the latest callbacks in refs so the live recognition instance always
-  // calls the current closures without needing `toggle` to be re-created (which
-  // would otherwise churn on every parent render).
-  const onResultRef = useRef(onResult);
+  const supported = useSyncExternalStore(
+    noopSubscribe,
+    getSupported,
+    getSupportedServer
+  );
+  const [phase, setPhase] = useState<VoicePhase>("idle");
+  const [committed, setCommitted] = useState("");
+  const [interim, setInterim] = useState("");
+  const [seconds, setSeconds] = useState(0);
+  const [errorType, setErrorType] = useState<VoiceErrorType | null>(null);
+  // Session-only language override. When null, the resolved profile default
+  // (`initialLang`) applies — so `lang` tracks auth loading automatically and
+  // needs no syncing effect.
+  const [langOverride, setLangOverride] = useState<string | null>(null);
+  const lang = langOverride ?? initialLang;
+
+  // Latest callbacks, so the live recognition instance always calls current
+  // closures. Updated in an effect (not render) per React's ref rules; the
+  // recognition events that read them only fire after effects have run.
+  const onCommitRef = useRef(onCommit);
   const onStartRef = useRef(onStart);
-  onResultRef.current = onResult;
-  onStartRef.current = onStart;
-
   useEffect(() => {
-    setSupported(
-      typeof window !== "undefined" &&
-        Boolean(window.SpeechRecognition ?? window.webkitSpeechRecognition)
-    );
+    onCommitRef.current = onCommit;
+    onStartRef.current = onStart;
+  });
+
+  const recognitionRef = useRef<SpeechRecognition | null>(null);
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  // Transcript carried across a mid-session language switch (which tears down
+  // and recreates the recognition instance).
+  const carryRef = useRef("");
+  // Latest full transcript, read synchronously when the session ends.
+  const transcriptRef = useRef("");
+
+  const clearTimer = useCallback(() => {
+    if (timerRef.current) {
+      clearInterval(timerRef.current);
+      timerRef.current = null;
+    }
   }, []);
 
+  const openRecognition = useCallback(
+    (langCode: string) => {
+      const Ctor = getCtor();
+      if (!Ctor) return;
+      const recognition = new Ctor();
+      recognition.lang = langCode;
+      recognition.interimResults = true;
+      recognition.continuous = true;
+
+      recognition.onresult = (event) => {
+        let final = "";
+        let live = "";
+        for (let i = 0; i < event.results.length; i++) {
+          const text = event.results[i][0].transcript;
+          if (event.results[i].isFinal) final += text;
+          else live += text;
+        }
+        const nextCommitted = (carryRef.current + final)
+          .replace(/\s+/g, " ")
+          .trimStart();
+        setCommitted(nextCommitted);
+        setInterim(live);
+        transcriptRef.current = `${nextCommitted} ${live}`.trim();
+      };
+      recognition.onerror = (event) => {
+        clearTimer();
+        recognitionRef.current = null;
+        setInterim("");
+        setErrorType(mapError(event.error));
+        setPhase("error");
+      };
+      recognition.onend = () => {
+        clearTimer();
+        recognitionRef.current = null;
+        const text = transcriptRef.current.trim();
+        setCommitted("");
+        setInterim("");
+        setPhase("idle");
+        if (text) onCommitRef.current(text);
+      };
+
+      recognitionRef.current = recognition;
+      try {
+        recognition.start();
+      } catch {
+        // start() throws if a prior session is still winding down.
+        recognitionRef.current = null;
+      }
+    },
+    [clearTimer]
+  );
+
+  const start = useCallback(() => {
+    if (!getCtor() || recognitionRef.current) return;
+    clearTimer();
+    carryRef.current = "";
+    transcriptRef.current = "";
+    setCommitted("");
+    setInterim("");
+    setSeconds(0);
+    setErrorType(null);
+    setPhase("listening");
+    onStartRef.current?.();
+    timerRef.current = setInterval(() => setSeconds((s) => s + 1), 1000);
+    openRecognition(lang);
+  }, [lang, clearTimer, openRecognition]);
+
   const stop = useCallback(() => {
+    // stop() triggers onend, which commits the transcript.
     recognitionRef.current?.stop();
   }, []);
 
-  const toggle = useCallback(() => {
-    // A live instance means we're recording — toggling stops it. Teardown
-    // happens in `onend`, which fires for both stop() and a natural end.
-    if (recognitionRef.current) {
-      recognitionRef.current.stop();
-      return;
+  const setLang = useCallback(
+    (code: string) => {
+      setLangOverride(code);
+      const current = recognitionRef.current;
+      if (phase !== "listening" || !current) return;
+      // Carry the transcript so far, then restart recognition in the new
+      // language. Detach handlers first so the abort can't commit or error.
+      carryRef.current = transcriptRef.current
+        ? `${transcriptRef.current} `
+        : "";
+      setCommitted(carryRef.current.trim());
+      setInterim("");
+      current.onend = null;
+      current.onerror = null;
+      current.onresult = null;
+      recognitionRef.current = null;
+      current.abort();
+      openRecognition(code);
+    },
+    [phase, openRecognition]
+  );
+
+  const retry = useCallback(() => {
+    if (errorType === "no-speech") {
+      start();
+    } else {
+      setErrorType(null);
+      setPhase("idle");
     }
-    const Ctor =
-      typeof window !== "undefined"
-        ? (window.SpeechRecognition ?? window.webkitSpeechRecognition)
-        : undefined;
-    if (!Ctor) return;
+  }, [errorType, start]);
 
-    const recognition = new Ctor();
-    recognition.lang = lang ?? "en-US";
-    recognition.interimResults = true;
-    recognition.continuous = false;
-
-    recognition.onstart = () => {
-      setListening(true);
-      onStartRef.current?.();
-    };
-    recognition.onresult = (event) => {
-      let transcript = "";
-      for (let i = 0; i < event.results.length; i++) {
-        transcript += event.results[i][0].transcript;
-      }
-      onResultRef.current(transcript);
-    };
-    recognition.onend = () => {
-      recognitionRef.current = null;
-      setListening(false);
-    };
-    recognition.onerror = () => {
-      recognitionRef.current = null;
-      setListening(false);
-    };
-
-    recognitionRef.current = recognition;
-    try {
-      recognition.start();
-    } catch {
-      // start() throws if invoked while a prior session is still winding down;
-      // reset so the UI doesn't get stuck showing a listening state.
-      recognitionRef.current = null;
-      setListening(false);
-    }
-  }, [lang]);
-
-  // Stop any in-flight recognition when the component unmounts.
-  useEffect(() => {
-    return () => {
-      recognitionRef.current?.stop();
-    };
+  const dismissError = useCallback(() => {
+    setErrorType(null);
+    setPhase("idle");
   }, []);
 
-  return supported ? { listening, toggle, stop } : null;
+  // Tear down any in-flight recognition and timer on unmount.
+  useEffect(() => {
+    return () => {
+      clearTimer();
+      const current = recognitionRef.current;
+      if (current) {
+        current.onend = null;
+        current.onerror = null;
+        current.abort();
+      }
+    };
+  }, [clearTimer]);
+
+  return supported
+    ? {
+        phase,
+        committed,
+        interim,
+        seconds,
+        errorType,
+        lang,
+        setLang,
+        start,
+        stop,
+        retry,
+        dismissError,
+      }
+    : null;
 }

--- a/app/store/authStore.ts
+++ b/app/store/authStore.ts
@@ -6,6 +6,9 @@ interface AuthState {
   userId: string | null;
   userEmail: string | null;
   userType: UserType | null;
+  // Onboarding language preference (ISO code, e.g. "pt"); used to default the
+  // Web Speech API dictation language. Null until /api/auth/me resolves.
+  preferredLanguageCode: string | null;
   isAuthenticated: boolean;
   hasProfile: boolean;
   authLoaded: boolean;
@@ -20,6 +23,7 @@ interface AuthState {
     id: string;
     hasProfile: boolean;
     userType: UserType | null;
+    preferredLanguageCode?: string | null;
   }) => void;
   setAuthLoaded: () => void;
   clearAuth: () => void;
@@ -30,6 +34,7 @@ const useAuthStore = create<AuthState>()((set) => ({
   userId: null,
   userEmail: null,
   userType: null,
+  preferredLanguageCode: null,
   isAuthenticated: false,
   hasProfile: false,
   authLoaded: false,
@@ -76,11 +81,18 @@ const useAuthStore = create<AuthState>()((set) => ({
       };
     });
   },
-  setAuthStatus: ({ email, id, hasProfile, userType }) => {
+  setAuthStatus: ({
+    email,
+    id,
+    hasProfile,
+    userType,
+    preferredLanguageCode = null,
+  }) => {
     set({
       userId: id,
       userEmail: email,
       userType,
+      preferredLanguageCode,
       isAuthenticated: true,
       hasProfile,
       authLoaded: true,
@@ -94,6 +106,7 @@ const useAuthStore = create<AuthState>()((set) => ({
       userId: null,
       userEmail: null,
       userType: null,
+      preferredLanguageCode: null,
       isAuthenticated: false,
       hasProfile: false,
       authLoaded: true,

--- a/app/theme/globalCss.tsx
+++ b/app/theme/globalCss.tsx
@@ -27,15 +27,6 @@ const globalCss = {
     marginTop: 4,
     marginBottom: 4,
   },
-  // Voice dictation panel: entrance fade and the "listening" dot blink.
-  "@keyframes vpFadeUp": {
-    from: { opacity: 0, transform: "translateY(6px)" },
-    to: { opacity: 1, transform: "translateY(0)" },
-  },
-  "@keyframes vpDotBlink": {
-    "0%, 100%": { opacity: 1 },
-    "50%": { opacity: 0.28 },
-  },
 };
 
 export default globalCss;

--- a/app/theme/globalCss.tsx
+++ b/app/theme/globalCss.tsx
@@ -27,6 +27,15 @@ const globalCss = {
     marginTop: 4,
     marginBottom: 4,
   },
+  // Voice dictation panel: entrance fade and the "listening" dot blink.
+  "@keyframes vpFadeUp": {
+    from: { opacity: 0, transform: "translateY(6px)" },
+    to: { opacity: 1, transform: "translateY(0)" },
+  },
+  "@keyframes vpDotBlink": {
+    "0%, 100%": { opacity: 1 },
+    "50%": { opacity: 0.28 },
+  },
 };
 
 export default globalCss;

--- a/app/theme/index.tsx
+++ b/app/theme/index.tsx
@@ -33,6 +33,11 @@ export const config = defineConfig({
         from: { opacity: 0, transform: "translateY(4px)" },
         to: { opacity: 1, transform: "translateY(0)" },
       },
+      // Blink for the voice "listening" indicator dot.
+      vpDotBlink: {
+        "0%, 100%": { opacity: 1 },
+        "50%": { opacity: 0.28 },
+      },
       dynamicSlideLeft: {
         from: {
           transform: "translateX(var(--start-x))",

--- a/app/types/speech-recognition.d.ts
+++ b/app/types/speech-recognition.d.ts
@@ -1,0 +1,55 @@
+// Ambient types for the Web Speech API (SpeechRecognition). These are not part
+// of TypeScript's default lib.dom.d.ts, so only the members used by
+// `useSpeechInput` are declared here. Spec: https://wicg.github.io/speech-api/
+
+interface SpeechRecognitionAlternative {
+  readonly transcript: string;
+  readonly confidence: number;
+}
+
+interface SpeechRecognitionResult {
+  readonly isFinal: boolean;
+  readonly length: number;
+  item(index: number): SpeechRecognitionAlternative;
+  readonly [index: number]: SpeechRecognitionAlternative;
+}
+
+interface SpeechRecognitionResultList {
+  readonly length: number;
+  item(index: number): SpeechRecognitionResult;
+  readonly [index: number]: SpeechRecognitionResult;
+}
+
+interface SpeechRecognitionEvent extends Event {
+  readonly resultIndex: number;
+  readonly results: SpeechRecognitionResultList;
+}
+
+interface SpeechRecognitionErrorEvent extends Event {
+  // e.g. "no-speech", "aborted", "not-allowed", "network"
+  readonly error: string;
+  readonly message: string;
+}
+
+interface SpeechRecognition extends EventTarget {
+  lang: string;
+  continuous: boolean;
+  interimResults: boolean;
+  maxAlternatives: number;
+  start(): void;
+  stop(): void;
+  abort(): void;
+  onstart: ((event: Event) => void) | null;
+  onresult: ((event: SpeechRecognitionEvent) => void) | null;
+  onerror: ((event: SpeechRecognitionErrorEvent) => void) | null;
+  onend: ((event: Event) => void) | null;
+}
+
+interface SpeechRecognitionConstructor {
+  new (): SpeechRecognition;
+}
+
+interface Window {
+  SpeechRecognition?: SpeechRecognitionConstructor;
+  webkitSpeechRecognition?: SpeechRecognitionConstructor;
+}

--- a/app/utils/__tests__/speechLang.test.ts
+++ b/app/utils/__tests__/speechLang.test.ts
@@ -48,8 +48,9 @@ describe("VOICE_LANGUAGES / labelForLang", () => {
 
   it("returns the label for a known code", () => {
     expect(labelForLang("es-419")).toBe("Spanish (Latin America)");
-    expect(labelForLang("zh-CN")).toBe("Chinese (Mandarin)");
+    expect(labelForLang("zh-CN")).toBe("Chinese (Simplified)");
     expect(labelForLang("en-GB")).toBe("English (UK)");
+    expect(labelForLang("it-IT")).toBe("Italian");
   });
 
   it("falls back to the raw tag for an unknown code", () => {

--- a/app/utils/__tests__/speechLang.test.ts
+++ b/app/utils/__tests__/speechLang.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { resolveSpeechLang } from "../speechLang";
+
+describe("resolveSpeechLang", () => {
+  it("region-qualifies a bare profile language code", () => {
+    expect(resolveSpeechLang("pt", "en-US")).toBe("pt-BR");
+    expect(resolveSpeechLang("es", null)).toBe("es-ES");
+    expect(resolveSpeechLang("en", null)).toBe("en-US");
+    expect(resolveSpeechLang("id", null)).toBe("id-ID");
+  });
+
+  it("prefers the profile code over the browser language", () => {
+    expect(resolveSpeechLang("pt", "en-GB")).toBe("pt-BR");
+  });
+
+  it("falls back to the browser language when no profile code", () => {
+    expect(resolveSpeechLang(null, "fr-CA")).toBe("fr-CA");
+    expect(resolveSpeechLang("", "pt-PT")).toBe("pt-PT");
+  });
+
+  it("region-qualifies a bare browser language when used as fallback", () => {
+    expect(resolveSpeechLang(null, "es")).toBe("es-ES");
+  });
+
+  it("trusts an already-qualified tag rather than overriding the region", () => {
+    expect(resolveSpeechLang("en-GB", null)).toBe("en-GB");
+  });
+
+  it("passes through an unknown bare code unchanged", () => {
+    expect(resolveSpeechLang("de", null)).toBe("de");
+  });
+
+  it("defaults to en-US when nothing is provided", () => {
+    expect(resolveSpeechLang(null, null)).toBe("en-US");
+    expect(resolveSpeechLang(undefined, undefined)).toBe("en-US");
+  });
+});

--- a/app/utils/__tests__/speechLang.test.ts
+++ b/app/utils/__tests__/speechLang.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from "vitest";
-import { resolveSpeechLang } from "../speechLang";
+import {
+  resolveSpeechLang,
+  labelForLang,
+  VOICE_LANGUAGES,
+} from "../speechLang";
 
 describe("resolveSpeechLang", () => {
   it("region-qualifies a bare profile language code", () => {
@@ -33,5 +37,22 @@ describe("resolveSpeechLang", () => {
   it("defaults to en-US when nothing is provided", () => {
     expect(resolveSpeechLang(null, null)).toBe("en-US");
     expect(resolveSpeechLang(undefined, undefined)).toBe("en-US");
+  });
+});
+
+describe("VOICE_LANGUAGES / labelForLang", () => {
+  it("has unique BCP-47 codes", () => {
+    const codes = VOICE_LANGUAGES.map((l) => l.code);
+    expect(new Set(codes).size).toBe(codes.length);
+  });
+
+  it("returns the label for a known code", () => {
+    expect(labelForLang("es-419")).toBe("Spanish (Latin America)");
+    expect(labelForLang("zh-CN")).toBe("Chinese (Mandarin)");
+    expect(labelForLang("en-GB")).toBe("English (UK)");
+  });
+
+  it("falls back to the raw tag for an unknown code", () => {
+    expect(labelForLang("xx-YY")).toBe("xx-YY");
   });
 });

--- a/app/utils/speechLang.ts
+++ b/app/utils/speechLang.ts
@@ -1,0 +1,34 @@
+// Bare ISO-639-1 codes (as stored in the user's onboarding profile) mapped to
+// region-qualified BCP-47 tags. Region qualification meaningfully improves
+// speech-recognition accuracy; pt-BR in particular fits GNW's Amazonia focus.
+// All values are locales Chrome's SpeechRecognition accepts.
+const REGION_QUALIFIED: Record<string, string> = {
+  en: "en-US",
+  fr: "fr-FR",
+  es: "es-ES",
+  pt: "pt-BR",
+  id: "id-ID",
+};
+
+const DEFAULT_LANG = "en-US";
+
+/**
+ * Resolve a BCP-47 language tag for the Web Speech API. The Web Speech API
+ * cannot detect the spoken language itself, so we default from what the app
+ * already knows, in priority order:
+ *   1. the user's onboarding language preference (`preferredLanguageCode`)
+ *   2. the browser's preferred language (`navigator.language`)
+ *   3. `en-US`
+ *
+ * A bare ISO code (e.g. "pt") is region-qualified for better accent handling;
+ * an already-qualified tag (e.g. "en-GB") is trusted as-is.
+ */
+export function resolveSpeechLang(
+  preferredCode?: string | null,
+  browserLang?: string | null
+): string {
+  const raw = preferredCode?.trim() || browserLang?.trim() || DEFAULT_LANG;
+  // Already region-qualified — trust it rather than overriding the region.
+  if (raw.includes("-")) return raw;
+  return REGION_QUALIFIED[raw.toLowerCase()] ?? raw;
+}

--- a/app/utils/speechLang.ts
+++ b/app/utils/speechLang.ts
@@ -12,29 +12,122 @@ const REGION_QUALIFIED: Record<string, string> = {
 
 const DEFAULT_LANG = "en-US";
 
-interface VoiceLanguage {
+export interface VoiceLanguageVariant {
+  /** BCP-47 tag passed to SpeechRecognition. */
+  code: string;
+  /** Full display label, e.g. "English (US)". */
+  name: string;
+  /** Short chip label, e.g. "US". */
+  tag: string;
+}
+
+export interface VoiceLanguageFamily {
+  /** English display name, e.g. "English". */
+  base: string;
+  /** Endonym, e.g. "Español". */
+  native: string;
+  /** Surfaced in the picker's "Common" shortlist. */
+  common?: boolean;
+  /** Regional variants; mutually exclusive with `code`. */
+  variants?: VoiceLanguageVariant[];
+  /** BCP-47 tag for a single-variant language; mutually exclusive with `variants`. */
+  code?: string;
+}
+
+// The full catalogue offered in the dictation picker. Every code is a locale
+// the browser's Web Speech API accepts. `common` languages form the shortlist
+// shown before the user searches or expands the full list.
+export const VOICE_LANGUAGE_FAMILIES: VoiceLanguageFamily[] = [
+  {
+    base: "English",
+    native: "English",
+    common: true,
+    variants: [
+      { code: "en-US", name: "English (US)", tag: "US" },
+      { code: "en-GB", name: "English (UK)", tag: "UK" },
+    ],
+  },
+  {
+    base: "Spanish",
+    native: "Español",
+    common: true,
+    variants: [
+      { code: "es-ES", name: "Spanish (Spain)", tag: "Spain" },
+      { code: "es-419", name: "Spanish (Latin America)", tag: "LatAm" },
+    ],
+  },
+  {
+    base: "Portuguese",
+    native: "Português",
+    common: true,
+    variants: [
+      { code: "pt-BR", name: "Portuguese (BR)", tag: "Brasil" },
+      { code: "pt-PT", name: "Portuguese (PT)", tag: "Portugal" },
+    ],
+  },
+  {
+    base: "Chinese",
+    native: "中文",
+    common: true,
+    variants: [
+      { code: "zh-CN", name: "Chinese (Simplified)", tag: "Simpl." },
+      { code: "zh-TW", name: "Chinese (Traditional)", tag: "Trad." },
+    ],
+  },
+  { base: "French", native: "Français", common: true, code: "fr-FR" },
+  { base: "Arabic", native: "العربية", common: true, code: "ar-SA" },
+  { base: "Hindi", native: "हिन्दी", common: true, code: "hi-IN" },
+  {
+    base: "Indonesian",
+    native: "Bahasa Indonesia",
+    common: true,
+    code: "id-ID",
+  },
+  { base: "Bengali", native: "বাংলা", code: "bn-IN" },
+  { base: "Czech", native: "Čeština", code: "cs-CZ" },
+  { base: "Danish", native: "Dansk", code: "da-DK" },
+  { base: "Dutch", native: "Nederlands", code: "nl-NL" },
+  { base: "Filipino", native: "Filipino", code: "fil-PH" },
+  { base: "Finnish", native: "Suomi", code: "fi-FI" },
+  { base: "German", native: "Deutsch", code: "de-DE" },
+  { base: "Greek", native: "Ελληνικά", code: "el-GR" },
+  { base: "Gujarati", native: "ગુજરાતી", code: "gu-IN" },
+  { base: "Hungarian", native: "Magyar", code: "hu-HU" },
+  { base: "Italian", native: "Italiano", code: "it-IT" },
+  { base: "Japanese", native: "日本語", code: "ja-JP" },
+  { base: "Kiswahili", native: "Kiswahili", code: "sw-KE" },
+  { base: "Korean", native: "한국어", code: "ko-KR" },
+  { base: "Malay", native: "Bahasa Melayu", code: "ms-MY" },
+  { base: "Norwegian", native: "Norsk", code: "nb-NO" },
+  { base: "Polish", native: "Polski", code: "pl-PL" },
+  { base: "Romanian", native: "Română", code: "ro-RO" },
+  { base: "Russian", native: "Русский", code: "ru-RU" },
+  { base: "Swedish", native: "Svenska", code: "sv-SE" },
+  { base: "Tamil", native: "தமிழ்", code: "ta-IN" },
+  { base: "Telugu", native: "తెలుగు", code: "te-IN" },
+  { base: "Thai", native: "ภาษาไทย", code: "th-TH" },
+  { base: "Turkish", native: "Türkçe", code: "tr-TR" },
+  { base: "Ukrainian", native: "Українська", code: "uk-UA" },
+  { base: "Urdu", native: "اردو", code: "ur-PK" },
+  { base: "Vietnamese", native: "Tiếng Việt", code: "vi-VN" },
+];
+
+export interface VoiceLanguage {
   /** BCP-47 tag passed to SpeechRecognition. */
   code: string;
   label: string;
 }
 
-// The languages offered in the dictation override menu (a superset of the
-// onboarding options). Codes are BCP-47 tags passed to SpeechRecognition.
-export const VOICE_LANGUAGES: VoiceLanguage[] = [
-  { code: "en-US", label: "English (US)" },
-  { code: "en-GB", label: "English (UK)" },
-  { code: "pt-BR", label: "Portuguese (BR)" },
-  { code: "es-ES", label: "Spanish (ES)" },
-  { code: "es-419", label: "Spanish (Latin America)" },
-  { code: "fr-FR", label: "French" },
-  { code: "it-IT", label: "Italian" },
-  { code: "id-ID", label: "Indonesian" },
-  { code: "zh-CN", label: "Chinese (Mandarin)" },
-  { code: "sw-KE", label: "Swahili" },
-];
+// Flat {code,label} list derived from the family catalogue, for label lookups.
+export const VOICE_LANGUAGES: VoiceLanguage[] = VOICE_LANGUAGE_FAMILIES.flatMap(
+  (f) =>
+    f.variants
+      ? f.variants.map((v) => ({ code: v.code, label: v.name }))
+      : [{ code: f.code as string, label: f.base }]
+);
 
 /**
- * Human-readable label for a BCP-47 tag, for the dictation language menu.
+ * Human-readable label for a BCP-47 tag, for the dictation language trigger.
  * Falls back to the raw tag when it isn't one of the offered options.
  */
 export function labelForLang(code: string): string {

--- a/app/utils/speechLang.ts
+++ b/app/utils/speechLang.ts
@@ -12,7 +12,7 @@ const REGION_QUALIFIED: Record<string, string> = {
 
 const DEFAULT_LANG = "en-US";
 
-export interface VoiceLanguage {
+interface VoiceLanguage {
   /** BCP-47 tag passed to SpeechRecognition. */
   code: string;
   label: string;

--- a/app/utils/speechLang.ts
+++ b/app/utils/speechLang.ts
@@ -24,7 +24,7 @@ export const VOICE_LANGUAGES: VoiceLanguage[] = [
   { code: "en-US", label: "English (US)" },
   { code: "en-GB", label: "English (UK)" },
   { code: "pt-BR", label: "Portuguese (BR)" },
-  { code: "es-ES", label: "Spanish (Spain)" },
+  { code: "es-ES", label: "Spanish (ES)" },
   { code: "es-419", label: "Spanish (Latin America)" },
   { code: "fr-FR", label: "French" },
   { code: "it-IT", label: "Italian" },

--- a/app/utils/speechLang.ts
+++ b/app/utils/speechLang.ts
@@ -12,6 +12,30 @@ const REGION_QUALIFIED: Record<string, string> = {
 
 const DEFAULT_LANG = "en-US";
 
+export interface VoiceLanguage {
+  /** BCP-47 tag passed to SpeechRecognition. */
+  code: string;
+  label: string;
+}
+
+// The languages offered in the dictation override menu. Codes match the
+// region-qualified tags above and the onboarding language options.
+export const VOICE_LANGUAGES: VoiceLanguage[] = [
+  { code: "en-US", label: "English (US)" },
+  { code: "pt-BR", label: "Portuguese (BR)" },
+  { code: "es-ES", label: "Spanish" },
+  { code: "fr-FR", label: "French" },
+  { code: "id-ID", label: "Indonesian" },
+];
+
+/**
+ * Human-readable label for a BCP-47 tag, for the dictation language menu.
+ * Falls back to the raw tag when it isn't one of the offered options.
+ */
+export function labelForLang(code: string): string {
+  return VOICE_LANGUAGES.find((l) => l.code === code)?.label ?? code;
+}
+
 /**
  * Resolve a BCP-47 language tag for the Web Speech API. The Web Speech API
  * cannot detect the spoken language itself, so we default from what the app

--- a/app/utils/speechLang.ts
+++ b/app/utils/speechLang.ts
@@ -18,14 +18,19 @@ interface VoiceLanguage {
   label: string;
 }
 
-// The languages offered in the dictation override menu. Codes match the
-// region-qualified tags above and the onboarding language options.
+// The languages offered in the dictation override menu (a superset of the
+// onboarding options). Codes are BCP-47 tags passed to SpeechRecognition.
 export const VOICE_LANGUAGES: VoiceLanguage[] = [
   { code: "en-US", label: "English (US)" },
+  { code: "en-GB", label: "English (UK)" },
   { code: "pt-BR", label: "Portuguese (BR)" },
-  { code: "es-ES", label: "Spanish" },
+  { code: "es-ES", label: "Spanish (Spain)" },
+  { code: "es-419", label: "Spanish (Latin America)" },
   { code: "fr-FR", label: "French" },
+  { code: "it-IT", label: "Italian" },
   { code: "id-ID", label: "Indonesian" },
+  { code: "zh-CN", label: "Chinese (Mandarin)" },
+  { code: "sw-KE", label: "Swahili" },
 ];
 
 /**


### PR DESCRIPTION
## What & why

Adds voice-to-text dictation to the chat input so users can speak their query instead of typing it. **No backend change** — the transcript flows into the same `sendMessage(text)` path as typing, so `/api/chat` sees plain text either way.

## Approach

Uses the **browser-native Web Speech API** (`SpeechRecognition` / `webkitSpeechRecognition`) — the light-touch option: no new dependency, no API key, no cost, and no audio leaves the browser's own speech service. This keeps the change entirely frontend-side.

## What changed

| File | What |
|---|---|
| `app/types/speech-recognition.d.ts` | Ambient TS types for the Web Speech API (not in the default DOM lib) |
| `app/hooks/useSpeechInput.ts` | `useSpeechInput` hook wrapping `SpeechRecognition`; returns `null` when unsupported |
| `app/components/ChatInput.tsx` | Mic button beside the send button, feeding the existing `inputValue` |

## Behaviour

- **Mic button** sits left of the send button. Idle = ghost mic; recording = solid red mic-slash. Tap to start/stop.
- **Dictation appends** to any already-typed text (input is snapshotted on start) and updates live as you speak.
- **Stops on send** — `submitPrompt` calls `speech?.stop()`.
- **Degrades cleanly** — the button only renders where the API exists (Chrome/Edge/Safari). Firefox and SSR get no button, and support is resolved in an effect to avoid a hydration mismatch.

## Verification

- `pnpm typecheck` — clean
- `pnpm build` — passes
- Prettier — clean
- Pre-push hook (format:check + typecheck) — passed

# Voice-to-Text (Dictation) — Languages & Browser Coverage

Speak instead of type. The mic button in the chat prompt streams speech to a
transcript that lands in the input box.

> **In one breath:** dictation runs entirely in the browser via the native Web
> Speech API. No audio and no transcript ever reach the GNW backend — so which
> languages work, and how well, is decided by the _browser_, not by us.

This page documents the language catalogue we offer and how coverage differs
across browsers. It is the source of truth for the two questions people ask
most: _"which languages can I dictate in?"_ and _"why is the mic button
missing / not working in my browser?"_

## How it works (why coverage is browser-dependent)

The feature is a thin wrapper around the browser-native
[`SpeechRecognition`](https://developer.mozilla.org/en-US/docs/Web/API/SpeechRecognition)
interface (`window.SpeechRecognition ?? window.webkitSpeechRecognition`).

- **No backend involvement.** Transcription happens client-side. In Chromium
  browsers the audio is sent to Google's speech service; in Safari it uses
  Apple's on-device / dictation engine. Either way it never touches our API.
- **The API cannot detect the spoken language.** We must hand it a BCP-47 tag
  up front (see [Language resolution](#language-resolution--defaults)).
- **If the API is absent, the mic button is hidden.** `useSpeechInput` returns
  `null` when neither constructor exists, so the affordance simply doesn't
  render (e.g. in Firefox).

Because the actual recognition engine is the browser's, **the set of languages
that truly work — and the transcription quality — is determined by the browser
and the user's device, not by our catalogue.** Our catalogue is the _menu_ we
offer; the browser decides what it can cook.

Source of truth in the code:

| Concern            | File                                                      |
| ------------------ | --------------------------------------------------------- |
| Language catalogue | `app/utils/speechLang.ts` (`VOICE_LANGUAGE_FAMILIES`)     |
| Support detection  | `app/hooks/useSpeechInput.ts` (`getCtor`, `getSupported`) |
| Picker UI          | `app/components/voice/ShortlistLanguagePicker.tsx`        |

---

## Browser coverage

Support is gated on the presence of the `SpeechRecognition` /
`webkitSpeechRecognition` constructor. This is the primary "is the mic button
even there?" gate.

| Browser                                    | Web Speech API                 | Behaviour in GNW                                                                                                                                      |
| ------------------------------------------ | ------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
| **Chrome** (desktop & Android) 25+         | ✅ `webkitSpeechRecognition`   | Full catalogue. Audio routed to Google's speech service.                                                                                              |
| **Edge** 87+                               | ✅ `webkitSpeechRecognition`   | Full catalogue (Chromium, same Google backend).                                                                                                       |
| **Opera / other Chromium**                 | ✅ `webkitSpeechRecognition`   | Full catalogue (Chromium, same Google backend).                                                                                                       |
| **Samsung Internet** 4+                    | ✅ `webkitSpeechRecognition`   | Full catalogue.                                                                                                                                       |
| **Safari** (macOS 14.1+, iOS/iPadOS 14.5+) | ✅ `webkitSpeechRecognition`   | Mic button shows. Uses Apple's dictation engine — language coverage is a **device-dependent subset** (see below).                                     |
| **Brave**                                  | ⚠️ present but usually blocked | Constructor exists, so the button shows, but Brave disables Google's speech endpoint by default, so recognition typically fails with a service error. |
| **Firefox**                                | ❌ off by default              | `SpeechRecognition` sits behind the `dom.webspeech.recognition.enable` flag and ships no engine. **Mic button is hidden.**                            |
| **Server-side render (SSR)**               | ❌ n/a                         | Support resolves to `false` on the server and first client render to avoid a hydration mismatch, then re-resolves in the browser.                     |

### Per-language coverage, by engine

The catalogue below lists every language we _offer_. Whether a given language
actually transcribes depends on the engine behind the browser:

- **Chromium browsers (Chrome, Edge, Opera, Samsung Internet)** — the **entire
  catalogue** is supported. Every code in `speechLang.ts` was chosen because
  it's a locale Chrome's `SpeechRecognition` accepts.
- **Safari (WebKit)** — recognition is delegated to Apple's dictation engine,
  so a language works only if its **dictation locale is available on that
  device**. Apple supports 50+ dictation locales, which covers **all eight
  shortlist ("common") languages and the large majority of the extended list**.
  Regional variants Apple does not distinguish (e.g. `es-419`, and `en-GB`
  vs `en-US`) resolve to the closest base locale rather than failing. Treat
  Safari as _"all common languages + most extended languages, subject to the
  device's installed dictation languages."_
- **Firefox** — no languages; the feature is hidden entirely.

> **Rule of thumb:** if a listed language ever fails to transcribe, it's a
> Safari/Firefox engine limitation, not a bug in our catalogue. In Chrome the
> full list is expected to work.

---

## Language catalogue

**35 language families → 39 BCP-47 locale codes.** The 8 families marked ●
form the "Common" shortlist shown at the top of the picker before the user
searches or expands the full list; the rest appear under the full list.

### Shortlist ("Common")

| ●   | Language   | Native           | BCP-47 code(s)                              |
| --- | ---------- | ---------------- | ------------------------------------------- |
| ●   | English    | English          | `en-US` (US), `en-GB` (UK)                  |
| ●   | Spanish    | Español          | `es-ES` (Spain), `es-419` (Latin America)   |
| ●   | Portuguese | Português        | `pt-BR` (Brasil), `pt-PT` (Portugal)        |
| ●   | Chinese    | 中文             | `zh-CN` (Simplified), `zh-TW` (Traditional) |
| ●   | French     | Français         | `fr-FR`                                     |
| ●   | Arabic     | العربية          | `ar-SA`                                     |
| ●   | Hindi      | हिन्दी           | `hi-IN`                                     |
| ●   | Indonesian | Bahasa Indonesia | `id-ID`                                     |

### Extended list

| Language   | Native        | BCP-47 code |
| ---------- | ------------- | ----------- |
| Bengali    | বাংলা         | `bn-IN`     |
| Czech      | Čeština       | `cs-CZ`     |
| Danish     | Dansk         | `da-DK`     |
| Dutch      | Nederlands    | `nl-NL`     |
| Filipino   | Filipino      | `fil-PH`    |
| Finnish    | Suomi         | `fi-FI`     |
| German     | Deutsch       | `de-DE`     |
| Greek      | Ελληνικά      | `el-GR`     |
| Gujarati   | ગુજરાતી       | `gu-IN`     |
| Hungarian  | Magyar        | `hu-HU`     |
| Italian    | Italiano      | `it-IT`     |
| Japanese   | 日本語        | `ja-JP`     |
| Kiswahili  | Kiswahili     | `sw-KE`     |
| Korean     | 한국어        | `ko-KR`     |
| Malay      | Bahasa Melayu | `ms-MY`     |
| Norwegian  | Norsk         | `nb-NO`     |
| Polish     | Polski        | `pl-PL`     |
| Romanian   | Română        | `ro-RO`     |
| Russian    | Русский       | `ru-RU`     |
| Swedish    | Svenska       | `sv-SE`     |
| Tamil      | தமிழ்         | `ta-IN`     |
| Telugu     | తెలుగు        | `te-IN`     |
| Thai       | ภาษาไทย       | `th-TH`     |
| Turkish    | Türkçe        | `tr-TR`     |
| Ukrainian  | Українська    | `uk-UA`     |
| Urdu       | اردو          | `ur-PK`     |
| Vietnamese | Tiếng Việt    | `vi-VN`     |

_All codes above are supported in Chromium browsers. Safari support tracks the
device's installed Apple dictation locales (see
[Per-language coverage](#per-language-coverage-by-engine)); Firefox supports
none._

---

## Language resolution & defaults

The Web Speech API can't guess the spoken language, so `resolveSpeechLang`
picks a starting tag in priority order:

1. The user's onboarding language preference (`preferredLanguageCode`)
2. The browser's preferred language (`navigator.language`)
3. `en-US`

A bare ISO-639-1 code (e.g. `pt`) is region-qualified for better accent
handling via a small map — `en→en-US`, `fr→fr-FR`, `es→es-ES`, `pt→pt-BR`,
`id→id-ID`. An already-qualified tag (e.g. `en-GB`) is trusted as-is.

The user can override the language for the current session from the language
menu in the listening footer (`VoiceLanguageMenu` → `ShortlistLanguagePicker`).
Switching language mid-session tears down and restarts recognition in place,
carrying the transcript captured so far.

---

## Privacy note

Because transcription is browser-native:

- **Chromium:** audio is streamed to Google's speech-recognition service.
- **Safari:** audio is handled by Apple's on-device / dictation engine.
- **GNW backend:** receives neither the audio nor the interim transcript. Only
  the final text the user chooses to send (as a normal chat message) leaves the
  browser.

---

_Last updated: 2026-07-09. Catalogue counts and support logic verified against
`app/utils/speechLang.ts` and `app/hooks/useSpeechInput.ts`._
