### PR TITLE
feat(trace-analytics): add taxonomy tagging and analytics drill-down

### DIFF
--- a/src/features/trace-analytics/lib/__tests__/daily.test.ts
+++ b/src/features/trace-analytics/lib/__tests__/daily.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { computeDailyOutcomeMix } from "../analytics/daily";
+import { makeRow } from "./helpers";
+
+describe("computeDailyOutcomeMix", () => {
+  const rows = [
+    makeRow({ traceId: "1", date: "2026-06-02", outcome: "ANSWER" }),
+    makeRow({ traceId: "2", date: "2026-06-01", outcome: "ANSWER" }),
+    makeRow({ traceId: "3", date: "2026-06-01", outcome: "ERROR" }),
+    makeRow({ traceId: "4", date: null, outcome: "ANSWER" }), // no date -> skipped
+    makeRow({ traceId: "5", date: "2026-06-01", outcome: null }), // null label -> skipped
+  ];
+
+  it("groups outcome counts per day in date order, skipping undated/unlabelled rows", () => {
+    const mix = computeDailyOutcomeMix(rows, (r) => r.outcome);
+    expect(mix.map((d) => d.date)).toEqual(["2026-06-01", "2026-06-02"]);
+
+    const june1 = mix[0];
+    expect(june1.total).toBe(2);
+    expect(june1.counts).toEqual({ ANSWER: 1, ERROR: 1 });
+
+    const june2 = mix[1];
+    expect(june2.total).toBe(1);
+    expect(june2.counts).toEqual({ ANSWER: 1 });
+  });
+
+  it("keys counts by whatever the label accessor returns", () => {
+    const mix = computeDailyOutcomeMix(rows, (r) =>
+      r.outcome === "ANSWER" ? "Success" : r.outcome ? "Failure" : null
+    );
+    expect(mix[0].counts).toEqual({ Success: 1, Failure: 1 });
+  });
+});

--- a/src/features/trace-analytics/lib/__tests__/funnel.test.ts
+++ b/src/features/trace-analytics/lib/__tests__/funnel.test.ts
@@ -70,4 +70,39 @@ describe("computeJourneyFunnel", () => {
     expect(funnel.totalSessions).toBe(0);
     expect(funnel.stages.every((s) => s.count === 0)).toBe(true);
   });
+
+  it("reports which sessions dropped before each stage", () => {
+    const rows = [
+      // s1: full journey.
+      makeRow({ sessionId: "s1", aoiName: "Brazil", hasInsight: true }),
+      // s2: AOI but no dataset → dropped before "dataset".
+      makeRow({
+        traceId: "t3",
+        sessionId: "s2",
+        aoiName: "Kenya",
+        datasetsAnalysed: "",
+        hasInsight: false,
+      }),
+      // s3: nothing at all → dropped before "aoi".
+      makeRow({
+        traceId: "t4",
+        sessionId: "s3",
+        aoiName: "",
+        datasetsAnalysed: "",
+        hasInsight: false,
+      }),
+      // s4: AOI + dataset but no insight → dropped before "insight".
+      makeRow({
+        traceId: "t5",
+        sessionId: "s4",
+        aoiName: "Peru",
+        hasInsight: false,
+      }),
+    ];
+
+    const funnel = computeJourneyFunnel(rows);
+    expect(funnel.droppedBefore.aoi).toEqual(["s3"]);
+    expect(funnel.droppedBefore.dataset).toEqual(["s2"]);
+    expect(funnel.droppedBefore.insight).toEqual(["s4"]);
+  });
 });

--- a/src/features/trace-analytics/lib/__tests__/taxonomy.test.ts
+++ b/src/features/trace-analytics/lib/__tests__/taxonomy.test.ts
@@ -1,0 +1,386 @@
+import { describe, expect, it } from "vitest";
+import {
+  classifyFlag,
+  classifyTopics,
+  classifyTurn,
+  coarseRollup,
+  complexityBand,
+  complexityScore,
+  continuationDistribution,
+  flagDistribution,
+  intentDistribution,
+  intentOf,
+  languageReconciliation,
+  NA_LABEL,
+  outcomeMixByDimension,
+  reconcileLang,
+  tagTraces,
+} from "../analytics/taxonomy";
+import { makeRow } from "./helpers";
+
+// The worked examples below are the ones documented in the taxonomy spec
+// (docs/taxonomy_v2.md §8, docs/redefinitions.md). They pin the v2.1 rules:
+// spatial is view-only, ranking+comparative merged into comparison, and
+// non-analytical turns gate to not_applicable.
+
+describe("classifyFlag", () => {
+  it("flags empty, junk, test scaffolding, system text and templated prompts", () => {
+    expect(classifyFlag("")).toBe("null");
+    expect(classifyFlag("   ")).toBe("null");
+    expect(classifyFlag("test")).toBe("junk_test");
+    expect(classifyFlag("dsdssds")).toBe("junk_test");
+    expect(classifyFlag("bcdfghjk")).toBe("junk_test"); // consonant soup
+    expect(classifyFlag("pick a dataset for the analysis")).toBe(
+      "internal_test"
+    );
+    expect(classifyFlag("User performed UI action")).toBe("system_injected");
+    expect(classifyFlag("Analyse Tree cover loss in Mali.")).toBe(
+      "templated_analyse"
+    );
+    expect(classifyFlag("Analyze Portugal")).toBe("templated_analyse");
+    expect(classifyFlag("How much forest did Brazil lose in 2023?")).toBe(
+      "organic"
+    );
+  });
+});
+
+describe("classifyTopics", () => {
+  it("tags subjects and rolls up to coarse buckets", () => {
+    // "tree cover loss" matches deforestation AND forest_status (the two
+    // regexes overlap in the source vocabulary) — multi-tag is faithful.
+    expect(classifyTopics("tree cover loss in Brazil")).toBe(
+      "deforestation|forest_status"
+    );
+    expect(classifyTopics("recent fire alerts")).toContain("fire");
+    expect(classifyTopics("hello there")).toBe("unclassified");
+    expect(coarseRollup("deforestation|fire")).toBe("Forest & tree cover|Fire");
+    // overlapping fine tags collapse to a single coarse bucket
+    expect(coarseRollup("deforestation|forest_status")).toBe(
+      "Forest & tree cover"
+    );
+    expect(coarseRollup("unclassified")).toBe("Unclassified");
+  });
+
+  it("tags the v2.1 satellite_imagery subject", () => {
+    expect(
+      classifyTopics("What year is the satellite image I am viewing?")
+    ).toBe("satellite_imagery");
+  });
+});
+
+describe("intent (v2.1 rules)", () => {
+  it("classifies a 'show me [metric]' prompt by its metric, not as spatial", () => {
+    // v2.1: spatial is view-only. "show me tree cover loss" is quantification.
+    expect(
+      intentOf("show me tree cover loss in this area", "deforestation")
+    ).toBe("quantification");
+    expect(
+      intentOf("show me tree cover loss in brazil in 2023", "deforestation")
+    ).toBe("quantification");
+  });
+
+  it("keeps true navigation as spatial", () => {
+    expect(intentOf("show me the map of the amazon", "unclassified")).toBe(
+      "spatial"
+    );
+    expect(intentOf("zoom to the congo basin", "unclassified")).toBe("spatial");
+  });
+
+  it("treats superlatives and A-vs-B as one comparison intent", () => {
+    expect(
+      intentOf("which country lost the most forest in 2023?", "deforestation")
+    ).toBe("comparison");
+    expect(
+      intentOf("compare deforestation in peru and colombia", "deforestation")
+    ).toBe("comparison");
+  });
+
+  it("classifies trend, causal and monitoring", () => {
+    expect(intentOf("how has fire activity changed since 2015?", "fire")).toBe(
+      "trend"
+    );
+    expect(intentOf("why did forest loss rise in para?", "deforestation")).toBe(
+      "causal"
+    );
+    expect(
+      intentOf("are there recent disturbance alerts here?", "alerts")
+    ).toBe("monitoring");
+  });
+});
+
+describe("classifyTurn", () => {
+  it("gates non-analytical roles to not_applicable", () => {
+    expect(
+      classifyTurn(
+        "give me a tl;dr of this insight",
+        "organic",
+        1,
+        "unclassified"
+      )
+    ).toMatchObject({ turnRole: "insight_operation", intent: NA_LABEL });
+    expect(classifyTurn("yes", "organic", 1, "unclassified")).toMatchObject({
+      turnRole: "confirmation_selection",
+      intent: NA_LABEL,
+    });
+    expect(
+      classifyTurn("what datasets do you have?", "organic", 0, "unclassified")
+    ).toMatchObject({ turnRole: "meta_platform", intent: NA_LABEL });
+  });
+
+  it("treats a bare correction as not_applicable (regressions: the 'no,' bug)", () => {
+    // docs/redefinitions.md: "no, do not use drivers." must gate to NA, not causal.
+    expect(
+      classifyTurn("no, do not use drivers.", "organic", 1, "unclassified")
+    ).toMatchObject({ turnRole: "follow_up_refine", intent: NA_LABEL });
+    expect(
+      classifyTurn(
+        "sorry I meant the bekaa valley",
+        "organic",
+        1,
+        "unclassified"
+      )
+    ).toMatchObject({ intent: NA_LABEL });
+  });
+
+  it("keeps a correction that carries a year or metric analytical", () => {
+    // "no, use 2024 instead" carries a year, so it stays a real intent.
+    const r = classifyTurn(
+      "no, use 2024 instead",
+      "organic",
+      1,
+      "unclassified"
+    );
+    expect(r.turnRole).toBe("follow_up_refine");
+    expect(r.intent).not.toBe(NA_LABEL);
+  });
+
+  it("does not misread 'now' as the negation 'no'", () => {
+    const r = classifyTurn(
+      "now compare it with syria",
+      "organic",
+      1,
+      "unclassified"
+    );
+    expect(r.turnRole).toBe("follow_up_refine");
+    expect(r.intent).toBe("comparison");
+  });
+});
+
+describe("complexity", () => {
+  it("returns null for an empty prompt and bands it as not_applicable", () => {
+    expect(complexityScore("")).toBeNull();
+    expect(complexityBand(null)).toBe(NA_LABEL);
+  });
+
+  it("does not credit a bare preposition as an area (the v2 'for' bug)", () => {
+    // "trend for tree cover loss" has no place — 'for' alone must not score area.
+    const score = complexityScore("what's the trend for tree cover loss") ?? 0;
+    const withPlace =
+      complexityScore("what's the trend for tree cover loss in Brazil") ?? 0;
+    expect(withPlace).toBeGreaterThan(score);
+  });
+
+  it("bands scores as documented", () => {
+    expect(complexityBand(0)).toBe("minimal");
+    expect(complexityBand(1)).toBe("minimal");
+    expect(complexityBand(2)).toBe("low");
+    expect(complexityBand(4)).toBe("moderate");
+    expect(complexityBand(6)).toBe("high");
+  });
+});
+
+describe("reconcileLang", () => {
+  it("is system-preferred, backfills blanks, flags disagreements", () => {
+    expect(reconcileLang("en", "en")).toEqual({
+      langFinal: "en",
+      langAgreement: "agree",
+    });
+    expect(reconcileLang("de", "en")).toEqual({
+      langFinal: "de",
+      langAgreement: "disagree",
+    });
+    expect(reconcileLang("", "es")).toEqual({
+      langFinal: "es",
+      langAgreement: "detected_only",
+    });
+    expect(reconcileLang("en", "und")).toEqual({
+      langFinal: "en",
+      langAgreement: "system_only",
+    });
+    expect(reconcileLang("", null)).toEqual({
+      langFinal: "und",
+      langAgreement: "none",
+    });
+  });
+});
+
+describe("tagTraces", () => {
+  it("orders a session by time, assigns turn position, and inherits topics", () => {
+    // Deliberately supplied out of order to prove the internal time-sort.
+    const tagged = tagTraces([
+      makeRow({
+        traceId: "b",
+        sessionId: "s1",
+        timestamp: "2026-06-01T10:05:00Z",
+        prompt: "now compare it with Syria",
+        language: "en",
+      }),
+      makeRow({
+        traceId: "a",
+        sessionId: "s1",
+        timestamp: "2026-06-01T10:00:00Z",
+        prompt: "How much tree cover loss did Lebanon have in 2023?",
+        language: "en",
+      }),
+    ]);
+    // Output preserves INPUT order (b, a).
+    const byId = new Map(tagged.map((t) => [t.row.traceId, t]));
+    const a = byId.get("a")!;
+    const b = byId.get("b")!;
+
+    expect(a.turnPos).toBe(0);
+    expect(a.topics).toBe("deforestation|forest_status");
+    expect(a.intent).toBe("quantification");
+
+    expect(b.turnPos).toBe(1);
+    expect(b.turnRole).toBe("follow_up_refine");
+    expect(b.intent).toBe("comparison");
+    // topic-less continuation inherits the session's literal topic
+    expect(b.topics).toBe("deforestation|forest_status");
+    expect(b.topicsInherited).toBe(true);
+    expect(b.topicCoarse).toBe("Forest & tree cover");
+  });
+
+  it("treats a null sessionId as its own singleton session", () => {
+    const tagged = tagTraces([
+      makeRow({ traceId: "x", sessionId: null, prompt: "yes" }),
+      makeRow({ traceId: "y", sessionId: null, prompt: "ok" }),
+    ]);
+    // Each is turn 0 of its own session, so neither is a confirmation follow-up.
+    expect(tagged.every((t) => t.turnPos === 0)).toBe(true);
+  });
+
+  it("produces sane distributions", () => {
+    const tagged = tagTraces([
+      makeRow({
+        traceId: "1",
+        sessionId: "s",
+        timestamp: "2026-06-01T10:00:00Z",
+        prompt: "How much forest did Brazil lose in 2023?",
+        language: "en",
+      }),
+      makeRow({
+        traceId: "2",
+        sessionId: "s",
+        timestamp: "2026-06-01T10:01:00Z",
+        prompt: "compare that with Peru",
+        language: "en",
+      }),
+      makeRow({
+        traceId: "3",
+        sessionId: "t",
+        timestamp: "2026-06-01T10:00:00Z",
+        prompt: "test",
+        language: "en",
+      }),
+    ]);
+
+    const flags = flagDistribution(tagged);
+    expect(flags.find((f) => f.label === "junk_test")?.count).toBe(1);
+    expect(flags.find((f) => f.label === "organic")?.count).toBe(2);
+
+    // junk excluded from organic-only intent distribution
+    const intents = intentDistribution(tagged, { organic: true });
+    const total = intents.reduce((a, b) => a + b.count, 0);
+    expect(total).toBe(2);
+
+    const cont = continuationDistribution(tagged, { organic: true });
+    expect(cont.find((c) => c.label === "refinement")?.count).toBe(1);
+
+    const lang = languageReconciliation(tagged);
+    expect(lang.finalCounts.find((l) => l.label === "en")?.count).toBe(2);
+  });
+});
+
+describe("outcomeMixByDimension", () => {
+  const tagged = tagTraces([
+    makeRow({
+      traceId: "1",
+      sessionId: "s",
+      prompt: "How much tree cover loss did Brazil have in 2023?",
+      outcome: "ANSWER",
+      language: "en",
+    }),
+    makeRow({
+      traceId: "2",
+      sessionId: "t",
+      prompt: "why did fires increase in Peru?",
+      outcome: "SOFT_ERROR",
+      language: "en",
+    }),
+    makeRow({
+      traceId: "3",
+      sessionId: "u",
+      prompt: "yes",
+      outcome: "DEFER",
+      language: "en",
+    }),
+  ]);
+
+  it("breaks outcomes down by coarse topic", () => {
+    const mix = outcomeMixByDimension(tagged, "topic");
+    expect(
+      mix.find((m) => m.label === "Forest & tree cover")?.counts.ANSWER
+    ).toBe(1);
+    expect(mix.find((m) => m.label === "Fire")?.counts.SOFT_ERROR).toBe(1);
+  });
+
+  it("breaks outcomes down by intent, skipping non-analytical turns", () => {
+    const mix = outcomeMixByDimension(tagged, "intent");
+    const labels = mix.map((m) => m.label);
+    expect(labels).toContain("quantification");
+    expect(labels).toContain("causal");
+    // the bare "yes" (not_applicable) contributes nothing
+    expect(mix.reduce((a, b) => a + b.total, 0)).toBe(2);
+  });
+
+  it("breaks outcomes down by reconciled language", () => {
+    const mix = outcomeMixByDimension(tagged, "language");
+    expect(mix.find((m) => m.label === "en")?.total).toBe(3);
+  });
+
+  it("breaks outcomes down by turn role (all roles, incl. non-analytical)", () => {
+    const mix = outcomeMixByDimension(tagged, "turn");
+    const labels = mix.map((m) => m.label);
+    expect(labels).toContain("new_query");
+    // "yes" is a confirmation_selection, which IS a turn category here
+    expect(mix.find((m) => m.label === "confirmation_selection")?.total).toBe(
+      1
+    );
+    expect(mix.reduce((a, b) => a + b.total, 0)).toBe(3);
+  });
+
+  it("uses a custom outcomeOf accessor (e.g. a refined outcome)", () => {
+    // Map every trace to a single injected code — proves the counts key off the
+    // accessor's return value, not row.outcome.
+    const mix = outcomeMixByDimension(tagged, "language", {
+      outcomeOf: () => "ANSWER_CLEAN",
+    });
+    expect(mix.find((m) => m.label === "en")?.counts.ANSWER_CLEAN).toBe(3);
+  });
+
+  it("skips turns with no outcome", () => {
+    const noOutcome = tagTraces([
+      makeRow({
+        traceId: "z",
+        prompt: "How much forest was lost?",
+        outcome: null,
+      }),
+    ]);
+    expect(outcomeMixByDimension(noOutcome, "topic")).toEqual([]);
+    // a custom accessor returning nullish also skips
+    expect(
+      outcomeMixByDimension(tagged, "topic", { outcomeOf: () => null })
+    ).toEqual([]);
+  });
+});

--- a/src/features/trace-analytics/lib/analytics/aggregations.ts
+++ b/src/features/trace-analytics/lib/analytics/aggregations.ts
@@ -262,7 +262,11 @@ export function computePromptLengths(rows: readonly TraceRow[]): PromptLengths {
 // Internal vs user-visible errors
 // ---------------------------------------------------------------------------
 
-const USER_VISIBLE_OUTCOMES = new Set(["ERROR", "EMPTY", "SOFT_ERROR"]);
+/**
+ * Outcomes the user experiences as a failure. Exported so drill-downs can
+ * select the exact rows the overlap donuts counted.
+ */
+export const USER_VISIBLE_OUTCOMES = new Set(["ERROR", "EMPTY", "SOFT_ERROR"]);
 
 export interface ErrorOverlap {
   readonly total: number;
@@ -311,6 +315,7 @@ export interface ToolUsageStats {
   readonly maxToolCalls: number;
   readonly toolErrorRate: number;
   readonly scatter: readonly {
+    readonly traceId: string;
     readonly toolCallCount: number;
     readonly latencySeconds: number;
     readonly outcome: string;
@@ -327,6 +332,7 @@ export function computeToolUsage(rows: readonly TraceRow[]): ToolUsageStats {
         Number.isFinite(r.latencySeconds)
     )
     .map((r) => ({
+      traceId: r.traceId,
       toolCallCount: r.toolCallCount,
       latencySeconds: r.latencySeconds as number,
       outcome: String(r.outcome ?? "Unknown"),

--- a/src/features/trace-analytics/lib/analytics/daily.ts
+++ b/src/features/trace-analytics/lib/analytics/daily.ts
@@ -3,6 +3,44 @@
 import type { TraceRow } from "../../model/types";
 import { finiteNumbers, mean, quantile } from "./stats";
 
+/** Per-day outcome composition, generic over the outcome label set. */
+export interface DailyOutcomeMix {
+  readonly date: string;
+  /** Rows with a resolvable label for the day. */
+  readonly total: number;
+  /** Outcome display label → trace count. */
+  readonly counts: Readonly<Record<string, number>>;
+}
+
+/**
+ * Group rows by calendar date and count outcomes per day using `labelOf`, which
+ * resolves each row to a display label (or null to skip it). This is outcome-
+ * source-agnostic: pass an accessor over `row.outcome` for the API view, or one
+ * that reads a refined label for the refined view. Rows with no date or a null
+ * label are skipped; days are returned in date order.
+ */
+export function computeDailyOutcomeMix(
+  rows: readonly TraceRow[],
+  labelOf: (row: TraceRow) => string | null
+): DailyOutcomeMix[] {
+  const byDate = new Map<string, Map<string, number>>();
+  for (const row of rows) {
+    if (!row.date) continue;
+    const label = labelOf(row);
+    if (!label) continue;
+    const counts = byDate.get(row.date) ?? new Map<string, number>();
+    counts.set(label, (counts.get(label) ?? 0) + 1);
+    byDate.set(row.date, counts);
+  }
+  return [...byDate.entries()]
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([date, counts]) => ({
+      date,
+      total: [...counts.values()].reduce((a, b) => a + b, 0),
+      counts: Object.fromEntries(counts),
+    }));
+}
+
 export interface DailyMetrics {
   readonly date: string;
   readonly traces: number;

--- a/src/features/trace-analytics/lib/analytics/funnel.ts
+++ b/src/features/trace-analytics/lib/analytics/funnel.ts
@@ -30,6 +30,21 @@ export interface JourneyFunnel {
    * predate the flag, and the insight stage should render as unavailable.
    */
   readonly insightKnown: boolean;
+  /**
+   * Session keys that cleared the previous stage but stalled before this one
+   * (the drop-off the funnel visualises). Keys match `sessionKey()`: a real
+   * sessionId, or `trace:<id>` for rows without one.
+   */
+  readonly droppedBefore: Readonly<{
+    aoi: readonly string[];
+    dataset: readonly string[];
+    insight: readonly string[];
+  }>;
+}
+
+/** Funnel grouping key: the sessionId, or a per-trace pseudo-session. */
+export function sessionKey(row: TraceRow): string {
+  return String(row.sessionId ?? "").trim() || `trace:${row.traceId}`;
 }
 
 interface SessionFlags {
@@ -45,7 +60,7 @@ export function computeJourneyFunnel(rows: readonly TraceRow[]): JourneyFunnel {
 
   for (const row of rows) {
     // Rows without a session id are their own single-turn pseudo-session.
-    const key = String(row.sessionId ?? "").trim() || `trace:${row.traceId}`;
+    const key = sessionKey(row);
     const flags = bySession.get(key) ?? {
       aoi: false,
       dataset: false,
@@ -59,16 +74,30 @@ export function computeJourneyFunnel(rows: readonly TraceRow[]): JourneyFunnel {
   }
 
   // One counting pass — a session only advances a stage if it cleared every
-  // earlier one, so counts are monotonically decreasing (a true funnel).
+  // earlier one, so counts are monotonically decreasing (a true funnel). The
+  // sessions that stall before a stage are kept so the UI can open them.
   let aoi = 0;
   let dataset = 0;
   let insight = 0;
-  for (const flags of bySession.values()) {
-    if (!flags.aoi) continue;
+  const droppedBeforeAoi: string[] = [];
+  const droppedBeforeDataset: string[] = [];
+  const droppedBeforeInsight: string[] = [];
+  for (const [key, flags] of bySession.entries()) {
+    if (!flags.aoi) {
+      droppedBeforeAoi.push(key);
+      continue;
+    }
     aoi += 1;
-    if (!flags.dataset) continue;
+    if (!flags.dataset) {
+      droppedBeforeDataset.push(key);
+      continue;
+    }
     dataset += 1;
-    if (flags.insight) insight += 1;
+    if (flags.insight) {
+      insight += 1;
+    } else {
+      droppedBeforeInsight.push(key);
+    }
   }
   const total = bySession.size;
 
@@ -92,5 +121,14 @@ export function computeJourneyFunnel(rows: readonly TraceRow[]): JourneyFunnel {
     };
   });
 
-  return { totalSessions: total, stages, insightKnown };
+  return {
+    totalSessions: total,
+    stages,
+    insightKnown,
+    droppedBefore: {
+      aoi: droppedBeforeAoi,
+      dataset: droppedBeforeDataset,
+      insight: droppedBeforeInsight,
+    },
+  };
 }

--- a/src/features/trace-analytics/lib/analytics/taxonomy.ts
+++ b/src/features/trace-analytics/lib/analytics/taxonomy.ts
@@ -1,0 +1,1032 @@
+/**
+ * GNW / Zeno prompt taxonomy — deterministic rule tagger.
+ *
+ * A faithful TypeScript port of the Python reference tagger
+ * (`skillz/projects/trace-analysis/taxonomy/src/tag_prompts.py`, v2.1). The
+ * Python file remains the source of truth for the vocabulary and rules; this
+ * port exists so the trace-analytics dashboard can classify prompts entirely
+ * client-side (no network, no LLM) from the trace rows it already holds.
+ *
+ * Keep the two in sync: the constants block below mirrors the Python constants
+ * near-verbatim. If a category or rule changes upstream, update it here too and
+ * re-run the unit tests. See docs/taxonomy_v2.md for what the categories mean.
+ *
+ * Axes (per turn):
+ *   - flag           cleaning segment (organic / templated_analyse /
+ *                    internal_test / junk_test / system_injected / null)
+ *   - turnRole       what the turn is doing (new_query, follow_up_refine, ...)
+ *   - continuation   in-session behaviour (opening, refinement, selection, ...)
+ *   - intent         analytical goal for substantive turns, else not_applicable
+ *   - topics         pipe-delimited fine tags (+ topicsInherited flag)
+ *   - topicCoarse    pipe-delimited coarse rollup
+ *   - complexity     0-10 constraint count (null for empty prompts); cxBand
+ *   - lang*          system value, independent detection, reconciled final
+ *
+ * Language note: unlike the Python (which uses `langdetect`), this port reuses
+ * the dashboard's existing franc-based detector (`detectPromptLanguage`) so we
+ * add no dependency. franc and langdetect differ on short/ambiguous text, so
+ * the reconciliation numbers will not byte-match the Python judged sample; the
+ * reconciliation *logic* (system-preferred, detection backfills blanks,
+ * disagreements flagged) is identical.
+ */
+
+import type { TraceRow } from "../../model/types";
+import { detectPromptLanguage } from "./language";
+
+// --------------------------------------------------------------------------- #
+// Constants: taxonomy vocabulary (mirror of tag_prompts.py)
+// --------------------------------------------------------------------------- #
+
+const JUNK = new Set([
+  "test",
+  "dsfghjkhjsdgfhjrertyuiloiuywertyui",
+  "dsdssds",
+  "dsadsdsdsffddf",
+  "gffgfg",
+  "dafgdfdsff",
+]);
+
+const CONFIRM = new Set([
+  "yes",
+  "no",
+  "done",
+  "sure",
+  "ok",
+  "okay",
+  "please do",
+  "lets go",
+  "let's go",
+  "yeah",
+  "yep",
+  "si",
+  "sí",
+  "haz el analisis",
+  "alright",
+  "3",
+]);
+
+/**
+ * Fine topic tag -> matching regex, applied to the lowercased prompt. Insertion
+ * order is preserved so multi-tag output lists tags in the same order as the
+ * Python dict.
+ */
+const TOPIC: ReadonlyArray<readonly [string, RegExp]> = [
+  ["fire", /fire|wildfire|burn|veld fire/],
+  [
+    "deforestation",
+    /deforest|forest loss|tree cover loss|\btcl\b|tree loss|pérdida de cobertura|perdida de cobertura|perdida de bosque|pérdida de bosque|deforestaci|pérdida forestal|perdida forestal|desmatamento/,
+  ],
+  [
+    "forest_status",
+    /tree cover\b|canopy|primary (rain)?forest|intact forest|forest extent|bosque|floresta|cobertura forestal|covered (by|in) trees|tree species|type of trees/,
+  ],
+  [
+    "natural_lands",
+    /natural land|natural\/semi-natural|natural ecosystem|semi-natural/,
+  ],
+  ["land_cover", /land cover|land use|cropland|land conversion|converted to/],
+  ["carbon", /carbon|emission|flux/],
+  ["biodiversity", /biodiversity|species|endangered|wildlife|flora/],
+  [
+    "agriculture",
+    /crop|agricultur|cocoa|palm|shrimp|aquaculture|pineapple|tea vs|coffee/,
+  ],
+  ["grasslands", /grassland/],
+  ["water_wetlands", /mangrove|wetland|peatland|lagoon|\bbasin\b|cuenca/],
+  ["urban", /\burban\b|urban expansion/],
+  ["mining", /mining|\bmine\b/],
+  [
+    "protected_areas",
+    /protected area|national park|reserva|reserve|world heritage|áreas protegidas|areas protegidas/,
+  ],
+  [
+    "alerts",
+    /alert|dist-alert|\baid\b|alerta|disturb|disaster|perturbaci|perturba/,
+  ],
+  ["restoration", /restoration|restore|reforest/],
+  ["climate", /temperature|climate|socioeconomic/],
+  ["indigenous_lands", /indigenous|comunidad|nativa|matses|matsés|ejido/],
+  // v2.1: added from LLM topic discovery — users ask about the satellite
+  // basemap itself (its date, clarity, availability).
+  [
+    "satellite_imagery",
+    /satellite imag|satellite-observ|\bimagery\b|satellite picture|clear (satellite )?imag/,
+  ],
+];
+
+/** Fine tag -> coarse rollup bucket. */
+const COARSE: Readonly<Record<string, string>> = {
+  deforestation: "Forest & tree cover",
+  forest_status: "Forest & tree cover",
+  fire: "Fire",
+  alerts: "Alerts & disturbance",
+  land_cover: "Land & agriculture",
+  agriculture: "Land & agriculture",
+  natural_lands: "Land & agriculture",
+  grasslands: "Land & agriculture",
+  carbon: "Carbon & climate",
+  climate: "Carbon & climate",
+  biodiversity: "Biodiversity & conservation",
+  protected_areas: "Biodiversity & conservation",
+  restoration: "Biodiversity & conservation",
+  indigenous_lands: "Biodiversity & conservation",
+  water_wetlands: "Water & wetlands",
+  urban: "Built & extractive",
+  mining: "Built & extractive",
+  satellite_imagery: "Satellite imagery",
+  unclassified: "Unclassified",
+};
+
+/**
+ * Turn roles that carry no analytical intent — their intent is always
+ * `not_applicable`. Part of the public vocabulary; `classifyTurn` returns
+ * `NA_LABEL` on each of these branches directly.
+ */
+export const NO_INTENT_ROLES = new Set([
+  "confirmation_selection",
+  "meta_platform",
+  "report_action",
+  "insight_operation",
+  "junk_test",
+  "system_injected",
+  "empty_null",
+]);
+
+/**
+ * Turn roles that continue the current analysis, so a topic-less one inherits
+ * the session's most-recent literal topic (v2.1). Deliberately excludes
+ * new_query: a topic-less new question may be a genuinely new subject.
+ */
+const INHERIT_ROLES = new Set([
+  "follow_up_refine",
+  "insight_operation",
+  "dataset_disambiguation",
+]);
+
+/**
+ * The 11 substantive intents. `comparison` replaces the overlapping
+ * `ranking`+`comparative` pair; `spatial` is view-only (v2.1).
+ */
+export const INTENT_LABELS: readonly string[] = [
+  "quantification",
+  "trend",
+  "monitoring",
+  "spatial",
+  "causal",
+  "comparison",
+  "risk",
+  "feasibility",
+  "conceptual",
+  "identification",
+  "other",
+];
+
+const INTENT_LABEL_SET = new Set(INTENT_LABELS);
+
+/**
+ * Sentinel for "no analytical intent". Kept as a full word (not the short code)
+ * to match the Python, where it must survive a pandas CSV round-trip.
+ */
+export const NA_LABEL = "not_applicable";
+
+export const UNCLASSIFIED = "unclassified";
+
+/** Undetermined language. */
+const UND = "und";
+
+export type CxBand = "minimal" | "low" | "moderate" | "high" | typeof NA_LABEL;
+export type LangAgreement =
+  | "agree"
+  | "disagree"
+  | "detected_only"
+  | "system_only"
+  | "none";
+
+/** All tags a single turn carries. `row` is kept for downstream joins. */
+export interface TaggedTrace {
+  readonly row: TraceRow;
+  readonly turnPos: number;
+  readonly flag: string;
+  readonly turnRole: string;
+  readonly continuation: string;
+  readonly intent: string;
+  readonly topics: string;
+  readonly topicsInherited: boolean;
+  readonly topicCoarse: string;
+  readonly complexity: number | null;
+  readonly cxBand: CxBand;
+  readonly langSystem: string;
+  readonly langDetected: string;
+  readonly langSession: string;
+  readonly langFinal: string;
+  readonly langAgreement: LangAgreement;
+}
+
+// --------------------------------------------------------------------------- #
+// Helpers
+// --------------------------------------------------------------------------- #
+
+function norm(prompt: string | null | undefined): string {
+  return (prompt ?? "").trim().toLowerCase();
+}
+
+function isEmptyPrompt(prompt: string | null | undefined): boolean {
+  return !prompt || prompt.trim() === "";
+}
+
+// --------------------------------------------------------------------------- #
+// flag (cleaning segment)
+// --------------------------------------------------------------------------- #
+
+export function classifyFlag(prompt: string | null | undefined): string {
+  if (isEmptyPrompt(prompt)) return "null";
+  const s = norm(prompt);
+  if (JUNK.has(s)) return "junk_test";
+  // Consonant soup: a single long token with almost no vowels is gibberish.
+  const letters = s.replace(/[^a-z]/g, "");
+  if (s.length >= 5 && !s.includes(" ") && letters) {
+    const vowels = [...letters].filter((c) => "aeiou".includes(c)).length;
+    if (vowels / letters.length < 0.2) return "junk_test";
+  }
+  if (
+    s.startsWith("pick a dataset") ||
+    s.startsWith("choose a dataset") ||
+    s.includes("best answer the question")
+  ) {
+    return "internal_test";
+  }
+  if (
+    s.includes("user performed ui action") ||
+    s.includes("acknowledge the updates")
+  ) {
+    return "system_injected";
+  }
+  if (
+    /^analy[sz]e /.test(s) &&
+    (s.includes(" in ") || /^analy[sz]e [a-z ]+$/.test(s))
+  ) {
+    return "templated_analyse";
+  }
+  return "organic";
+}
+
+// --------------------------------------------------------------------------- #
+// topics
+// --------------------------------------------------------------------------- #
+
+export function classifyTopics(prompt: string | null | undefined): string {
+  if (isEmptyPrompt(prompt)) return UNCLASSIFIED;
+  const s = norm(prompt);
+  const tags = TOPIC.filter(([, rx]) => rx.test(s)).map(([k]) => k);
+  return tags.length ? tags.join("|") : UNCLASSIFIED;
+}
+
+export function coarseRollup(topics: string): string {
+  const seen: string[] = [];
+  for (const t of topics.split("|")) {
+    const c = COARSE[t] ?? "Unclassified";
+    if (!seen.includes(c)) seen.push(c);
+  }
+  return seen.join("|");
+}
+
+// --------------------------------------------------------------------------- #
+// intent
+// --------------------------------------------------------------------------- #
+
+function baseIntent(s: string): string {
+  // comparison = explicit A-vs-B OR superlative/rank over a set (v2.1 merge).
+  if (
+    /(compare|comparar|versus| vs |vs\.|more .* than|between .+ and .+|how does .* compare|compara)/.test(
+      s
+    )
+  ) {
+    return "comparison";
+  }
+  if (
+    /(top \d|top three|the most|biggest|largest|highest|which .*(had|has|lost) (the )?most|prioriti|más pérdida|mayor pérdida)/.test(
+      s
+    )
+  ) {
+    return "comparison";
+  }
+  if (
+    /(trend|over the (last|past)|since \d{4}|between \d{4}|over time|tendencia|changes in .* (over|between)|past decade|last \d+ (years|months)|\d{4}\s*[-–to]{1,3}\s*\d{4}|\d{4}-\d{4})/.test(
+      s
+    )
+  ) {
+    return "trend";
+  }
+  if (
+    /(why|driver|drivers|caused by|due to|causes|cause of|led to|linked to|dominant driver)/.test(
+      s
+    )
+  ) {
+    return "causal";
+  }
+  if (
+    /(alert|recent|latest|last month|this month|disturb|near-real|what.*happening|disaster|alerta|perturbaci|\baid\b|fires in )/.test(
+      s
+    )
+  ) {
+    return "monitoring";
+  }
+  if (
+    /(how much|how many|what percentage|percent|%|what area|hectares|area of|total area|covered by trees|perdida de cobertura|cuanto|cuánto|net (carbon )?emissions)/.test(
+      s
+    )
+  ) {
+    return "quantification";
+  }
+  if (/(at risk|vulnerab|environmental risk)/.test(s)) return "risk";
+  if (
+    /(should i prioriti|restoration|restore|protect|carbon credit|viabilit)/.test(
+      s
+    )
+  ) {
+    return "feasibility";
+  }
+  if (
+    /(how does .* impact|correlation|relationship between|socioeconomic)/.test(
+      s
+    )
+  ) {
+    return "conceptual";
+  }
+  if (/(what is this|describe|type of|what data|what year|identif)/.test(s)) {
+    return "identification";
+  }
+  // spatial is VIEW-ONLY (v2.1): map / navigate / where-is, with no metric.
+  if (
+    /(\bmap\b|where (is|are|can)|\bwhere\b.*\?|zoom|go to|navigate|pan to|give me a map|muestra el mapa|mostrar el mapa|dónde)/.test(
+      s
+    )
+  ) {
+    return "spatial";
+  }
+  return "other";
+}
+
+/** Fallback for terse prompts that carry a topic but no explicit verb. */
+function inferShorthand(s: string, topics: string): string {
+  const hasTopic = topics !== UNCLASSIFIED;
+  const yrRange =
+    /(\d{4}\s*[-–]\s*\d{4}|\d{4} to \d{4}|since \d{4}|last \d+ (year|month)|past .*(year|decade))/.test(
+      s
+    );
+  const yrSingle = /\b(19|20)\d{2}\b/.test(s);
+  const metric = /(loss|cover|area|%|hectares|extent|emissions)/.test(s);
+  if (/\b(vs|versus)\b| vs\.|between .+ and |(most|biggest|top)/.test(s)) {
+    return "comparison";
+  }
+  if (/(fire|alert|disturb|disaster|latest|recent)/.test(s))
+    return "monitoring";
+  if (yrRange) return "trend";
+  if (metric || yrSingle) return "quantification";
+  if (hasTopic) return "spatial";
+  return "other";
+}
+
+export function intentOf(s: string, topics: string): string {
+  const intent = baseIntent(s);
+  return intent === "other" ? inferShorthand(s, topics) : intent;
+}
+
+// --------------------------------------------------------------------------- #
+// turn role / continuation / intent
+// --------------------------------------------------------------------------- #
+
+interface TurnResult {
+  readonly turnRole: string;
+  readonly continuation: string;
+  readonly intent: string;
+}
+
+export function classifyTurn(
+  prompt: string | null | undefined,
+  flag: string,
+  turnPos: number,
+  topics: string
+): TurnResult {
+  if (isEmptyPrompt(prompt)) {
+    return {
+      turnRole: "empty_null",
+      continuation: "opening",
+      intent: NA_LABEL,
+    };
+  }
+  const s = norm(prompt);
+  const first = turnPos === 0;
+
+  if (flag === "junk_test") {
+    return { turnRole: "junk_test", continuation: "other", intent: NA_LABEL };
+  }
+  if (flag === "system_injected") {
+    return {
+      turnRole: "system_injected",
+      continuation: "other",
+      intent: NA_LABEL,
+    };
+  }
+  if (flag === "templated_analyse") {
+    return {
+      turnRole: "templated_command",
+      continuation: first ? "opening" : "new_question",
+      intent: intentOf(s, topics),
+    };
+  }
+
+  if (
+    /(what datasets|what tools|what layers|what data (do|you)|do you have.*(dataset|layer|data)|are you aware|what year is|what is the area|access to (limites|geographic)|what are some data)/.test(
+      s
+    ) ||
+    s === "hey man" ||
+    s === "hey"
+  ) {
+    return {
+      turnRole: "meta_platform",
+      continuation: "meta",
+      intent: NA_LABEL,
+    };
+  }
+  if (
+    s.includes("this insight") ||
+    /^(explain|simplify|give me a one-sentence tl;dr|tl;dr)/.test(s)
+  ) {
+    // v2.1: operating on an existing insight is not an analytical goal.
+    return {
+      turnRole: "insight_operation",
+      continuation: first ? "opening" : "refinement",
+      intent: NA_LABEL,
+    };
+  }
+  if (
+    /(pin (it |this )?into|create a report|for my report|into my report)/.test(
+      s
+    )
+  ) {
+    return {
+      turnRole: "report_action",
+      continuation: "refinement",
+      intent: NA_LABEL,
+    };
+  }
+  if (/^(go to|zoom to|zoom|navigate|pan to)\b/.test(s)) {
+    return {
+      turnRole: "ui_navigation",
+      continuation: first ? "new_question" : "refinement",
+      intent: "spatial",
+    };
+  }
+  if (
+    /(which dataset|what about that .*dataset|do you have the .*dataset)/.test(
+      s
+    )
+  ) {
+    return {
+      turnRole: "dataset_disambiguation",
+      continuation: first ? "opening" : "refinement",
+      intent: intentOf(s, topics),
+    };
+  }
+
+  // bare confirmation / selection
+  if (
+    CONFIRM.has(s) ||
+    (!first &&
+      s.split(/\s+/).length <= 2 &&
+      !/(loss|cover|fire|alert|deforest|tcl)/.test(s))
+  ) {
+    return {
+      turnRole: "confirmation_selection",
+      continuation: "selection",
+      intent: NA_LABEL,
+    };
+  }
+
+  // refinement vs new question for later turns
+  const referential =
+    /\b(this|that|these|those|here|it|now|instead|as well|also)\b/.test(s);
+  const modifier =
+    /^(no,|no |also|and |now |just |can you (convert|add|show)|actually|sorry|rerun|the map|do not|don't|yeah actuslly|i like)/.test(
+      s
+    );
+  const introducesPlace = /\b(in|en|de|del)\s+[a-z]/.test(s) && !referential;
+
+  // v2.1: a bare correction/negation carrying no topic, year or metric is not
+  // an analytical goal ("sorry I meant the bekaa valley", "no, do not use
+  // drivers"). Any year or metric term keeps the analytical intent.
+  const correction =
+    /^(no|sorry|actually|do not|don'?t)\b/.test(s) &&
+    topics === UNCLASSIFIED &&
+    !/\b(19|20)\d{2}\b|\b(loss|cover|area|hectares|extent|emissions|percent)\b|%/.test(
+      s
+    );
+
+  if (!first) {
+    if ((referential || modifier) && !introducesPlace) {
+      return {
+        turnRole: "follow_up_refine",
+        continuation: "refinement",
+        intent: correction ? NA_LABEL : intentOf(s, topics),
+      };
+    }
+    return {
+      turnRole: "new_query",
+      continuation: "new_question",
+      intent: intentOf(s, topics),
+    };
+  }
+  return {
+    turnRole: "new_query",
+    continuation: "opening",
+    intent: intentOf(s, topics),
+  };
+}
+
+// --------------------------------------------------------------------------- #
+// complexity
+// --------------------------------------------------------------------------- #
+
+export function complexityScore(
+  prompt: string | null | undefined
+): number | null {
+  if (isEmptyPrompt(prompt)) return null;
+  const s = norm(prompt);
+  const raw = String(prompt);
+  let f = 0;
+  // area specified: preposition + a capitalised place (raw text), or an
+  // explicit reference to the current AOI. Matching on raw text stops bare
+  // prepositions with no location from being credited.
+  if (
+    /\b(in|en|for|around|near|at|de|del|para|sobre)\s+[A-ZÁÉÍÓÚÜÑ]/.test(raw) ||
+    /this (area|aoi)|\bhere\b/.test(s)
+  ) {
+    f += 1;
+  }
+  if (
+    /(state|province|district|municipality|county|region|provincia|distrito|departamento|park|reserve|reserva|basin|cuenca|comunidad|nativa|highlands|valley|island|plateau|ejido|key biodiversity)/.test(
+      s
+    )
+  ) {
+    f += 1; // sub-national granularity
+  }
+  if (
+    /(\b(19|20)\d{2}\b|last \d+ (year|month)|past (\d+ )?(year|decade|month)|since \d|between \d{4}|q[1-4]|quarter|summer|first half|second half|january|february|march|april|may|june|july|august|september|october|november|december|periodo)/.test(
+      s
+    )
+  ) {
+    f += 1; // temporal constraint
+  }
+  if (
+    /(how much|how many|percentage|percent|%|hectares|\barea\b|total|net (carbon )?emissions|cuanto|cuánto)/.test(
+      s
+    )
+  ) {
+    f += 1; // metric / quantity
+  }
+  if (
+    /(dataset|dist-alert|integrated alert|dominant driver|high conf|confidence|canopy|natural land|land cover|grassland|carbon flux|tree cover)/.test(
+      s
+    )
+  ) {
+    f += 1; // dataset / layer named
+  }
+  if (
+    /(\d+%|canopy density|high confidence|crop management|due to (fires|logging|settlement)|by driver|multiple systems|natural events vs)/.test(
+      s
+    )
+  ) {
+    f += 1; // filter condition
+  }
+  if (
+    /(compare|versus| vs |between .+ and .+|more .* than|comparar|compara)/.test(
+      s
+    )
+  ) {
+    f += 1; // comparison
+  }
+  if (
+    /(top \d|the most|biggest|largest|by year|by driver|by region|per region|breakdown|desglose|each year|separately)/.test(
+      s
+    )
+  ) {
+    f += 1; // aggregation / superlative
+  }
+  if (
+    /(correlation|true or false|caught by multiple|overlap|combine|rerun|both .* and|convert)/.test(
+      s
+    )
+  ) {
+    f += 1; // multi-step reasoning
+  }
+  if (/(sq km|square km|chart|graph|tl;dr|one-sentence|simplify|pin)/.test(s)) {
+    f += 1; // output / format operation
+  }
+  return f;
+}
+
+export function complexityBand(c: number | null): CxBand {
+  if (c === null) return NA_LABEL;
+  if (c <= 1) return "minimal";
+  if (c <= 3) return "low";
+  if (c <= 5) return "moderate";
+  return "high";
+}
+
+// --------------------------------------------------------------------------- #
+// language reconciliation
+// --------------------------------------------------------------------------- #
+
+/**
+ * Reconcile a system (API) language value against an independent detection.
+ * System-preferred, because the system had whole-session context a short turn
+ * lacks; detection backfills blanks; disagreements are kept but flagged.
+ */
+export function reconcileLang(
+  system: string | null | undefined,
+  detected: string | null | undefined
+): { langFinal: string; langAgreement: LangAgreement } {
+  const sys = (system ?? "").trim().toLowerCase();
+  const det = (detected ?? UND).trim().toLowerCase();
+  const hasSys = Boolean(sys);
+  const hasDet = det !== UND;
+
+  if (!hasDet) {
+    return hasSys
+      ? { langFinal: sys, langAgreement: "system_only" }
+      : { langFinal: UND, langAgreement: "none" };
+  }
+  if (!hasSys) return { langFinal: det, langAgreement: "detected_only" };
+  return sys === det
+    ? { langFinal: sys, langAgreement: "agree" }
+    : { langFinal: sys, langAgreement: "disagree" };
+}
+
+// --------------------------------------------------------------------------- #
+// tagTraces — the DataFrame-level entry point (mirrors tag_dataframe)
+// --------------------------------------------------------------------------- #
+
+/** Milliseconds for sorting; null/unparseable timestamps sort last. */
+function tsMillis(iso: string | null): number {
+  if (!iso) return Number.POSITIVE_INFINITY;
+  const t = Date.parse(iso);
+  return Number.isNaN(t) ? Number.POSITIVE_INFINITY : t;
+}
+
+/**
+ * Tag every row on all axes, returned in the SAME order as the input. Rows are
+ * grouped by session and ordered by timestamp internally to compute turn
+ * position, topic inheritance, and session-level language, exactly as the
+ * Python `tag_dataframe` does. A null/blank sessionId is treated as its own
+ * singleton session (never lumped together).
+ */
+export function tagTraces(rows: readonly TraceRow[]): TaggedTrace[] {
+  // Group original indices by session key.
+  const groups = new Map<string, number[]>();
+  rows.forEach((row, i) => {
+    const key =
+      row.sessionId && row.sessionId.trim() ? row.sessionId : `__row_${i}`;
+    const bucket = groups.get(key);
+    if (bucket) bucket.push(i);
+    else groups.set(key, [i]);
+  });
+
+  const out = new Array<TaggedTrace>(rows.length);
+
+  for (const indices of groups.values()) {
+    // Stable sort by timestamp ascending (nulls last), preserving input order
+    // on ties — Array.prototype.sort is stable in modern engines.
+    const ordered = [...indices].sort(
+      (a, b) => tsMillis(rows[a].timestamp) - tsMillis(rows[b].timestamp)
+    );
+
+    // Session-level language detection over the concatenated prompts, so short
+    // turns ("yes", "Cusco") inherit a decision the session can make.
+    const sessionText = ordered.map((i) => rows[i].prompt ?? "").join(" ");
+    const langSession = detectPromptLanguage(sessionText) ?? UND;
+
+    // First pass: flag, literal topics, turn classification, complexity, lang.
+    const literalTopics = new Array<string>(ordered.length);
+    const roles = new Array<string>(ordered.length);
+    const partial = new Array<TaggedTrace>(ordered.length);
+
+    ordered.forEach((rowIndex, pos) => {
+      const row = rows[rowIndex];
+      const flag = classifyFlag(row.prompt);
+      const topics = classifyTopics(row.prompt);
+      const turn = classifyTurn(row.prompt, flag, pos, topics);
+      const complexity = complexityScore(row.prompt);
+
+      const langSystem = (row.language ?? "").trim().toLowerCase();
+      const langDetected = detectPromptLanguage(row.prompt) ?? UND;
+      // Effective detection prefers the turn, then falls back to its session.
+      const detEff = langDetected !== UND ? langDetected : langSession;
+      const { langFinal, langAgreement } = reconcileLang(langSystem, detEff);
+
+      literalTopics[pos] = topics;
+      roles[pos] = turn.turnRole;
+      partial[pos] = {
+        row,
+        turnPos: pos,
+        flag,
+        turnRole: turn.turnRole,
+        continuation: turn.continuation,
+        intent: turn.intent,
+        topics,
+        topicsInherited: false,
+        topicCoarse: coarseRollup(topics),
+        complexity,
+        cxBand: complexityBand(complexity),
+        langSystem,
+        langDetected,
+        langSession,
+        langFinal,
+        langAgreement,
+      };
+    });
+
+    // Second pass: topic inheritance. Carry the most-recent literal topic onto
+    // a topic-less continuation turn. `last` is only ever a literal topic, so
+    // nothing chains off a guess.
+    let last: string | null = null;
+    ordered.forEach((rowIndex, pos) => {
+      const t = literalTopics[pos];
+      const p = partial[pos];
+      if (
+        p.flag === "organic" &&
+        t === UNCLASSIFIED &&
+        INHERIT_ROLES.has(roles[pos]) &&
+        last
+      ) {
+        out[rowIndex] = {
+          ...p,
+          topics: last,
+          topicsInherited: true,
+          topicCoarse: coarseRollup(last),
+        };
+      } else {
+        out[rowIndex] = p;
+        if (t !== UNCLASSIFIED) last = t;
+      }
+    });
+  }
+
+  return out;
+}
+
+// --------------------------------------------------------------------------- #
+// Aggregation helpers for the dashboard
+// --------------------------------------------------------------------------- #
+
+export interface AxisCount {
+  readonly label: string;
+  readonly count: number;
+}
+
+function organicOnly(tagged: readonly TaggedTrace[]): TaggedTrace[] {
+  return tagged.filter((t) => t.flag === "organic");
+}
+
+/** Generic descending count of a string field, optionally organic-only. */
+function countBy(
+  tagged: readonly TaggedTrace[],
+  pick: (t: TaggedTrace) => string
+): AxisCount[] {
+  const counts = new Map<string, number>();
+  for (const t of tagged) counts.set(pick(t), (counts.get(pick(t)) ?? 0) + 1);
+  return [...counts.entries()]
+    .map(([label, count]) => ({ label, count }))
+    .sort((a, b) => b.count - a.count || a.label.localeCompare(b.label));
+}
+
+/** flag distribution across ALL traffic (this is the cleaning axis itself). */
+export function flagDistribution(tagged: readonly TaggedTrace[]): AxisCount[] {
+  return countBy(tagged, (t) => t.flag);
+}
+
+/** intent distribution over substantive turns only. */
+export function intentDistribution(
+  tagged: readonly TaggedTrace[],
+  opts: { readonly organic?: boolean } = {}
+): AxisCount[] {
+  const pool = opts.organic ? organicOnly(tagged) : tagged;
+  return countBy(
+    pool.filter((t) => INTENT_LABEL_SET.has(t.intent)),
+    (t) => t.intent
+  );
+}
+
+export function turnRoleDistribution(
+  tagged: readonly TaggedTrace[],
+  opts: { readonly organic?: boolean } = {}
+): AxisCount[] {
+  const pool = opts.organic ? organicOnly(tagged) : tagged;
+  return countBy(pool, (t) => t.turnRole);
+}
+
+/** continuation distribution over in-session turns (turnPos > 0). */
+export function continuationDistribution(
+  tagged: readonly TaggedTrace[],
+  opts: { readonly organic?: boolean } = {}
+): AxisCount[] {
+  const pool = (opts.organic ? organicOnly(tagged) : tagged).filter(
+    (t) => t.turnPos > 0
+  );
+  return countBy(pool, (t) => t.continuation);
+}
+
+/** Coarse topic occurrences (multi-tag, so total may exceed row count). */
+export function topicCoarseDistribution(
+  tagged: readonly TaggedTrace[],
+  opts: { readonly organic?: boolean } = {}
+): AxisCount[] {
+  const pool = opts.organic ? organicOnly(tagged) : tagged;
+  const counts = new Map<string, number>();
+  for (const t of pool) {
+    for (const c of t.topicCoarse.split("|")) {
+      counts.set(c, (counts.get(c) ?? 0) + 1);
+    }
+  }
+  return [...counts.entries()]
+    .map(([label, count]) => ({ label, count }))
+    .sort((a, b) => b.count - a.count || a.label.localeCompare(b.label));
+}
+
+const CX_BAND_ORDER: readonly CxBand[] = ["minimal", "low", "moderate", "high"];
+
+export interface ComplexitySummary {
+  readonly bands: AxisCount[];
+  /** Mean over scored (non-empty) prompts; null when there are none. */
+  readonly mean: number | null;
+  readonly inheritedTopics: number;
+}
+
+export function complexitySummary(
+  tagged: readonly TaggedTrace[],
+  opts: { readonly organic?: boolean } = {}
+): ComplexitySummary {
+  const pool = opts.organic ? organicOnly(tagged) : tagged;
+  const bandCounts = new Map<string, number>();
+  const scored: number[] = [];
+  let inherited = 0;
+  for (const t of pool) {
+    if (t.cxBand !== NA_LABEL) {
+      bandCounts.set(t.cxBand, (bandCounts.get(t.cxBand) ?? 0) + 1);
+    }
+    if (t.complexity !== null) scored.push(t.complexity);
+    if (t.topicsInherited) inherited += 1;
+  }
+  const bands = CX_BAND_ORDER.filter((b) => bandCounts.has(b)).map((b) => ({
+    label: b,
+    count: bandCounts.get(b) ?? 0,
+  }));
+  const mean = scored.length
+    ? scored.reduce((a, b) => a + b, 0) / scored.length
+    : null;
+  return { bands, mean, inheritedTopics: inherited };
+}
+
+export interface LanguageReconciliation {
+  /** Final reconciled language counts (organic), largest first. */
+  readonly finalCounts: AxisCount[];
+  /** Raw API/system language counts (organic), largest first. */
+  readonly systemCounts: AxisCount[];
+  /** Agreement breakdown across ALL traffic. */
+  readonly agreement: AxisCount[];
+  readonly backfilled: number;
+  readonly disagreements: number;
+}
+
+export function languageReconciliation(
+  tagged: readonly TaggedTrace[]
+): LanguageReconciliation {
+  const org = organicOnly(tagged);
+  const finalCounts = countBy(
+    org.filter((t) => t.langFinal && t.langFinal !== UND),
+    (t) => t.langFinal
+  );
+  const systemCounts = countBy(
+    org.filter((t) => t.langSystem),
+    (t) => t.langSystem
+  );
+  const agreement = countBy(tagged, (t) => t.langAgreement);
+  const backfilled = tagged.filter(
+    (t) => t.langAgreement === "detected_only"
+  ).length;
+  const disagreements = tagged.filter(
+    (t) => t.langAgreement === "disagree"
+  ).length;
+  return { finalCounts, systemCounts, agreement, backfilled, disagreements };
+}
+
+/**
+ * A snake_case / lower-case taxonomy code as a readable label, e.g.
+ * "follow_up_refine" -> "Follow up refine". Coarse topic labels (already
+ * Title Case) pass through unchanged.
+ */
+export function prettyLabel(label: string): string {
+  const s = label.replace(/_/g, " ");
+  return s.charAt(0).toUpperCase() + s.slice(1);
+}
+
+// --------------------------------------------------------------------------- #
+// Outcome mix by taxonomy dimension
+// --------------------------------------------------------------------------- #
+
+/** Taxonomy dimensions the outcome mix can be broken down by. */
+export type OutcomeMixDimension = "topic" | "intent" | "language" | "turn";
+
+export interface OutcomeMix {
+  /** Dimension value: a coarse topic, an intent, a language code, or a role. */
+  readonly label: string;
+  readonly total: number;
+  /** Outcome key (whatever `outcomeOf` returns) -> trace count. */
+  readonly counts: Readonly<Record<string, number>>;
+}
+
+export interface OutcomeMixOptions {
+  readonly topN?: number;
+  /**
+   * Resolves each turn's outcome key. Defaults to the raw server
+   * `row.outcome`; pass a refined-outcome accessor to break down by the
+   * refined taxonomy without coupling this module to it. Return null/undefined
+   * to skip the turn.
+   */
+  readonly outcomeOf?: (t: TaggedTrace) => string | null | undefined;
+}
+
+/**
+ * Outcome composition for each value of a taxonomy dimension, largest cohort
+ * first, capped at `topN`. Counts are keyed by whatever `outcomeOf` returns
+ * (raw server outcome code by default) so the caller owns label/colour mapping;
+ * the API outcome is never re-derived here.
+ *
+ * - topic: a turn counts under EACH of its coarse topics (topics are multi-tag).
+ * - intent: only substantive turns (not_applicable is skipped).
+ * - language: uses the reconciled `langFinal`; undetermined turns are skipped.
+ * - turn: the turn role / category (every role, including non-analytical ones).
+ *
+ * Turns with no resolved outcome are skipped in every mode.
+ */
+/**
+ * The dimension value(s) a turn belongs to, or null when it is outside the
+ * dimension's population (non-substantive for intent, undetermined language).
+ * Single source of truth for both the mix aggregation and the drill-down, so
+ * "view these traces" always matches what the chart counted.
+ */
+export function dimensionKeys(
+  t: TaggedTrace,
+  dimension: OutcomeMixDimension
+): string[] | null {
+  if (dimension === "topic") return t.topicCoarse.split("|").filter(Boolean);
+  if (dimension === "intent") {
+    return INTENT_LABEL_SET.has(t.intent) ? [t.intent] : null;
+  }
+  if (dimension === "turn") return [t.turnRole];
+  return t.langFinal && t.langFinal !== UND ? [t.langFinal] : null;
+}
+
+/** All tagged turns whose dimension value includes `value`. */
+export function tracesForDimensionValue(
+  tagged: readonly TaggedTrace[],
+  dimension: OutcomeMixDimension,
+  value: string
+): TaggedTrace[] {
+  return tagged.filter((t) =>
+    (dimensionKeys(t, dimension) ?? []).includes(value)
+  );
+}
+
+export function outcomeMixByDimension(
+  tagged: readonly TaggedTrace[],
+  dimension: OutcomeMixDimension,
+  opts: OutcomeMixOptions = {}
+): OutcomeMix[] {
+  const { topN = 8, outcomeOf } = opts;
+  const byKey = new Map<string, Map<string, number>>();
+  for (const t of tagged) {
+    const outcome = String(
+      (outcomeOf ? outcomeOf(t) : t.row.outcome) ?? ""
+    ).trim();
+    if (!outcome) continue;
+
+    const keys = dimensionKeys(t, dimension);
+    if (!keys) continue;
+
+    for (const key of keys) {
+      const counts = byKey.get(key) ?? new Map<string, number>();
+      counts.set(outcome, (counts.get(outcome) ?? 0) + 1);
+      byKey.set(key, counts);
+    }
+  }
+
+  return [...byKey.entries()]
+    .map(([label, counts]) => ({
+      label,
+      total: [...counts.values()].reduce((a, b) => a + b, 0),
+      counts: Object.fromEntries(counts),
+    }))
+    .sort((a, b) => b.total - a.total || a.label.localeCompare(b.label))
+    .slice(0, topN);
+}

--- a/src/features/trace-analytics/model/dataStores.ts
+++ b/src/features/trace-analytics/model/dataStores.ts
@@ -143,6 +143,12 @@ export const useSessionsStore = create<SessionsState>()((set) => ({
 
 interface ExplorerState extends FetchMeta {
   readonly entries: readonly TraceListEntry[];
+  /**
+   * When set, `entries` were handed over from an analytics aggregate (e.g.
+   * "Topic = Fire") rather than fetched with the explorer's own filters. The
+   * label describes that selection so the view can explain what is loaded.
+   */
+  readonly selectionLabel: string | null;
   readonly selectedId: string | null;
   readonly detailCache: Readonly<Record<string, TraceDetail>>;
   readonly detailStatus: FetchStatus;
@@ -152,6 +158,13 @@ interface ExplorerState extends FetchMeta {
   readonly succeed: (entries: readonly TraceListEntry[]) => void;
   readonly fail: (error: string) => void;
   readonly select: (traceId: string | null) => void;
+  /** Load a pre-computed trace list from an analytics drill-down. */
+  readonly loadSelection: (
+    entries: readonly TraceListEntry[],
+    label: string
+  ) => void;
+  /** Drop a drill-down selection and return the explorer to its idle state. */
+  readonly clearSelection: () => void;
   readonly startDetail: () => void;
   readonly cacheDetail: (detail: TraceDetail) => void;
   readonly failDetail: (error: string) => void;
@@ -160,11 +173,13 @@ interface ExplorerState extends FetchMeta {
 export const useExplorerStore = create<ExplorerState>()((set) => ({
   ...idleMeta,
   entries: [],
+  selectionLabel: null,
   selectedId: null,
   detailCache: {},
   detailStatus: "idle",
   detailError: null,
-  start: () => set({ status: "loading", error: null, progress: 0 }),
+  start: () =>
+    set({ status: "loading", error: null, progress: 0, selectionLabel: null }),
   setProgress: (progress) => set({ progress }),
   succeed: (entries) =>
     set({
@@ -173,9 +188,28 @@ export const useExplorerStore = create<ExplorerState>()((set) => ({
       error: null,
       fetchedAt: Date.now(),
       selectedId: entries.length ? entries[0].id : null,
+      // A manual fetch replaces any drill-down selection.
+      selectionLabel: null,
     }),
   fail: (error) => set({ status: "error", error }),
   select: (traceId) => set({ selectedId: traceId }),
+  loadSelection: (entries, label) =>
+    set({
+      status: "loaded",
+      entries,
+      error: null,
+      fetchedAt: Date.now(),
+      selectedId: entries.length ? entries[0].id : null,
+      selectionLabel: label,
+    }),
+  clearSelection: () =>
+    set({
+      status: "idle",
+      entries: [],
+      selectedId: null,
+      selectionLabel: null,
+      error: null,
+    }),
   startDetail: () => set({ detailStatus: "loading", detailError: null }),
   cacheDetail: (detail) =>
     set((state) => ({

--- a/src/features/trace-analytics/ui/AnalyticsView.tsx
+++ b/src/features/trace-analytics/ui/AnalyticsView.tsx
@@ -26,6 +26,7 @@ import { OutcomesSection } from "./analytics/OutcomesSection";
 import { ToolUsageSection } from "./analytics/ToolUsageSection";
 import { CostLatencySection } from "./analytics/CostLatencySection";
 import { PromptSection } from "./analytics/PromptSection";
+import { TaxonomySection } from "./analytics/TaxonomySection";
 import { StarterMixSection } from "./analytics/StarterMixSection";
 import { GnwUsageSection } from "./analytics/GnwUsageSection";
 import { JourneyFunnelSection } from "./analytics/JourneyFunnelSection";
@@ -389,6 +390,9 @@ export function AnalyticsView() {
           <Tabs.Content value="content">
             <Flex direction="column" gap={6}>
               <PromptSection rows={rows} />
+              {/* Taxonomy tags from the pre-merge rows so the language axis can
+                  compare the raw API value against independent detection. */}
+              <TaxonomySection rows={filteredRows} />
               <StarterMixSection rows={rows} />
               <GnwUsageSection rows={rows} />
             </Flex>

--- a/src/features/trace-analytics/ui/TracesView.tsx
+++ b/src/features/trace-analytics/ui/TracesView.tsx
@@ -249,6 +249,30 @@ export function TracesView() {
         />
       ) : null}
 
+      {store.selectionLabel ? (
+        <Flex
+          align="center"
+          gap={3}
+          wrap="wrap"
+          bg="bg.info"
+          borderWidth="1px"
+          borderColor="border.info"
+          borderRadius="sm"
+          px={3}
+          py={2}
+        >
+          <Text fontSize="sm">
+            Showing <b>{formatCount(store.entries.length)}</b> trace
+            {store.entries.length === 1 ? "" : "s"} from Analytics:{" "}
+            <b>{store.selectionLabel}</b>. Running a fetch above replaces this
+            selection.
+          </Text>
+          <Button size="xs" variant="outline" onClick={store.clearSelection}>
+            Clear selection
+          </Button>
+        </Flex>
+      ) : null}
+
       {store.status !== "loaded" ? (
         <InlineAlert
           status="info"

--- a/src/features/trace-analytics/ui/analytics/GnwUsageSection.tsx
+++ b/src/features/trace-analytics/ui/analytics/GnwUsageSection.tsx
@@ -14,6 +14,15 @@ import { DonutChart } from "../charts/DonutChart";
 import { HorizontalBarChart } from "../charts/HorizontalBarChart";
 import { OutcomeMixBars } from "../charts/OutcomeMixBars";
 import { InfoCallout } from "../primitives/InfoCallout";
+import { useOpenTracesInExplorer } from "../useOpenTracesInExplorer";
+
+/** Does the trace's thread-cumulative dataset CSV include this dataset? */
+function usedDataset(row: TraceRow, dataset: string): boolean {
+  return row.datasetsAnalysed
+    .split(",")
+    .map((part) => part.trim())
+    .includes(dataset);
+}
 
 interface GnwUsageSectionProps {
   readonly rows: readonly TraceRow[];
@@ -42,6 +51,7 @@ function coverageData(
 }
 
 export function GnwUsageSection({ rows }: GnwUsageSectionProps) {
+  const openTraces = useOpenTracesInExplorer();
   const datasetCounts = useMemo(
     () =>
       countCategories(
@@ -98,29 +108,46 @@ export function GnwUsageSection({ rows }: GnwUsageSectionProps) {
           {datasetCounts.length ? (
             <ChartCard
               title="Datasets analysed"
-              help="Datasets referenced in analyses (one trace can reference several)."
+              help="Datasets referenced in analyses (one trace can reference several). Click a bar to open those traces."
               info="Counts come from trace context, so bars don't sum to the trace
                 total and shares of a whole aren't meaningful — compare bar lengths
                 instead. Use this to see which data products actually drive agent
-                usage, and which are never touched."
+                usage, and which are never touched. Click any bar to inspect its
+                traces in the Trace Explorer."
             >
               <HorizontalBarChart
                 data={datasetCounts.map((d) => ({
                   label: d.label,
                   count: d.count,
                 }))}
+                onBarClick={(datum) =>
+                  openTraces(
+                    `Dataset = ${datum.label}`,
+                    rows.filter((r) => usedDataset(r, datum.label))
+                  )
+                }
               />
             </ChartCard>
           ) : null}
           {aoiTypeCounts.length ? (
             <ChartCard
               title="AOI type"
-              help="What kinds of areas users analyse (country, region, drawn polygon…)."
+              help="What kinds of areas users analyse (country, region, drawn polygon…). Click a slice to open those traces."
               info="A high share of drawn polygons suggests users care about custom
                 places the catalog doesn't cover; a high share of countries suggests
-                broad exploratory use."
+                broad exploratory use. Click a slice to inspect its traces in the
+                Trace Explorer."
             >
-              <DonutChart data={aoiTypeCounts} centerLabel="analyses" />
+              <DonutChart
+                data={aoiTypeCounts}
+                centerLabel="analyses"
+                onSliceClick={(label) =>
+                  openTraces(
+                    `AOI type = ${label}`,
+                    rows.filter((r) => r.aoiType.trim() === label)
+                  )
+                }
+              />
             </ChartCard>
           ) : null}
         </SimpleGrid>
@@ -128,33 +155,47 @@ export function GnwUsageSection({ rows }: GnwUsageSectionProps) {
           {insight.known ? (
             <ChartCard
               title="Insight coverage"
-              help="Share of traces that produced a saved insight."
+              help="Share of traces that produced a saved insight. Click a slice to open those traces."
               info="Insights are the agent's packaged takeaway (chart + narrative).
                 A low share isn't automatically bad — clarifications and follow-ups
                 don't produce insights — but a falling trend after a release is a
-                regression signal."
+                regression signal. Click a slice to inspect its traces in the Trace
+                Explorer."
             >
               <DonutChart
                 data={insight.data}
                 colors={insight.colors}
                 height={200}
                 centerLabel="traces"
+                onSliceClick={(label) =>
+                  openTraces(
+                    label,
+                    rows.filter((r) => r.hasInsight === (label === "Insight"))
+                  )
+                }
               />
             </ChartCard>
           ) : null}
           {globalScope.known ? (
             <ChartCard
               title="Global vs specific area"
-              help="Whether analyses ran globally or on a selected area."
+              help="Whether analyses ran globally or on a selected area. Click a slice to open those traces."
               info="Global queries (“all countries”) are heavier and often
                 exploratory; specific areas signal a user with a concrete place in
-                mind. A rising global share can also flag misfired AOI selection."
+                mind. A rising global share can also flag misfired AOI selection.
+                Click a slice to inspect its traces in the Trace Explorer."
             >
               <DonutChart
                 data={globalScope.data}
                 colors={globalScope.colors}
                 height={200}
                 centerLabel="traces"
+                onSliceClick={(label) =>
+                  openTraces(
+                    label,
+                    rows.filter((r) => r.isGlobal === (label === "Global"))
+                  )
+                }
               />
             </ChartCard>
           ) : null}
@@ -162,23 +203,38 @@ export function GnwUsageSection({ rows }: GnwUsageSectionProps) {
         {datasetOutcomes.length ? (
           <ChartCard
             title="Outcome mix by dataset"
-            help="How turns that touched each dataset ended, best → worst."
+            help="How turns that touched each dataset ended, best → worst. Click a segment to open its traces."
             info="Rows are the most-used datasets; segments read left to right from
               Success to Empty. A dataset whose warm share is well above its peers
-              usually has a broken handler or confusing schema — open its failing
-              traces in the Trace Explorer. Small totals swing wildly; check the
-              trace count in the tooltip before reacting."
+              usually has a broken handler or confusing schema — click the warm
+              segment to open exactly those failing traces in the Trace Explorer.
+              Small totals swing wildly; check the trace count in the tooltip
+              before reacting."
           >
-            <OutcomeMixBars data={datasetOutcomes} />
+            <OutcomeMixBars
+              data={datasetOutcomes}
+              onSegmentClick={(dataset, outcome) =>
+                openTraces(
+                  `Dataset = ${dataset} · outcome ${outcome}`,
+                  rows.filter(
+                    (r) =>
+                      usedDataset(r, dataset) &&
+                      (OUTCOME_LABELS[String(r.outcome)] ??
+                        String(r.outcome)) === outcome
+                  )
+                )
+              }
+            />
           </ChartCard>
         ) : null}
         {aoiNames.length ? (
           <ChartCard
             title="AOI selection counts"
-            help="Most commonly analysed places, colored by dominant AOI type."
+            help="Most commonly analysed places, colored by dominant AOI type. Click a bar to open those traces."
             info="Bars share one count axis; color only says what kind of area the
               place is. Repeated appearances of one place often trace back to a
-              single user's project — click through Top Users to confirm."
+              single user's project — click the bar to open its traces, or click
+              through Top Users to confirm."
           >
             <HorizontalBarChart
               data={aoiNames.map((a) => ({
@@ -186,6 +242,12 @@ export function GnwUsageSection({ rows }: GnwUsageSectionProps) {
                 count: a.count,
                 category: a.aoiType,
               }))}
+              onBarClick={(datum) =>
+                openTraces(
+                  `AOI = ${datum.label}`,
+                  rows.filter((r) => r.aoiName.trim() === datum.label)
+                )
+              }
             />
           </ChartCard>
         ) : null}

--- a/src/features/trace-analytics/ui/analytics/JourneyFunnelSection.tsx
+++ b/src/features/trace-analytics/ui/analytics/JourneyFunnelSection.tsx
@@ -7,11 +7,16 @@
  */
 
 import { useMemo } from "react";
-import { Box, Flex, Text } from "@chakra-ui/react";
+import { Box, Flex, Link as ChakraLink, Text } from "@chakra-ui/react";
 import { ChartCard } from "../charts/ChartCard";
-import { computeJourneyFunnel } from "../../lib/analytics/funnel";
+import {
+  computeJourneyFunnel,
+  sessionKey,
+  type FunnelStageKey,
+} from "../../lib/analytics/funnel";
 import { formatCount, formatPercent } from "../../lib/format";
 import type { TraceRow } from "../../model/types";
+import { useOpenTracesInExplorer } from "../useOpenTracesInExplorer";
 
 interface JourneyFunnelSectionProps {
   readonly rows: readonly TraceRow[];
@@ -19,6 +24,18 @@ interface JourneyFunnelSectionProps {
 
 export function JourneyFunnelSection({ rows }: JourneyFunnelSectionProps) {
   const funnel = useMemo(() => computeJourneyFunnel(rows), [rows]);
+  const openTraces = useOpenTracesInExplorer();
+
+  /** All traces of the sessions that stalled before `stage`. */
+  function openDropped(stage: Exclude<FunnelStageKey, "sessions">) {
+    const dropped = new Set(funnel.droppedBefore[stage]);
+    const stageLabel =
+      funnel.stages.find((s) => s.key === stage)?.label ?? stage;
+    openTraces(
+      `Conversations dropped before "${stageLabel}"`,
+      rows.filter((r) => dropped.has(sessionKey(r)))
+    );
+  }
 
   return (
     <ChartCard
@@ -31,7 +48,9 @@ export function JourneyFunnelSection({ rows }: JourneyFunnelSectionProps) {
           satisfy a stage). Big drops mark where users stall — a low
           area-selection rate points at AOI understanding, a low
           dataset-conversion at data discovery, a low insight-conversion at
-          analysis completion.
+          analysis completion. Use the &ldquo;view dropped&rdquo; links to open
+          the traces of the conversations that stalled before a stage in the
+          Trace Explorer.
           {!funnel.insightKnown ? (
             <>
               {" "}
@@ -45,24 +64,45 @@ export function JourneyFunnelSection({ rows }: JourneyFunnelSectionProps) {
       <Flex direction="column" gap={3} py={2}>
         {funnel.stages.map((stage, i) => {
           const unavailable = stage.key === "insight" && !funnel.insightKnown;
+          const droppedCount =
+            stage.key === "sessions" || unavailable
+              ? 0
+              : funnel.droppedBefore[stage.key].length;
           return (
             <Box key={stage.key}>
-              <Flex justify="space-between" fontSize="xs" mb={1}>
+              <Flex justify="space-between" fontSize="xs" mb={1} gap={2}>
                 <Text color="fg.muted" fontWeight="medium">
                   {stage.label}
                 </Text>
-                <Text
-                  color="fg.subtle"
+                <Flex
+                  gap={1}
+                  align="baseline"
                   style={{ fontVariantNumeric: "tabular-nums" }}
                 >
-                  {unavailable
-                    ? "not reported"
-                    : `${formatCount(stage.count)} · ${formatPercent(stage.shareOfTotal)} of conversations${
-                        i > 0
-                          ? ` · ${formatPercent(stage.conversionFromPrev)} from previous`
-                          : ""
-                      }`}
-                </Text>
+                  <Text color="fg.subtle">
+                    {unavailable
+                      ? "not reported"
+                      : `${formatCount(stage.count)} · ${formatPercent(stage.shareOfTotal)} of conversations${
+                          i > 0
+                            ? ` · ${formatPercent(stage.conversionFromPrev)} from previous`
+                            : ""
+                        }`}
+                  </Text>
+                  {droppedCount > 0 ? (
+                    <ChakraLink
+                      color="fg.link"
+                      fontSize="xs"
+                      onClick={() =>
+                        openDropped(
+                          stage.key as Exclude<FunnelStageKey, "sessions">
+                        )
+                      }
+                      title="Open the traces of the conversations that stalled before this stage"
+                    >
+                      · view {formatCount(droppedCount)} dropped
+                    </ChakraLink>
+                  ) : null}
+                </Flex>
               </Flex>
               <Box bg="bg.subtle" borderRadius="sm" h="18px" overflow="hidden">
                 <Box

--- a/src/features/trace-analytics/ui/analytics/OutcomesSection.tsx
+++ b/src/features/trace-analytics/ui/analytics/OutcomesSection.tsx
@@ -13,21 +13,42 @@ import {
 } from "@chakra-ui/react";
 import type { TraceRow } from "../../model/types";
 import type { DailyMetrics } from "../../lib/analytics/daily";
-import { computeErrorOverlap } from "../../lib/analytics/aggregations";
+import { computeDailyOutcomeMix } from "../../lib/analytics/daily";
+import {
+  computeErrorOverlap,
+  USER_VISIBLE_OUTCOMES,
+} from "../../lib/analytics/aggregations";
 import {
   computeFailureFollowUps,
   computeOutcomeFlow,
   refineOutcomes,
+  REFINED_LABELS,
   type FlowMode,
   type OutcomeOverrides,
   type RefinedOutcome,
 } from "../../lib/analytics/outcomeRefine";
-import { computeOutcomeMixByLanguage } from "../../lib/analytics/language";
+import {
+  outcomeMixByDimension,
+  prettyLabel,
+  tagTraces,
+  tracesForDimensionValue,
+  type OutcomeMixDimension,
+  type TaggedTrace,
+} from "../../lib/analytics/taxonomy";
+import { useOpenTracesInExplorer } from "../useOpenTracesInExplorer";
 import { looksLikeRefusal } from "../../lib/analytics/refusalNeedles";
 import { fetchTraceDetail } from "../../api/zeno";
 import { AUDIT_MAX_TRACES } from "../../model/config";
 import { formatCount, formatPercent, languageName } from "../../lib/format";
-import { OUTCOME_LABELS } from "../charts/palette";
+import {
+  OUTCOME_COLORS,
+  OUTCOME_LABELS,
+  OUTCOME_SEVERITY_ORDER,
+  OUTCOME_STACK_ORDER,
+  REFINED_OUTCOME_COLORS,
+  REFINED_SEVERITY_ORDER,
+  REFINED_STACK_ORDER,
+} from "../charts/palette";
 import { ChartCard } from "../charts/ChartCard";
 import { DonutChart } from "../charts/DonutChart";
 import { DailyOutcomeAreaChart } from "../charts/DailyOutcomeAreaChart";
@@ -70,6 +91,14 @@ const OVERLAP_COLORS = {
 const ANSWER_KEYS = new Set(["ANSWER", "ANSWER_CLEAN", "ANSWER_DEGRADED"]);
 const AUDIT_CONCURRENCY = 4;
 
+/** Display labels for the "Outcome mix by …" dimension selector. */
+const MIX_DIM_LABEL: Readonly<Record<OutcomeMixDimension, string>> = {
+  topic: "Topic",
+  intent: "Intent",
+  language: "Language",
+  turn: "Turn",
+};
+
 interface AuditState {
   readonly status: "idle" | "running" | "done";
   readonly done: number;
@@ -98,6 +127,7 @@ export function OutcomesSection({
   daily,
 }: OutcomesSectionProps) {
   const [mode, setMode] = useState<FlowMode>("refined");
+  const [mixDim, setMixDim] = useState<OutcomeMixDimension>("topic");
   const [overrides, setOverrides] = useState<OutcomeOverrides>(new Map());
   const [audit, setAudit] = useState<AuditState>(AUDIT_IDLE);
   const cancelled = useRef(false);
@@ -120,19 +150,130 @@ export function OutcomesSection({
   );
   const overlap = useMemo(() => computeErrorOverlap(rows), [rows]);
   const followUps = useMemo(() => computeFailureFollowUps(rows), [rows]);
-  const languageMix = useMemo(
+  // Tag once for the dimension-agnostic outcome mix (topic / intent / language
+  // / turn). The `mode` toggle (shared with the Sankey) swaps the outcome
+  // definition used by the mix and the daily chart between the raw API labels
+  // and the locally refined ones; the audit overrides flow through both.
+  const tagged = useMemo(() => tagTraces(rows), [rows]);
+  const refinedByTrace = useMemo(
     () =>
-      computeOutcomeMixByLanguage(rows).map((mix) => ({
-        label: languageName(mix.label),
-        total: mix.total,
-        counts: Object.fromEntries(
-          Object.entries(mix.counts).map(([outcome, count]) => [
-            OUTCOME_LABELS[outcome] ?? outcome,
-            count,
-          ])
-        ),
-      })),
-    [rows]
+      new Map(
+        refineOutcomes(rows, overrides).map((r) => [r.row.traceId, r.refined])
+      ),
+    [rows, overrides]
+  );
+  const refined = mode === "refined";
+
+  const outcomeMix = useMemo(() => {
+    const labelMap: Readonly<Record<string, string>> = refined
+      ? REFINED_LABELS
+      : OUTCOME_LABELS;
+    const outcomeOf = refined
+      ? (t: { row: TraceRow }) => refinedByTrace.get(t.row.traceId)
+      : undefined;
+    // Charts show prettified labels; keep the raw dimension value so a
+    // clicked segment can be mapped back to its traces.
+    const rawByPretty = new Map<string, string>();
+    const data = outcomeMixByDimension(tagged, mixDim, { outcomeOf }).map(
+      (mix) => {
+        const pretty =
+          mixDim === "language"
+            ? languageName(mix.label)
+            : mixDim === "topic"
+              ? mix.label
+              : prettyLabel(mix.label);
+        rawByPretty.set(pretty, mix.label);
+        return {
+          label: pretty,
+          total: mix.total,
+          counts: Object.fromEntries(
+            Object.entries(mix.counts).map(([code, count]) => [
+              labelMap[code] ?? code,
+              count,
+            ])
+          ),
+        };
+      }
+    );
+    return { data, rawByPretty };
+  }, [tagged, mixDim, refined, refinedByTrace]);
+  const mixOrder = refined ? REFINED_SEVERITY_ORDER : OUTCOME_SEVERITY_ORDER;
+  const mixColors = refined ? REFINED_OUTCOME_COLORS : OUTCOME_COLORS;
+
+  const openTraces = useOpenTracesInExplorer();
+
+  /** Display label of a turn's outcome under the current API/Refined mode. */
+  function outcomeLabelOf(t: TaggedTrace): string | null {
+    if (refined) {
+      const code = refinedByTrace.get(t.row.traceId);
+      return code ? REFINED_LABELS[code] : null;
+    }
+    return t.row.outcome
+      ? (OUTCOME_LABELS[t.row.outcome] ?? t.row.outcome)
+      : null;
+  }
+
+  /** One cohort × outcome cell of the mix chart → its traces. */
+  function handleMixSegmentClick(rowLabel: string, outcome: string) {
+    const raw = outcomeMix.rawByPretty.get(rowLabel);
+    if (!raw) return;
+    const picked = tracesForDimensionValue(tagged, mixDim, raw).filter(
+      (t) => outcomeLabelOf(t) === outcome
+    );
+    openTraces(
+      `${MIX_DIM_LABEL[mixDim]} = ${rowLabel} · outcome ${outcome} (${
+        refined ? "refined" : "API"
+      })`,
+      picked.map((t) => t.row)
+    );
+  }
+
+  function handleDayClick(date: string) {
+    openTraces(
+      `All traces on ${date}`,
+      rows.filter((r) => r.date === date)
+    );
+  }
+
+  /** Slice predicates matching computeErrorOverlap's four categories. */
+  const overlapPredicates: Readonly<Record<string, (r: TraceRow) => boolean>> =
+    {
+      "No errors": (r) =>
+        !r.hasInternalError && !USER_VISIBLE_OUTCOMES.has(String(r.outcome)),
+      "Internal only": (r) =>
+        r.hasInternalError && !USER_VISIBLE_OUTCOMES.has(String(r.outcome)),
+      "User-visible only": (r) =>
+        !r.hasInternalError && USER_VISIBLE_OUTCOMES.has(String(r.outcome)),
+      Both: (r) =>
+        r.hasInternalError && USER_VISIBLE_OUTCOMES.has(String(r.outcome)),
+    };
+
+  const dailyMix = useMemo(() => {
+    const labelOf = refined
+      ? (row: TraceRow) => {
+          const code = refinedByTrace.get(row.traceId);
+          return code ? REFINED_LABELS[code] : null;
+        }
+      : (row: TraceRow) =>
+          row.outcome ? (OUTCOME_LABELS[row.outcome] ?? row.outcome) : null;
+    return computeDailyOutcomeMix(rows, labelOf);
+  }, [rows, refined, refinedByTrace]);
+  const dailyOrder = refined ? REFINED_STACK_ORDER : OUTCOME_STACK_ORDER;
+  const dailyColors = refined ? REFINED_OUTCOME_COLORS : OUTCOME_COLORS;
+
+  const modeToggle = (
+    <Flex gap={1}>
+      {(["api", "refined"] as const).map((m) => (
+        <Button
+          key={m}
+          size="xs"
+          variant={mode === m ? "solid" : "outline"}
+          onClick={() => setMode(m)}
+        >
+          {m === "api" ? "API" : "Refined"}
+        </Button>
+      ))}
+    </Flex>
   );
   // Audit candidates come from the un-overridden refinement so the count
   // stays stable after reclassification.
@@ -238,17 +379,8 @@ export function OutcomesSection({
             points. Toggle API to see the raw server labels; Refined re-groups
             them with the local corrections."
         >
-          <Flex justify="flex-end" gap={1} mb={1}>
-            {(["api", "refined"] as const).map((m) => (
-              <Button
-                key={m}
-                size="xs"
-                variant={mode === m ? "solid" : "outline"}
-                onClick={() => setMode(m)}
-              >
-                {m === "api" ? "API" : "Refined"}
-              </Button>
-            ))}
+          <Flex justify="flex-end" mb={1}>
+            {modeToggle}
           </Flex>
           <OutcomeSankey flow={flow} />
           {auditCandidates.length ? (
@@ -297,36 +429,86 @@ export function OutcomesSection({
           {daily.length ? (
             <ChartCard
               title="Daily outcomes"
-              help="Share of each day's traces by outcome (API labels)."
+              help={`Share of each day's traces by outcome (${
+                refined ? "refined" : "API"
+              } labels).`}
               info="Each day stacks to 100%, so a shrinking green band is a rising
                 failure rate even if absolute volume grew. Isolated bad days point at
-                incidents; a persistent warm band points at a systemic issue."
+                incidents; a persistent warm band points at a systemic issue. Toggle
+                API/Refined to switch between the raw server outcome and the locally
+                re-derived one. Click a day to open all of its traces in the Trace
+                Explorer."
             >
-              <DailyOutcomeAreaChart data={daily} />
+              <Flex justify="flex-end" mb={1}>
+                {modeToggle}
+              </Flex>
+              <DailyOutcomeAreaChart
+                data={dailyMix}
+                order={dailyOrder}
+                colors={dailyColors}
+                onDayClick={handleDayClick}
+              />
             </ChartCard>
           ) : null}
-          {languageMix.length >= 2 ? (
-            <ChartCard
-              title="Outcome mix by language"
-              help="How turns end, split by detected prompt language."
-              info="Soft errors are detected with English-only phrases, so
-                non-English failure rates are understated by construction — treat a
-                clean-looking non-English row with suspicion and use the refusal
-                audit above. Small totals swing wildly; check the trace count in the
-                tooltip."
+          <ChartCard
+            title={`Outcome mix by ${MIX_DIM_LABEL[mixDim].toLowerCase()}`}
+            help="How turns end, split by the selected taxonomy dimension. Click a segment to open its traces."
+            info="Bars are 100% stacked best→worst, so a shrinking green segment
+              means a higher failure rate for that cohort. Topics are multi-tag,
+              so a turn counts under each of its topics; intent covers
+              substantive turns only; turn splits by the turn's role. For
+              language, soft-error detection is English-only, so non-English
+              failure is understated — use the refusal audit above. Small cohorts
+              swing wildly; check the trace count in the tooltip. Toggle
+              API/Refined to switch the outcome definition; both the dimensions
+              and the refined outcomes are derived locally and never modify the
+              trace. Click any segment to open exactly those traces (cohort ×
+              outcome) in the Trace Explorer."
+          >
+            <Flex
+              justify="space-between"
+              align="center"
+              gap={2}
+              mb={1}
+              wrap="wrap"
             >
-              <OutcomeMixBars data={languageMix} />
-            </ChartCard>
-          ) : null}
+              <Flex gap={1} wrap="wrap">
+                {(["topic", "intent", "language", "turn"] as const).map((d) => (
+                  <Button
+                    key={d}
+                    size="xs"
+                    variant={mixDim === d ? "solid" : "outline"}
+                    onClick={() => setMixDim(d)}
+                  >
+                    {MIX_DIM_LABEL[d]}
+                  </Button>
+                ))}
+              </Flex>
+              {modeToggle}
+            </Flex>
+            {outcomeMix.data.length ? (
+              <OutcomeMixBars
+                data={outcomeMix.data}
+                order={mixOrder}
+                colors={mixColors}
+                onSegmentClick={handleMixSegmentClick}
+              />
+            ) : (
+              <Text fontSize="sm" color="fg.muted">
+                No {MIX_DIM_LABEL[mixDim].toLowerCase()} data in this window.
+              </Text>
+            )}
+          </ChartCard>
         </SimpleGrid>
 
         <SimpleGrid columns={{ base: 1, lg: 2 }} gap={4}>
           <ChartCard
             title="Internal errors"
-            help="Traces where any tool or API call failed internally."
+            help="Traces where any tool or API call failed internally. Click a slice to open those traces."
             info="Internal errors are failures inside the agent's tool calls — the
               user may never see them if the agent recovers. This is the raw rate
-              before recovery."
+              before recovery. Click a slice to inspect its traces in the Trace
+              Explorer."
           >
             <DonutChart
               data={[
@@ -341,16 +523,25 @@ export function OutcomesSection({
                 "Internal error": OVERLAP_COLORS.userVisibleOnly,
               }}
               centerLabel="traces"
+              onSliceClick={(label) =>
+                openTraces(
+                  label,
+                  rows.filter(
+                    (r) => (label === "Internal error") === r.hasInternalError
+                  )
+                )
+              }
             />
           </ChartCard>
           <ChartCard
             title="Internal vs user-visible overlap"
-            help="How internal failures relate to what users actually saw."
+            help="How internal failures relate to what users actually saw. Click a slice to open those traces."
             info="Internal only (amber) = the agent hit a tool error but recovered —
               invisible to the user, still worth fixing. User-visible only (red) =
               the user saw a failure with no internal error logged, usually a
               generation problem. Both (dark red) = a tool error surfaced all the
-              way to the user."
+              way to the user. Click a slice to inspect its traces in the Trace
+              Explorer."
           >
             <DonutChart
               data={[
@@ -366,6 +557,12 @@ export function OutcomesSection({
                 Both: OVERLAP_COLORS.both,
               }}
               centerLabel="traces"
+              onSliceClick={(label) => {
+                const predicate = overlapPredicates[label];
+                if (predicate) {
+                  openTraces(`Error overlap: ${label}`, rows.filter(predicate));
+                }
+              }}
             />
           </ChartCard>
         </SimpleGrid>

--- a/src/features/trace-analytics/ui/analytics/OverviewTab.tsx
+++ b/src/features/trace-analytics/ui/analytics/OverviewTab.tsx
@@ -6,6 +6,7 @@ import { useMemo } from "react";
 import { Flex, SimpleGrid, Text } from "@chakra-ui/react";
 import type { TraceRow } from "../../model/types";
 import type { DailyMetrics } from "../../lib/analytics/daily";
+import { computeDailyOutcomeMix } from "../../lib/analytics/daily";
 import type {
   SummaryStats,
   PromptUtilisation,
@@ -23,7 +24,12 @@ import { ChartCard } from "../charts/ChartCard";
 import { DailyLinesChart } from "../charts/DailyLinesChart";
 import { DailyOutcomeAreaChart } from "../charts/DailyOutcomeAreaChart";
 import { SummarySection } from "./SummarySection";
-import { CATEGORY_COLORS, CHART_CHROME } from "../charts/palette";
+import { useOpenTracesInExplorer } from "../useOpenTracesInExplorer";
+import {
+  CATEGORY_COLORS,
+  CHART_CHROME,
+  OUTCOME_LABELS,
+} from "../charts/palette";
 
 interface OverviewTabProps {
   readonly rows: readonly TraceRow[];
@@ -64,11 +70,21 @@ export function OverviewTab({
   const showMa = daily.length >= 10;
   const spark = (key: keyof DailyMetrics) =>
     daily.length >= 2 ? daily.map((d) => Number(d[key])) : undefined;
+  // Daily outcome composition (API labels) for the stacked-area chart.
+  const dailyOutcomeMix = useMemo(
+    () =>
+      computeDailyOutcomeMix(rows, (r) =>
+        r.outcome ? (OUTCOME_LABELS[r.outcome] ?? r.outcome) : null
+      ),
+    [rows]
+  );
+  const openTraces = useOpenTracesInExplorer();
 
   const kpis = [
     {
       label: "Prompts (traces)",
       value: formatCount(stats.totalTraces),
+      hint: "One trace = one user turn",
       delta: prevStats
         ? relativeDelta(stats.totalTraces, prevStats.totalTraces, {
             upIsGood: true,
@@ -79,6 +95,7 @@ export function OverviewTab({
     {
       label: "Active users",
       value: formatCount(stats.uniqueUsers),
+      hint: "Sent ≥1 prompt in the window",
       delta: prevStats
         ? relativeDelta(stats.uniqueUsers, prevStats.uniqueUsers, {
             upIsGood: true,
@@ -89,6 +106,7 @@ export function OverviewTab({
     {
       label: "Conversations",
       value: formatCount(stats.uniqueThreads),
+      hint: "Distinct threads touched",
       delta: prevStats
         ? relativeDelta(stats.uniqueThreads, prevStats.uniqueThreads, {
             upIsGood: true,
@@ -99,6 +117,7 @@ export function OverviewTab({
     {
       label: "Success rate",
       value: formatPercent(stats.successRate),
+      hint: "Turns answered with ≥1 tool call",
       delta: prevStats
         ? percentagePointDelta(stats.successRate, prevStats.successRate, {
             upIsGood: true,
@@ -111,6 +130,7 @@ export function OverviewTab({
           {
             label: "New users",
             value: formatCount(segments.newUsers.size),
+            hint: "First-ever activity in the window",
             delta: prevSegments
               ? relativeDelta(
                   segments.newUsers.size,
@@ -124,6 +144,7 @@ export function OverviewTab({
           {
             label: "Engaged users",
             value: formatCount(segments.engagedUsers.size),
+            hint: "≥2 sessions with ≥2 prompts each",
             delta: prevSegments
               ? relativeDelta(
                   segments.engagedUsers.size,
@@ -139,6 +160,7 @@ export function OverviewTab({
     {
       label: "Prompts / user / day",
       value: utilisation.meanPrompts.toFixed(2),
+      hint: "Mean per active user-day",
       delta: prevUtilisation
         ? relativeDelta(utilisation.meanPrompts, prevUtilisation.meanPrompts, {
             upIsGood: true,
@@ -148,6 +170,7 @@ export function OverviewTab({
     {
       label: "p95 latency",
       value: `${stats.p95Latency.toFixed(1)}s`,
+      hint: "95% of turns respond faster",
       delta: prevStats
         ? relativeDelta(stats.p95Latency, prevStats.p95Latency, {
             upIsGood: false,
@@ -158,6 +181,7 @@ export function OverviewTab({
     {
       label: "LLM cost",
       value: `$${stats.totalCost.toFixed(2)}`,
+      hint: "Total Langfuse-reported spend",
       delta: prevStats
         ? relativeDelta(stats.totalCost, prevStats.totalCost, {
             upIsGood: false,
@@ -231,7 +255,7 @@ export function OverviewTab({
         {daily.length ? (
           <ChartCard
             title="Daily outcomes"
-            help="Share of each day's traces by outcome."
+            help="Share of each day's traces by outcome. Click a day to open its traces."
             info={
               <>
                 Every trace gets exactly one outcome, so each day stacks to
@@ -239,12 +263,20 @@ export function OverviewTab({
                 bottom are failures — amber = apologetic answer, red =
                 user-visible error, dark red = no answer at all. Gray (Defer) is
                 a clarification request, not a failure. A widening warm band on
-                a specific day usually points at an incident — drill into it
-                from the Quality tab.
+                a specific day usually points at an incident — click the day to
+                open its traces, or drill in from the Quality tab.
               </>
             }
           >
-            <DailyOutcomeAreaChart data={daily} />
+            <DailyOutcomeAreaChart
+              data={dailyOutcomeMix}
+              onDayClick={(date) =>
+                openTraces(
+                  `All traces on ${date}`,
+                  rows.filter((r) => r.date === date)
+                )
+              }
+            />
           </ChartCard>
         ) : null}
       </SimpleGrid>

--- a/src/features/trace-analytics/ui/analytics/PromptSection.tsx
+++ b/src/features/trace-analytics/ui/analytics/PromptSection.tsx
@@ -14,6 +14,7 @@ import { HistogramChart } from "../charts/HistogramChart";
 import { HorizontalBarChart } from "../charts/HorizontalBarChart";
 import { InfoCallout } from "../primitives/InfoCallout";
 import { StatCards } from "../primitives/StatCards";
+import { useOpenTracesInExplorer } from "../useOpenTracesInExplorer";
 
 interface PromptSectionProps {
   readonly rows: readonly TraceRow[];
@@ -34,15 +35,19 @@ function lengthStats(values: readonly number[]) {
 }
 
 export function PromptSection({ rows }: PromptSectionProps) {
+  const openTraces = useOpenTracesInExplorer();
   const lengths = useMemo(() => computePromptLengths(rows), [rows]);
   const charBins = useMemo(() => binValues(lengths.chars, 60), [lengths]);
   const wordBins = useMemo(() => binValues(lengths.words, 60), [lengths]);
+  // Keep the ISO code alongside the display name so a clicked bar can be
+  // mapped back to its rows.
   const languageCounts = useMemo(
     () =>
       countCategories(
         rows.map((r) => r.language),
         { topN: 12 }
       ).map((entry) => ({
+        code: entry.label,
         label: languageName(entry.label),
         count: entry.count,
       })),
@@ -56,9 +61,14 @@ export function PromptSection({ rows }: PromptSectionProps) {
       </Heading>
       <Flex direction="column" gap={3}>
         <InfoCallout title="Prompt analysis explained">
-          Prompt-level metrics help understand what users are asking and how.
-          Length distributions reveal typical query complexity and outliers that
-          may inflate cost or latency.
+          Length is measured on the raw prompt text: characters include spaces
+          and punctuation, words are whitespace-separated tokens. Empty prompts
+          (UI events, dropped requests) are excluded from both. Very long
+          prompts often mean pasted content or templated text and can inflate
+          cost and latency; a pile-up of one-word prompts usually marks
+          confirmations and selections rather than real questions. For the
+          deeper what-are-users-asking view (intent, topic, complexity), see the
+          Prompt Taxonomy section below.
         </InfoCallout>
         <SimpleGrid columns={{ base: 1, lg: 2 }} gap={4}>
           <ChartCard
@@ -103,18 +113,30 @@ export function PromptSection({ rows }: PromptSectionProps) {
         {languageCounts.length ? (
           <ChartCard
             title="Prompt language"
-            help="Detected language of user prompts (server-side langid, local fallback)."
+            help="Detected language of user prompts (server-side langid, local fallback). Click a bar to open those traces."
             info="Language detection is heuristic and skips very short prompts, so
               counts undershoot the trace total. A meaningful non-English share
               matters twice over: the UI is English-only, and the soft-error
               detection heuristics only match English phrases — non-English
-              failures are systematically undercounted in the outcome data."
+              failures are systematically undercounted in the outcome data.
+              Click any bar to inspect its traces in the Trace Explorer."
           >
             <HorizontalBarChart
               data={languageCounts.map((l) => ({
                 label: l.label,
                 count: l.count,
               }))}
+              onBarClick={(datum) => {
+                const code = languageCounts.find(
+                  (l) => l.label === datum.label
+                )?.code;
+                if (code) {
+                  openTraces(
+                    `Language = ${datum.label}`,
+                    rows.filter((r) => r.language === code)
+                  );
+                }
+              }}
             />
           </ChartCard>
         ) : null}

--- a/src/features/trace-analytics/ui/analytics/StarterMixSection.tsx
+++ b/src/features/trace-analytics/ui/analytics/StarterMixSection.tsx
@@ -8,17 +8,37 @@ import {
   STARTER_PROMPTS,
   STARTER_PROMPT_LABELS,
 } from "../../lib/analytics/report";
+import { normalizePrompt } from "../../lib/format";
 import { SEGMENT_COLORS } from "../charts/palette";
 import { ChartCard } from "../charts/ChartCard";
 import { DonutChart } from "../charts/DonutChart";
 import { HorizontalBarChart } from "../charts/HorizontalBarChart";
+import { useOpenTracesInExplorer } from "../useOpenTracesInExplorer";
 
 interface StarterMixSectionProps {
   readonly rows: readonly TraceRow[];
 }
 
+// Same normalization the mix computation uses, so clicks select exactly the
+// rows that were counted.
+const STARTER_SET = new Set(STARTER_PROMPTS.map(normalizePrompt));
+const NORMALIZED_BY_LABEL = new Map<string, string[]>();
+for (const [prompt, label] of Object.entries(STARTER_PROMPT_LABELS)) {
+  const normalized = normalizePrompt(prompt);
+  NORMALIZED_BY_LABEL.set(label, [
+    ...(NORMALIZED_BY_LABEL.get(label) ?? []),
+    normalized,
+  ]);
+}
+
+function isStarter(row: TraceRow): boolean {
+  const normalized = normalizePrompt(row.prompt);
+  return Boolean(normalized) && STARTER_SET.has(normalized);
+}
+
 /** Starter prompt adoption — which canned prompts drive engagement. */
 export function StarterMixSection({ rows }: StarterMixSectionProps) {
+  const openTraces = useOpenTracesInExplorer();
   const starterMix = useMemo(
     () => computeStarterPromptMix(rows, STARTER_PROMPTS, STARTER_PROMPT_LABELS),
     [rows]
@@ -34,11 +54,12 @@ export function StarterMixSection({ rows }: StarterMixSectionProps) {
       <SimpleGrid columns={{ base: 1, lg: 2 }} gap={4}>
         <ChartCard
           title="Starter vs other prompts"
-          help="Share of prompts matching the pre-defined starter library."
+          help="Share of prompts matching the pre-defined starter library. Click a slice to open those traces."
           info="Starter prompts are the canned suggestions shown in the GNW UI. A
             high Starter share means users lean on the suggestions to get going; a
             high Other share means they arrive with their own questions. Track this
-            after changing the starter library."
+            after changing the starter library. Click a slice to inspect its
+            traces in the Trace Explorer."
         >
           <DonutChart
             data={[
@@ -52,20 +73,40 @@ export function StarterMixSection({ rows }: StarterMixSectionProps) {
             }}
             height={200}
             centerLabel="prompts"
+            onSliceClick={(label) =>
+              openTraces(
+                `${label} prompts`,
+                rows.filter((r) => isStarter(r) === (label === "Starter"))
+              )
+            }
           />
         </ChartCard>
         {starterMix.breakdown.length ? (
           <ChartCard
             title="Starter prompt breakdown"
-            help="Which starter prompts are used most."
+            help="Which starter prompts are used most. Click a bar to open those traces."
             info="Only prompts that matched the starter library appear here. Rarely
-              used starters are candidates for replacement."
+              used starters are candidates for replacement. Click any bar to
+              inspect its traces in the Trace Explorer."
           >
             <HorizontalBarChart
               data={starterMix.breakdown.map((b) => ({
                 label: b.label,
                 count: b.count,
               }))}
+              onBarClick={(datum) => {
+                // A breakdown label may cover several library phrasings; an
+                // unlabelled starter falls back to its normalized text.
+                const normalizedSet = new Set(
+                  NORMALIZED_BY_LABEL.get(datum.label) ?? [datum.label]
+                );
+                openTraces(
+                  `Starter prompt = ${datum.label}`,
+                  rows.filter((r) =>
+                    normalizedSet.has(normalizePrompt(r.prompt))
+                  )
+                );
+              }}
             />
           </ChartCard>
         ) : null}

--- a/src/features/trace-analytics/ui/analytics/TaxonomySection.tsx
+++ b/src/features/trace-analytics/ui/analytics/TaxonomySection.tsx
@@ -1,0 +1,418 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { Box, Button, Flex, Heading, SimpleGrid, Text } from "@chakra-ui/react";
+import type { TraceRow } from "../../model/types";
+import type { TaggedTrace } from "../../lib/analytics/taxonomy";
+import {
+  complexitySummary,
+  continuationDistribution,
+  flagDistribution,
+  intentDistribution,
+  languageReconciliation,
+  prettyLabel,
+  tagTraces,
+  topicCoarseDistribution,
+  turnRoleDistribution,
+  type AxisCount,
+} from "../../lib/analytics/taxonomy";
+import { formatCount, formatPercent, languageName } from "../../lib/format";
+import { ChartCard } from "../charts/ChartCard";
+import { DonutChart } from "../charts/DonutChart";
+import { HorizontalBarChart } from "../charts/HorizontalBarChart";
+import { InfoCallout } from "../primitives/InfoCallout";
+import { StatCards } from "../primitives/StatCards";
+import { useOpenTracesInExplorer } from "../useOpenTracesInExplorer";
+
+interface TaxonomySectionProps {
+  /**
+   * Raw, pre-language-merge trace rows (server `language` nulls preserved) so
+   * the language axis can compare the API value against independent detection.
+   */
+  readonly rows: readonly TraceRow[];
+}
+
+function toBars(counts: readonly AxisCount[]): AxisCount[] {
+  return counts.map((c) => ({ label: prettyLabel(c.label), count: c.count }));
+}
+
+type Scope = "organic" | "all";
+
+export function TaxonomySection({ rows }: TaxonomySectionProps) {
+  // Tag once; the toggles below only change how the tags are aggregated.
+  const tagged = useMemo<TaggedTrace[]>(() => tagTraces(rows), [rows]);
+
+  const [scope, setScope] = useState<Scope>("organic");
+  const [langMode, setLangMode] = useState<"api" | "refined">("refined");
+  const organic = scope === "organic";
+  const openTraces = useOpenTracesInExplorer();
+  const scopeTag = organic ? "organic" : "all traffic";
+  const pool = useMemo(
+    () => (organic ? tagged.filter((t) => t.flag === "organic") : tagged),
+    [tagged, organic]
+  );
+
+  /**
+   * Click handler factory for one taxonomy axis. Charts display prettified
+   * labels, so `byPretty` maps them back to the raw code before matching;
+   * axes whose labels are already raw (topics) pass an empty map.
+   */
+  function axisClick(
+    axis: string,
+    byPretty: ReadonlyMap<string, string>,
+    match: (t: TaggedTrace, raw: string) => boolean,
+    opts: {
+      readonly source?: readonly TaggedTrace[];
+      readonly note?: string;
+    } = {}
+  ): (datum: { label: string }) => void {
+    return (datum) => {
+      const raw = byPretty.get(datum.label) ?? datum.label;
+      openTraces(
+        `${axis} = ${datum.label} (${opts.note ?? scopeTag})`,
+        (opts.source ?? pool).filter((t) => match(t, raw)).map((t) => t.row)
+      );
+    };
+  }
+
+  /** pretty label -> raw code, for reversing chart labels on click. */
+  const byPretty = (counts: readonly AxisCount[]) =>
+    new Map(counts.map((c) => [prettyLabel(c.label), c.label]));
+
+  const flags = useMemo(() => flagDistribution(tagged), [tagged]);
+  const intents = useMemo(
+    () => intentDistribution(tagged, { organic }),
+    [tagged, organic]
+  );
+  const topics = useMemo(
+    () => topicCoarseDistribution(tagged, { organic }),
+    [tagged, organic]
+  );
+  const turnRoles = useMemo(
+    () => turnRoleDistribution(tagged, { organic }),
+    [tagged, organic]
+  );
+  const continuation = useMemo(
+    () => continuationDistribution(tagged, { organic }),
+    [tagged, organic]
+  );
+  const cx = useMemo(
+    () => complexitySummary(tagged, { organic }),
+    [tagged, organic]
+  );
+  const lang = useMemo(() => languageReconciliation(tagged), [tagged]);
+  const langCounts =
+    langMode === "refined" ? lang.finalCounts : lang.systemCounts;
+
+  const total = tagged.length;
+  const organicCount = useMemo(
+    () => tagged.filter((t) => t.flag === "organic").length,
+    [tagged]
+  );
+  const substantive = intents.reduce((a, b) => a + b.count, 0);
+
+  const headline = [
+    {
+      label: "Turns tagged",
+      value: formatCount(total),
+      hint: "All traces in the filtered window",
+    },
+    {
+      label: "Organic",
+      value: formatCount(organicCount),
+      hint: total
+        ? `${formatPercent(organicCount / total, 0)} · real user prompts`
+        : undefined,
+    },
+    {
+      label: `Substantive (${organic ? "organic" : "all"})`,
+      value: formatCount(substantive),
+      hint: "Turns with an analytical intent",
+    },
+    {
+      label: "Mean complexity",
+      value: cx.mean === null ? "—" : cx.mean.toFixed(2),
+      hint: `0–10 constraint count (${organic ? "organic" : "all"})`,
+    },
+  ];
+
+  return (
+    <Box>
+      <Heading as="h3" size="md" mb={3}>
+        Prompt Taxonomy
+      </Heading>
+      <Flex direction="column" gap={3}>
+        <InfoCallout title="What is the prompt taxonomy?">
+          <Text mb={2}>
+            Every turn is classified on five axes plus a complexity score by a
+            deterministic rule tagger (ported from the GNW taxonomy project) —
+            no LLM and no server call, so the same window always yields the same
+            numbers.
+          </Text>
+          <Text>
+            These are a <b>derived view</b>: the trace data is never modified,
+            and the categories will defer to a server-side taxonomy if one
+            ships. The rules were tuned on a ~360-turn sample, so treat the
+            figures as indicative and watch the <b>Other</b> intent and{" "}
+            <b>Unclassified</b> topic shares on a fresh window — if either
+            climbs, the data has surfaced patterns the rules do not cover.
+          </Text>
+        </InfoCallout>
+
+        <Flex align="center" gap={2} wrap="wrap">
+          <Text fontSize="xs" color="fg.muted">
+            Population
+          </Text>
+          {(["organic", "all"] as const).map((s) => (
+            <Button
+              key={s}
+              size="xs"
+              variant={scope === s ? "solid" : "outline"}
+              onClick={() => setScope(s)}
+            >
+              {s === "organic" ? "Organic only" : "All traffic"}
+            </Button>
+          ))}
+          <Text fontSize="xs" color="fg.subtle">
+            Excludes templated, test and system turns when set to organic. The
+            cleaning breakdown below always shows all traffic.
+          </Text>
+        </Flex>
+
+        <StatCards items={headline} columns={4} />
+
+        <SimpleGrid columns={{ base: 1, lg: 2 }} gap={4}>
+          <ChartCard
+            title="Analytical intent"
+            help="The single analytical goal of each substantive turn. Click a bar to open those traces."
+            info="Intent is the review-heavy axis: precedence is load-bearing
+              (comparison, trend, causal, monitoring, quantification, …) and
+              'Spatial' is view-only. A rising 'Other' share means the rules are
+              hitting prompts they cannot place — hand-check before quoting
+              per-intent figures. Click any bar to inspect its traces in the
+              Trace Explorer."
+          >
+            {intents.length ? (
+              <HorizontalBarChart
+                data={toBars(intents)}
+                onBarClick={axisClick(
+                  "Intent",
+                  byPretty(intents),
+                  (t, raw) => t.intent === raw
+                )}
+              />
+            ) : (
+              <Text fontSize="sm" color="fg.muted">
+                No substantive turns in this window.
+              </Text>
+            )}
+          </ChartCard>
+
+          <ChartCard
+            title="Topic (coarse)"
+            help="Subject of the turn, rolled up. Turns can carry more than one topic, so occurrences can exceed the turn count. Click a bar to open those traces."
+            info="Topics are tagged from the prompt text and carried across a
+              session's continuation turns (topic inheritance). 'Unclassified'
+              collects genuinely topic-free turns (confirmations, navigation)
+              plus any subject the vocabulary misses. Click any bar to inspect
+              its traces in the Trace Explorer."
+          >
+            {topics.length ? (
+              <HorizontalBarChart
+                data={topics.map((t) => ({ label: t.label, count: t.count }))}
+                onBarClick={axisClick("Topic", new Map(), (t, raw) =>
+                  t.topicCoarse.split("|").includes(raw)
+                )}
+              />
+            ) : (
+              <Text fontSize="sm" color="fg.muted">
+                No topics in this window.
+              </Text>
+            )}
+          </ChartCard>
+        </SimpleGrid>
+
+        <SimpleGrid columns={{ base: 1, lg: 2 }} gap={4}>
+          <ChartCard
+            title="Prompt complexity"
+            help={`Constraint count per prompt (0–10), banded. Mean ${
+              cx.mean === null ? "—" : cx.mean.toFixed(2)
+            }.`}
+            info="Complexity counts prompt-intrinsic constraints (area, time,
+              metric, dataset named, comparison, aggregation, …). It is the
+              interim per-type difficulty signal until graded accuracy exists.
+              Click a slice to inspect its traces in the Trace Explorer."
+          >
+            {cx.bands.length ? (
+              <DonutChart
+                data={cx.bands.map((b) => ({
+                  label: prettyLabel(b.label),
+                  count: b.count,
+                }))}
+                centerLabel="turns"
+                onSliceClick={(label) =>
+                  axisClick(
+                    "Complexity",
+                    byPretty(cx.bands),
+                    (t, raw) => t.cxBand === raw
+                  )({ label })
+                }
+              />
+            ) : (
+              <Text fontSize="sm" color="fg.muted">
+                No scored prompts in this window.
+              </Text>
+            )}
+          </ChartCard>
+
+          <ChartCard
+            title="Turn role"
+            help="What each turn is doing in the conversation."
+            info="New queries vs refinements, confirmations, dataset
+              disambiguation, insight/report operations and platform/meta
+              questions. Non-analytical roles are gated to 'not applicable'
+              intent by design. Click any bar to inspect its traces in the
+              Trace Explorer."
+          >
+            {turnRoles.length ? (
+              <HorizontalBarChart
+                data={toBars(turnRoles)}
+                onBarClick={axisClick(
+                  "Turn role",
+                  byPretty(turnRoles),
+                  (t, raw) => t.turnRole === raw
+                )}
+              />
+            ) : (
+              <Text fontSize="sm" color="fg.muted">
+                No turns in this window.
+              </Text>
+            )}
+          </ChartCard>
+        </SimpleGrid>
+
+        <SimpleGrid columns={{ base: 1, lg: 2 }} gap={4}>
+          <ChartCard
+            title="In-session behaviour"
+            help="How later turns (after the first) relate to the conversation so far."
+            info="Only turns at position > 0 are counted. A high 'Refinement'
+              share means users iterate on an answer; 'New question' means they
+              pivot within the same session. Click a slice to inspect its
+              traces in the Trace Explorer."
+          >
+            {continuation.length ? (
+              <DonutChart
+                data={toBars(continuation)}
+                centerLabel="turns"
+                onSliceClick={(label) =>
+                  axisClick(
+                    "In-session behaviour",
+                    byPretty(continuation),
+                    (t, raw) => t.continuation === raw,
+                    { source: pool.filter((t) => t.turnPos > 0) }
+                  )({ label })
+                }
+              />
+            ) : (
+              <Text fontSize="sm" color="fg.muted">
+                No in-session turns (every session is a single turn).
+              </Text>
+            )}
+          </ChartCard>
+
+          <ChartCard
+            title="Traffic cleaning"
+            help="Segments the raw traffic so non-organic turns can be excluded. Always shows all traffic."
+            info="Organic = real user prompts (the population reported above).
+              Templated = welcome 'Analyse X in Y' prompts. Internal/junk/system
+              = test scaffolding, gibberish and platform-generated text. Null =
+              empty prompts. Click a slice to inspect its traces in the Trace
+              Explorer."
+          >
+            <DonutChart
+              data={flags.map((f) => ({
+                label: prettyLabel(f.label),
+                count: f.count,
+              }))}
+              centerLabel="turns"
+              onSliceClick={(label) =>
+                axisClick(
+                  "Traffic segment",
+                  byPretty(flags),
+                  (t, raw) => t.flag === raw,
+                  { source: tagged, note: "all traffic" }
+                )({ label })
+              }
+            />
+          </ChartCard>
+        </SimpleGrid>
+
+        <ChartCard
+          title="Prompt language"
+          help="Reconciles the API's language field against independent detection."
+          info="API shows the raw server language (blank on some turns). Refined
+            keeps the server value where present, backfills blanks from
+            detection, and flags disagreements for review — it never overwrites
+            a server value. Soft-error detection is English-only, so a
+            meaningful non-English share means non-English failures are
+            undercounted elsewhere. Click any bar to inspect its traces in the
+            Trace Explorer."
+        >
+          <Flex
+            justify="space-between"
+            align="center"
+            gap={2}
+            mb={1}
+            wrap="wrap"
+          >
+            <Text fontSize="xs" color="fg.muted">
+              {langMode === "refined"
+                ? `Detection backfilled ${formatCount(lang.backfilled)} blank server value${
+                    lang.backfilled === 1 ? "" : "s"
+                  }; flagged ${formatCount(lang.disagreements)} disagreement${
+                    lang.disagreements === 1 ? "" : "s"
+                  } for review.`
+                : "Raw server language field (organic turns; blanks omitted)."}
+            </Text>
+            <Flex gap={1}>
+              {(["api", "refined"] as const).map((m) => (
+                <Button
+                  key={m}
+                  size="xs"
+                  variant={langMode === m ? "solid" : "outline"}
+                  onClick={() => setLangMode(m)}
+                >
+                  {m === "api" ? "API" : "Refined"}
+                </Button>
+              ))}
+            </Flex>
+          </Flex>
+          {langCounts.length ? (
+            <HorizontalBarChart
+              data={langCounts.map((l) => ({
+                label: languageName(l.label),
+                count: l.count,
+              }))}
+              onBarClick={axisClick(
+                `Language (${langMode === "refined" ? "reconciled" : "API"})`,
+                new Map(
+                  langCounts.map((c) => [languageName(c.label), c.label])
+                ),
+                (t, raw) =>
+                  (langMode === "refined" ? t.langFinal : t.langSystem) === raw,
+                {
+                  source: tagged.filter((t) => t.flag === "organic"),
+                  note: "organic",
+                }
+              )}
+            />
+          ) : (
+            <Text fontSize="sm" color="fg.muted">
+              No language data in this window.
+            </Text>
+          )}
+        </ChartCard>
+      </Flex>
+    </Box>
+  );
+}

--- a/src/features/trace-analytics/ui/analytics/ToolUsageSection.tsx
+++ b/src/features/trace-analytics/ui/analytics/ToolUsageSection.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useMemo } from "react";
+import { useRouter } from "next/navigation";
 import { Box, Flex, Heading, Text } from "@chakra-ui/react";
 import type { TraceRow } from "../../model/types";
 import { computeToolUsage } from "../../lib/analytics/aggregations";
@@ -8,12 +9,14 @@ import { formatCount, formatPercent } from "../../lib/format";
 import { ChartCard } from "../charts/ChartCard";
 import { ToolCallsScatterChart } from "../charts/ToolCallsScatterChart";
 import { StatCards } from "../primitives/StatCards";
+import { tabHref } from "../links";
 
 interface ToolUsageSectionProps {
   readonly rows: readonly TraceRow[];
 }
 
 export function ToolUsageSection({ rows }: ToolUsageSectionProps) {
+  const router = useRouter();
   const usage = useMemo(() => computeToolUsage(rows), [rows]);
 
   return (
@@ -32,11 +35,17 @@ export function ToolUsageSection({ rows }: ToolUsageSectionProps) {
             {
               label: "Avg tool calls / trace",
               value: usage.avgToolCalls.toFixed(2),
+              hint: "Mean over all turns, incl. 0-tool answers",
             },
-            { label: "Max tool calls", value: formatCount(usage.maxToolCalls) },
+            {
+              label: "Max tool calls",
+              value: formatCount(usage.maxToolCalls),
+              hint: "Heaviest single turn in the window",
+            },
             {
               label: "Tool error rate",
               value: formatPercent(usage.toolErrorRate),
+              hint: "Turns with ≥1 internal tool error",
             },
           ]}
           columns={3}
@@ -44,14 +53,20 @@ export function ToolUsageSection({ rows }: ToolUsageSectionProps) {
         {usage.scatter.length ? (
           <ChartCard
             title="Tool calls vs latency"
-            help="Each dot is one trace: how many tools it called and how long it took."
+            help="Each dot is one trace: how many tools it called and how long it took. Click a dot to open that trace."
             info="Latency should rise roughly linearly with tool calls — that diagonal
               band is normal. Watch for red dots at low tool counts (fast failures,
               often refusals or crashes) and green dots far above the band (slow
               successes worth optimising). Dots at zero tool calls are answers that
-              never touched a tool."
+              never touched a tool. Click any dot to open that exact trace in the
+              Trace Explorer."
           >
-            <ToolCallsScatterChart data={usage.scatter} />
+            <ToolCallsScatterChart
+              data={usage.scatter}
+              onPointClick={(traceId) =>
+                router.push(tabHref("traces", { trace: traceId }))
+              }
+            />
           </ChartCard>
         ) : null}
       </Flex>

--- a/src/features/trace-analytics/ui/charts/DailyOutcomeAreaChart.tsx
+++ b/src/features/trace-analytics/ui/charts/DailyOutcomeAreaChart.tsx
@@ -10,7 +10,7 @@ import {
   XAxis,
   YAxis,
 } from "recharts";
-import type { DailyMetrics } from "../../lib/analytics/daily";
+import type { DailyOutcomeMix } from "../../lib/analytics/daily";
 import { CHART_CHROME, OUTCOME_COLORS, OUTCOME_STACK_ORDER } from "./palette";
 import { formatDateTick } from "./axis";
 import { ChartTooltip } from "./ChartTooltip";
@@ -18,34 +18,50 @@ import { ChartLegend, keepPayloadOrder } from "./ChartLegend";
 import { formatCount, formatReportDate } from "../../lib/format";
 
 interface DailyOutcomeAreaChartProps {
-  readonly data: readonly DailyMetrics[];
+  readonly data: readonly DailyOutcomeMix[];
+  /** Outcome labels bottom → top; also the color-map keys. */
+  readonly order?: readonly string[];
+  readonly colors?: Readonly<Record<string, string>>;
   readonly height?: number;
+  /** When set, clicking the chart reports the clicked day (YYYY-MM-DD). */
+  readonly onDayClick?: (date: string) => void;
 }
 
-const SERIES: readonly { key: keyof DailyMetrics; label: string }[] = [
-  { key: "errorRate", label: "Error" },
-  { key: "emptyRate", label: "Error (Empty)" },
-  { key: "deferRate", label: "Defer" },
-  { key: "softErrorRate", label: "Soft error" },
-  { key: "successRate", label: "Success" },
-];
-
-/** Normalized stacked area of daily outcome rates (success stacks on top). */
+/** Normalized stacked area of daily outcome shares (best on top). */
 export function DailyOutcomeAreaChart({
   data,
+  order = OUTCOME_STACK_ORDER,
+  colors = OUTCOME_COLORS,
   height = 260,
+  onDayClick,
 }: DailyOutcomeAreaChartProps) {
-  const ordered = OUTCOME_STACK_ORDER.map(
-    (label) => SERIES.find((s) => s.label === label) as (typeof SERIES)[number]
-  );
+  // Pre-compute each label's share per day so the tooltip reads a share (not a
+  // raw count); stackOffset="expand" then keeps the stack normalized to 100%.
+  const rows = data.map((d) => {
+    const total = Math.max(1, d.total);
+    const shares = Object.fromEntries(
+      order.map((label) => [label, (d.counts[label] ?? 0) / total])
+    );
+    return { date: d.date, traces: d.total, ...shares };
+  });
   // With ≤2 days an area has no width to paint — show dots at each value.
   const sparse = data.length <= 2;
   return (
     <ResponsiveContainer width="100%" height={height}>
       <AreaChart
-        data={[...data]}
+        data={rows}
         stackOffset="expand"
         margin={{ top: 4, right: 8, bottom: 4, left: 0 }}
+        style={onDayClick ? { cursor: "pointer" } : undefined}
+        onClick={
+          onDayClick
+            ? (state: unknown) => {
+                // Chart-level clicks carry the hovered category as activeLabel.
+                const label = (state as { activeLabel?: unknown })?.activeLabel;
+                if (typeof label === "string" && label) onDayClick(label);
+              }
+            : undefined
+        }
       >
         <CartesianGrid
           strokeDasharray="3 3"
@@ -77,7 +93,7 @@ export function DailyOutcomeAreaChart({
           content={
             <ChartTooltip
               reverse
-              colorMap={OUTCOME_COLORS}
+              colorMap={colors}
               formatValue={(v) => `${(v * 100).toFixed(1)}%`}
               formatLabel={(label, payload) => {
                 const date = formatReportDate(String(label ?? ""));
@@ -96,24 +112,20 @@ export function DailyOutcomeAreaChart({
         <Legend
           verticalAlign="top"
           itemSorter={keepPayloadOrder}
-          content={<ChartLegend reverse colorMap={OUTCOME_COLORS} />}
+          content={<ChartLegend reverse colorMap={colors} />}
         />
-        {ordered.map((s) => (
+        {order.map((label) => (
           <Area
-            key={s.key}
+            key={label}
             type="monotone"
-            dataKey={s.key}
-            name={s.label}
+            dataKey={label}
+            name={label}
             stackId="outcomes"
             stroke={CHART_CHROME.surface}
             strokeWidth={1}
-            fill={OUTCOME_COLORS[s.label]}
+            fill={colors[label]}
             fillOpacity={0.9}
-            dot={
-              sparse
-                ? { r: 3, fill: OUTCOME_COLORS[s.label], strokeWidth: 0 }
-                : false
-            }
+            dot={sparse ? { r: 3, fill: colors[label], strokeWidth: 0 } : false}
             isAnimationActive={false}
           />
         ))}

--- a/src/features/trace-analytics/ui/charts/DonutChart.tsx
+++ b/src/features/trace-analytics/ui/charts/DonutChart.tsx
@@ -14,6 +14,8 @@ interface DonutChartProps {
   readonly height?: number;
   /** Caption under the center total, e.g. "traces" or "users". */
   readonly centerLabel?: string;
+  /** When set, slices and legend rows render clickable and report the label. */
+  readonly onSliceClick?: (label: string) => void;
 }
 
 /**
@@ -25,6 +27,7 @@ export function DonutChart({
   colors,
   height = 240,
   centerLabel = "total",
+  onSliceClick,
 }: DonutChartProps) {
   const visible = data.filter((d) => d.count > 0);
   const total = visible.reduce((acc, d) => acc + d.count, 0);
@@ -52,7 +55,14 @@ export function DonutChart({
               isAnimationActive={false}
             >
               {visible.map((entry, i) => (
-                <Cell key={entry.label} fill={colorFor(entry.label, i)} />
+                <Cell
+                  key={entry.label}
+                  fill={colorFor(entry.label, i)}
+                  cursor={onSliceClick ? "pointer" : undefined}
+                  onClick={
+                    onSliceClick ? () => onSliceClick(entry.label) : undefined
+                  }
+                />
               ))}
             </Pie>
             <Tooltip
@@ -90,7 +100,15 @@ export function DonutChart({
 
       <Flex direction="column" gap={1.5} minW="150px" maxW="55%" flex="1">
         {visible.map((entry, i) => (
-          <Flex key={entry.label} align="center" gap={2}>
+          <Flex
+            key={entry.label}
+            align="center"
+            gap={2}
+            cursor={onSliceClick ? "pointer" : undefined}
+            onClick={onSliceClick ? () => onSliceClick(entry.label) : undefined}
+            _hover={onSliceClick ? { bg: "bg.subtle" } : undefined}
+            borderRadius="sm"
+          >
             <Box
               w="8px"
               h="8px"

--- a/src/features/trace-analytics/ui/charts/HorizontalBarChart.tsx
+++ b/src/features/trace-analytics/ui/charts/HorizontalBarChart.tsx
@@ -27,6 +27,8 @@ interface HorizontalBarChartProps {
   readonly data: readonly HorizontalBarDatum[];
   readonly color?: string;
   readonly barHeight?: number;
+  /** When set, bars render clickable and report the clicked datum. */
+  readonly onBarClick?: (datum: HorizontalBarDatum) => void;
 }
 
 /** Horizontal count bars with direct value labels at the bar ends. */
@@ -34,6 +36,7 @@ export function HorizontalBarChart({
   data,
   color = "#3361C0",
   barHeight = 24,
+  onBarClick,
 }: HorizontalBarChartProps) {
   const height = Math.max(200, Math.min(800, data.length * barHeight + 40));
   const categories = [
@@ -116,6 +119,8 @@ export function HorizontalBarChart({
                     ? categoryColor(categories.indexOf(entry.category))
                     : color
                 }
+                cursor={onBarClick ? "pointer" : undefined}
+                onClick={onBarClick ? () => onBarClick(entry) : undefined}
               />
             ))}
             <LabelList

--- a/src/features/trace-analytics/ui/charts/OutcomeMixBars.tsx
+++ b/src/features/trace-analytics/ui/charts/OutcomeMixBars.tsx
@@ -33,18 +33,29 @@ export interface OutcomeMixDatum {
 
 interface OutcomeMixBarsProps {
   readonly data: readonly OutcomeMixDatum[];
+  /** Outcome labels left → right (best → worst); also the color-map keys. */
+  readonly order?: readonly string[];
+  readonly colors?: Readonly<Record<string, string>>;
   readonly barHeight?: number;
+  /**
+   * When set, segments render clickable and report (row label, outcome label)
+   * — i.e. one cohort × outcome cell of the mix.
+   */
+  readonly onSegmentClick?: (label: string, outcome: string) => void;
 }
 
-export function OutcomeMixBars({ data, barHeight = 28 }: OutcomeMixBarsProps) {
+export function OutcomeMixBars({
+  data,
+  order = OUTCOME_SEVERITY_ORDER,
+  colors = OUTCOME_COLORS,
+  barHeight = 28,
+  onSegmentClick,
+}: OutcomeMixBarsProps) {
   const height = Math.max(160, Math.min(600, data.length * barHeight + 60));
   const rows = data.map((d) => {
     const total = Math.max(1, d.total);
     const shares = Object.fromEntries(
-      OUTCOME_SEVERITY_ORDER.map((label) => [
-        label,
-        (d.counts[label] ?? 0) / total,
-      ])
+      order.map((label) => [label, (d.counts[label] ?? 0) / total])
     );
     return { label: d.label, total: d.total, ...shares };
   });
@@ -109,16 +120,33 @@ export function OutcomeMixBars({ data, barHeight = 28 }: OutcomeMixBarsProps) {
           itemSorter={keepPayloadOrder}
           content={<ChartLegend />}
         />
-        {OUTCOME_SEVERITY_ORDER.map((label) => (
+        {order.map((label) => (
           <Bar
             key={label}
             dataKey={label}
             name={label}
             stackId="mix"
-            fill={OUTCOME_COLORS[label]}
+            fill={colors[label]}
             stroke={CHART_CHROME.surface}
             strokeWidth={1}
             isAnimationActive={false}
+            cursor={onSegmentClick ? "pointer" : undefined}
+            onClick={
+              onSegmentClick
+                ? (entry: unknown) => {
+                    // Recharts hands the bar's datum either directly or under
+                    // `payload` depending on version — read both defensively.
+                    const raw = entry as {
+                      payload?: { label?: unknown };
+                      label?: unknown;
+                    };
+                    const rowLabel = raw?.payload?.label ?? raw?.label;
+                    if (typeof rowLabel === "string" && rowLabel) {
+                      onSegmentClick(rowLabel, label);
+                    }
+                  }
+                : undefined
+            }
           />
         ))}
       </BarChart>

--- a/src/features/trace-analytics/ui/charts/ToolCallsScatterChart.tsx
+++ b/src/features/trace-analytics/ui/charts/ToolCallsScatterChart.tsx
@@ -21,6 +21,7 @@ import { ChartTooltip } from "./ChartTooltip";
 import { ChartLegend, keepPayloadOrder } from "./ChartLegend";
 
 interface ScatterPoint {
+  readonly traceId?: string;
   readonly toolCallCount: number;
   readonly latencySeconds: number;
   readonly outcome: string;
@@ -29,12 +30,15 @@ interface ScatterPoint {
 interface ToolCallsScatterChartProps {
   readonly data: readonly ScatterPoint[];
   readonly height?: number;
+  /** When set, dots render clickable and report their traceId. */
+  readonly onPointClick?: (traceId: string) => void;
 }
 
 /** Tool calls per trace vs latency, colored by outcome. */
 export function ToolCallsScatterChart({
   data,
   height = 280,
+  onPointClick,
 }: ToolCallsScatterChartProps) {
   const byOutcome = new Map<string, ScatterPoint[]>();
   for (const point of data) {
@@ -115,6 +119,22 @@ export function ToolCallsScatterChart({
             stroke={CHART_CHROME.surface}
             strokeWidth={1}
             isAnimationActive={false}
+            cursor={onPointClick ? "pointer" : undefined}
+            onClick={
+              onPointClick
+                ? (entry: unknown) => {
+                    // The clicked dot's datum arrives directly or as payload.
+                    const raw = entry as {
+                      payload?: { traceId?: unknown };
+                      traceId?: unknown;
+                    };
+                    const traceId = raw?.payload?.traceId ?? raw?.traceId;
+                    if (typeof traceId === "string" && traceId) {
+                      onPointClick(traceId);
+                    }
+                  }
+                : undefined
+            }
           />
         ))}
       </ScatterChart>

--- a/src/features/trace-analytics/ui/charts/palette.ts
+++ b/src/features/trace-analytics/ui/charts/palette.ts
@@ -56,6 +56,48 @@ export function outcomeOrderIndex(label: string): number {
 }
 
 /**
+ * Refined-outcome display colors, keyed by the REFINED_LABELS values in
+ * lib/analytics/outcomeRefine. Keep the label strings in sync with that map.
+ * Same status scale as OUTCOME_COLORS: green = answered (mint/cyan steps split
+ * degraded and context answers), gray = defer/UI-event, amber = soft error, red
+ * = empty answer, dark maroon = no response.
+ */
+export const REFINED_OUTCOME_COLORS: Readonly<Record<string, string>> = {
+  "Attempted answer": "#00A651",
+  "Answered (internal errors)": "#00B086",
+  "Answered from context": "#0092C4",
+  "Defer (clarify / other)": "#B2B7BD",
+  "Soft error": "#D97D05",
+  "Empty answer": "#E23A22",
+  "No response": "#8C2332",
+  "UI event (no prompt)": "#CDD2D8",
+};
+
+/** Refined labels, best → worst (mix bars, legends). */
+export const REFINED_SEVERITY_ORDER = [
+  "Attempted answer",
+  "Answered (internal errors)",
+  "Answered from context",
+  "Defer (clarify / other)",
+  "Soft error",
+  "Empty answer",
+  "No response",
+  "UI event (no prompt)",
+] as const;
+
+/** Refined stacking order for the daily area (bottom → top; best on top). */
+export const REFINED_STACK_ORDER = [
+  "UI event (no prompt)",
+  "No response",
+  "Empty answer",
+  "Soft error",
+  "Defer (clarify / other)",
+  "Answered from context",
+  "Answered (internal errors)",
+  "Attempted answer",
+] as const;
+
+/**
  * Refined-outcome / flow-diagram colors, keyed by node key (see
  * lib/analytics/outcomeRefine). Validated with the outcome set: CVD worst
  * adjacent pair ΔE 13.0; low-contrast steps (amber, grays, mint) are

--- a/src/features/trace-analytics/ui/primitives/KpiCard.tsx
+++ b/src/features/trace-analytics/ui/primitives/KpiCard.tsx
@@ -80,7 +80,7 @@ export function KpiCard({ label, value, delta, hint, spark }: KpiCardProps) {
         ) : null}
       </Flex>
       {hint ? (
-        <Text fontSize="xs" color="fg.subtle" mt={1} lineClamp={1}>
+        <Text fontSize="xs" color="fg.subtle" mt={1} lineClamp={1} title={hint}>
           {hint}
         </Text>
       ) : null}

--- a/src/features/trace-analytics/ui/useOpenTracesInExplorer.ts
+++ b/src/features/trace-analytics/ui/useOpenTracesInExplorer.ts
@@ -1,0 +1,61 @@
+"use client";
+
+/**
+ * Drill-down from an analytics aggregate to the Trace Explorer.
+ *
+ * Analytics categories (taxonomy axes, outcome cohorts, dataset/AOI buckets…)
+ * are derived client-side, so they cannot be expressed as explorer fetch
+ * filters. Instead, the exact rows behind a category are handed straight to
+ * the explorer store (no refetch — the analytics window already holds them)
+ * and the view switches to the Traces tab, where a banner explains the loaded
+ * selection.
+ */
+
+import { useCallback } from "react";
+import { useRouter } from "next/navigation";
+import type { TraceRow } from "../model/types";
+import { useExplorerStore } from "../model/dataStores";
+import { EXPLORER_MAX_TRACES } from "../model/config";
+import { tabHref } from "./links";
+
+/** Sort key: newest first; rows without a timestamp go last. */
+function tsKey(row: TraceRow): string {
+  return row.timestamp ?? "";
+}
+
+/**
+ * Returns `openTraces(label, rows)`: loads `rows` into the Trace Explorer as a
+ * named selection and navigates to the Traces tab. `label` should say what the
+ * selection is, e.g. `Topic = Fire · outcome Soft error`.
+ */
+export function useOpenTracesInExplorer(): (
+  label: string,
+  rows: readonly TraceRow[]
+) => void {
+  const router = useRouter();
+
+  return useCallback(
+    (label, rows) => {
+      const entries = [...rows]
+        .sort((a, b) => tsKey(b).localeCompare(tsKey(a)))
+        .slice(0, EXPLORER_MAX_TRACES)
+        .map((row) => ({
+          id: row.traceId,
+          prompt: row.prompt,
+          traceTimestamp: row.timestamp,
+          sessionId: row.sessionId,
+        }));
+      const capped = rows.length > entries.length;
+      useExplorerStore
+        .getState()
+        .loadSelection(
+          entries,
+          capped
+            ? `${label} (first ${entries.length} of ${rows.length})`
+            : label
+        );
+      router.push(tabHref("traces"));
+    },
+    [router]
+  );
+}


### PR DESCRIPTION
Adds independent topic/language detection over trace content, a TaxonomySection to surface it, and a way to jump from any analytics aggregate straight into the trace explorer with the underlying rows pre-loaded.