### PR TITLE
Add insights to Dashboard via chat

### DIFF
--- a/app/ChatPanel.tsx
+++ b/app/ChatPanel.tsx
@@ -1,21 +1,19 @@
 "use client";
 
-import { useState } from "react";
 import { AnimatePresence, motion } from "framer-motion";
 import ChatPanelCompact from "./ChatPanelCompact";
 import ChatPanelFullSize from "./ChatPanelFullSize";
 import useSidebarStore from "./store/sidebarStore";
 
 function ChatPanel() {
-  const [isFullSize, setIsFullSize] = useState(false);
-  const { setChatFullSize } = useSidebarStore();
+  // The store is the single source of truth for panel size. Layout consumers
+  // (map controls, dashboard content offset) read isChatFullSize, and the
+  // panel remounts across surfaces (map ↔ dashboard) — local state here would
+  // reset to compact while the store kept reporting full-size.
+  const isFullSize = useSidebarStore((s) => s.isChatFullSize);
+  const setChatFullSize = useSidebarStore((s) => s.setChatFullSize);
 
-  const toggleSize = () => {
-    setIsFullSize((prev) => {
-      setChatFullSize(!prev);
-      return !prev;
-    });
-  };
+  const toggleSize = () => setChatFullSize(!isFullSize);
 
   return (
     <AnimatePresence mode="wait">

--- a/app/ChatPanelCompact.tsx
+++ b/app/ChatPanelCompact.tsx
@@ -16,6 +16,8 @@ import {
 import { usePromptQuota } from "./hooks/usePromptQuota";
 import useChatStore from "./store/chatStore";
 import useSidebarStore from "./store/sidebarStore";
+import { isAppRoute } from "./utils/threadNavigation";
+import { usePathname } from "next/navigation";
 import { useState, useEffect, useRef, useCallback } from "react";
 
 // Intentionally narrower than the full-size panel (see FULLSIZE_CHAT_PANEL_WIDTH_PX).
@@ -41,7 +43,12 @@ function ChatPanelCompact({ onToggleSize }: ChatPanelCompactProps) {
   const { promptsExhausted } = usePromptQuota();
   const { messages } = useChatStore();
   const { dataCatalogOpen, areasPanelOpen } = useSidebarStore();
-  const chatLeftPx = getCompactChatLeftPx(dataCatalogOpen || areasPanelOpen);
+  const pathname = usePathname();
+  // The catalog/areas panels only render in the map layout; off it (dashboard
+  // pages) their persisted open state must not push the panel sideways.
+  const chatLeftPx = getCompactChatLeftPx(
+    isAppRoute(pathname) && (dataCatalogOpen || areasPanelOpen)
+  );
   const hasConversation = messages.some(
     (m) => m.type === "user" || m.type === "assistant"
   );

--- a/app/__tests__/explorationLayout.test.ts
+++ b/app/__tests__/explorationLayout.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect } from "vitest";
 import {
   getCompactChatLeftPx,
   getCatalogLeftPx,
+  getDashboardContentLeftPx,
   getMapAreaToolsLeftPx,
   getMapControlsLeftPx,
   getMapFeedbackLeftPx,
@@ -63,5 +64,13 @@ describe("explorationLayout", () => {
 
   it("places map feedback past the full-size chat when the catalog is closed", () => {
     expect(getMapFeedbackLeftPx(true, false)).toBe(436);
+  });
+
+  it("shifts dashboard content past the full-size chat panel", () => {
+    expect(getDashboardContentLeftPx(true)).toBe(436);
+  });
+
+  it("keeps dashboard content unshifted when the chat is compact", () => {
+    expect(getDashboardContentLeftPx(false)).toBe(0);
   });
 });

--- a/app/app/(chat)/layout.tsx
+++ b/app/app/(chat)/layout.tsx
@@ -24,6 +24,7 @@ import DraggableBottomSheet from "@/app/components/BottomSheet";
 import { ListIcon } from "@phosphor-icons/react";
 import useSidebarStore from "@/app/store/sidebarStore";
 import useAgentProfileStore from "@/app/store/agentProfileStore";
+import useViewContextStore from "@/app/store/viewContextStore";
 import MapAreaFeedback from "@/app/components/MapAreaFeedback";
 import { AnalysisCtaTrigger } from "@/app/lib/analysis/AnalysisCtaTrigger";
 import {
@@ -53,6 +54,8 @@ export default function DashboardLayout({
     // /app/threads/:id after the first message, so the param must be persisted
     // rather than re-read from the live URL on each request.
     useAgentProfileStore.getState().initFromUrl();
+    // Report this surface to the agent on every chat request from here on.
+    useViewContextStore.getState().setViewContext({ page: "map" });
   }, []);
 
   const DesktopLayout = (

--- a/app/app/(chat)/layout.tsx
+++ b/app/app/(chat)/layout.tsx
@@ -11,6 +11,7 @@ import {
 import { useEffect, useState } from "react";
 
 import ChatPanel from "@/app/ChatPanel";
+import ConversationHistoryDrawer from "@/app/components/ConversationHistoryDrawer";
 import UploadAreaDialog from "@/app/components/UploadAreaDialog";
 import Map from "@/app/components/Map";
 import CatalogPanel from "@/app/components/CatalogPanel";
@@ -40,7 +41,7 @@ export default function DashboardLayout({
 }) {
   const isReady = useAuthGuard();
   const [sheetHeight, setSheetHeight] = useState(400);
-  const { toggleSidebar, sideBarVisible } = useSidebarStore();
+  const { toggleSidebar } = useSidebarStore();
   const isMobile = useBreakpointValue({ base: true, md: false });
   const [mobileHeight, setMobileHeight] = useState("0");
 
@@ -111,22 +112,7 @@ export default function DashboardLayout({
           <ChatPanel />
         </Box>
       </Box>
-      <Drawer.Root
-        placement="start"
-        open={sideBarVisible}
-        onOpenChange={(e) => {
-          if (!e.open && sideBarVisible) toggleSidebar();
-        }}
-      >
-        <Portal>
-          <Drawer.Backdrop backdropFilter="blur(2px)" />
-          <Drawer.Positioner>
-            <Drawer.Content maxW="428px" w="428px">
-              <Sidebar />
-            </Drawer.Content>
-          </Drawer.Positioner>
-        </Portal>
-      </Drawer.Root>
+      <ConversationHistoryDrawer />
     </Box>
   );
 

--- a/app/app/(chat)/page.tsx
+++ b/app/app/(chat)/page.tsx
@@ -8,6 +8,7 @@ import useMapStore from "@/app/store/mapStore";
 import { DATASET_CARDS } from "@/app/constants/datasets";
 import { getLayerContextFromDatasetCard } from "@/app/utils/datasetCardLayerContext";
 import { buildDatasetLayers } from "@/app/utils/datasetLayerContext";
+import { firstMessageRedirectPath } from "@/app/utils/threadNavigation";
 
 const DEFAULT_LANDING_DATASET_ID = 4;
 
@@ -57,7 +58,12 @@ function NewThread() {
     async (prompt: string) => {
       const result = await sendMessage(prompt);
       if (result.isNew) {
-        router.replace(`/app/threads/${result.id}`);
+        const redirect = firstMessageRedirectPath(
+          window.location.pathname,
+          result.id,
+          window.location.search
+        );
+        if (redirect) router.replace(redirect);
       }
     },
     [sendMessage, router]

--- a/app/components/ChatInput.tsx
+++ b/app/components/ChatInput.tsx
@@ -127,7 +127,11 @@ export default function ChatInput({
 
     const result = await sendMessage(message);
     if (result.isNew) {
-      const redirect = firstMessageRedirectPath(pathname, result.id);
+      const redirect = firstMessageRedirectPath(
+        pathname,
+        result.id,
+        window.location.search
+      );
       if (redirect) router.replace(redirect);
     }
   };

--- a/app/components/ChatInput.tsx
+++ b/app/components/ChatInput.tsx
@@ -20,7 +20,10 @@ import useMapStore from "../store/mapStore";
 import { isAreaLayer } from "../store/layerManagerSlice";
 import useSidebarStore from "../store/sidebarStore";
 import { useRouter, usePathname } from "next/navigation";
-import { firstMessageRedirectPath } from "../utils/threadNavigation";
+import {
+  firstMessageRedirectPath,
+  isAppRoute,
+} from "../utils/threadNavigation";
 
 export default function ChatInput({
   isChatDisabled,
@@ -238,22 +241,28 @@ export default function ChatInput({
       />
       <Flex justifyContent="space-between" alignItems="center" w="full">
         <Flex gap="2">
-          <ContextButton
-            contextType="layer"
-            onClick={openLayerPicker}
-            disabled={disabled}
-            borderColor={dataCatalogOpen ? "primary.solid" : "#E0E2E5"}
-            color={dataCatalogOpen ? "primary.solid" : undefined}
-            aria-expanded={dataCatalogOpen}
-          />
-          <ContextButton
-            contextType="area"
-            onClick={openAreaPicker}
-            disabled={disabled}
-            borderColor={areasPanelOpen ? "primary.solid" : "#E0E2E5"}
-            color={areasPanelOpen ? "primary.solid" : undefined}
-            aria-expanded={areasPanelOpen}
-          />
+          {/* The pickers these open (catalog / areas panels) only exist in
+              the map layout — hide them on other surfaces (dashboards). */}
+          {isAppRoute(pathname) && (
+            <>
+              <ContextButton
+                contextType="layer"
+                onClick={openLayerPicker}
+                disabled={disabled}
+                borderColor={dataCatalogOpen ? "primary.solid" : "#E0E2E5"}
+                color={dataCatalogOpen ? "primary.solid" : undefined}
+                aria-expanded={dataCatalogOpen}
+              />
+              <ContextButton
+                contextType="area"
+                onClick={openAreaPicker}
+                disabled={disabled}
+                borderColor={areasPanelOpen ? "primary.solid" : "#E0E2E5"}
+                color={areasPanelOpen ? "primary.solid" : undefined}
+                aria-expanded={areasPanelOpen}
+              />
+            </>
+          )}
         </Flex>
         {canCancelRequest ? (
           <Button

--- a/app/components/ChatInput.tsx
+++ b/app/components/ChatInput.tsx
@@ -19,7 +19,8 @@ import ContextMenu from "./ContextMenu";
 import useMapStore from "../store/mapStore";
 import { isAreaLayer } from "../store/layerManagerSlice";
 import useSidebarStore from "../store/sidebarStore";
-import { useRouter } from "next/navigation";
+import { useRouter, usePathname } from "next/navigation";
+import { firstMessageRedirectPath } from "../utils/threadNavigation";
 
 export default function ChatInput({
   isChatDisabled,
@@ -38,6 +39,7 @@ export default function ChatInput({
     useState<ChatContextType | null>(null);
 
   const router = useRouter();
+  const pathname = usePathname();
 
   // Hooks for responsive modal behavior
   const isMobile = useBreakpointValue({ base: true, md: false });
@@ -122,7 +124,8 @@ export default function ChatInput({
 
     const result = await sendMessage(message);
     if (result.isNew) {
-      router.replace(`/app/threads/${result.id}`);
+      const redirect = firstMessageRedirectPath(pathname, result.id);
+      if (redirect) router.replace(redirect);
     }
   };
 

--- a/app/components/ChatMessages.tsx
+++ b/app/components/ChatMessages.tsx
@@ -2,7 +2,9 @@
 import { Fragment, useEffect, useRef } from "react";
 import { Box, BoxProps } from "@chakra-ui/react";
 import useChatStore from "@/app/store/chatStore";
+import useViewContextStore from "@/app/store/viewContextStore";
 import { usePinnedPrompt } from "@/app/hooks/usePinnedPrompt";
+import DashboardChatNudges from "@/src/features/dashboards/ui/DashboardChatNudges";
 import MessageBubble from "./MessageBubble";
 import PinnedPrompt from "./PinnedPrompt";
 import Reasoning from "./Reasoning";
@@ -23,6 +25,11 @@ function ChatMessages({ pt }: ChatMessagesProps) {
   const lastUserMessageRef = useRef<HTMLDivElement>(null);
   const spacerRef = useRef<HTMLDivElement>(null);
   const { messages, isLoading, toolSteps: currentToolSteps } = useChatStore();
+  // The greeting and first-message prompts are surface-specific: on a
+  // dashboard the seeded map welcome is swapped for the dashboard nudges.
+  const onDashboard = useViewContextStore(
+    (s) => s.viewContext?.page === "dashboard"
+  );
   const shouldAutoScroll = useRef(true);
   const { pinnedMessage, registerPromptNode, jumpToPinnedPrompt } =
     usePinnedPrompt(containerRef, messages);
@@ -115,20 +122,25 @@ function ChatMessages({ pt }: ChatMessagesProps) {
         const isLast = index === messages.length - 1;
         const isLastUserMessage =
           index === lastUserMessageIndex && message.type === "user";
+        const isSeededGreeting = isFirst && message.type === "system";
         return (
           <Fragment key={message.id}>
             {isLastUserMessage && <Box ref={lastUserMessageRef} />}
-            <MessageBubble
-              bubbleRef={
-                message.type === "user"
-                  ? registerPromptNode(message.id)
-                  : undefined
-              }
-              message={message}
-              isConsecutive={isConsecutive}
-              isFirst={isFirst}
-              isLast={isLast}
-            />
+            {isSeededGreeting && onDashboard ? (
+              <DashboardChatNudges showChips={messages.length < 2} />
+            ) : (
+              <MessageBubble
+                bubbleRef={
+                  message.type === "user"
+                    ? registerPromptNode(message.id)
+                    : undefined
+                }
+                message={message}
+                isConsecutive={isConsecutive}
+                isFirst={isFirst}
+                isLast={isLast}
+              />
+            )}
             {message.type === "user" && (
               <>
                 {/* Show reasoning for current loading query (last user message) */}
@@ -146,8 +158,9 @@ function ChatMessages({ pt }: ChatMessagesProps) {
               </>
             )}
 
-            {/* Prompt options for first message, removed when sent */}
-            {messages.length < 2 && <SamplePrompts />}
+            {/* Prompt options for first message, removed when sent. On the
+                dashboard surface DashboardChatNudges renders its own chips. */}
+            {messages.length < 2 && !onDashboard && <SamplePrompts />}
           </Fragment>
         );
       })}

--- a/app/components/ConversationHistoryDrawer.tsx
+++ b/app/components/ConversationHistoryDrawer.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { Drawer, Portal } from "@chakra-ui/react";
+
+import { Sidebar } from "@/app/sidebar";
+import useSidebarStore from "@/app/store/sidebarStore";
+
+/**
+ * The conversation-history sidebar in a left drawer, driven by
+ * `sidebarStore.sideBarVisible` (the PageHeader clock icon toggles it).
+ * The header renders that button on every surface, so every surface must
+ * mount this drawer — otherwise the click silently flips an invisible flag.
+ * Extracted from the map layout so the dashboard pages can mount it too.
+ */
+export default function ConversationHistoryDrawer() {
+  const { sideBarVisible, toggleSidebar } = useSidebarStore();
+  return (
+    <Drawer.Root
+      placement="start"
+      open={sideBarVisible}
+      onOpenChange={(e) => {
+        if (!e.open && sideBarVisible) toggleSidebar();
+      }}
+    >
+      <Portal>
+        <Drawer.Backdrop backdropFilter="blur(2px)" />
+        <Drawer.Positioner>
+          <Drawer.Content maxW="428px" w="428px">
+            <Sidebar />
+          </Drawer.Content>
+        </Drawer.Positioner>
+      </Portal>
+    </Drawer.Root>
+  );
+}

--- a/app/components/PageHeader.tsx
+++ b/app/components/PageHeader.tsx
@@ -39,6 +39,7 @@ import { usePathname } from "next/navigation";
 import { useLogout } from "@/app/hooks/useLogout";
 import { useThreadsInfinite } from "@/app/hooks/useThreadsInfinite";
 import { useFeatureFlag } from "@/src/shared/lib/feature-flags";
+import { mapTabHref } from "@/app/utils/threadNavigation";
 
 const isPrototype = process.env.NEXT_PUBLIC_PROTOTYPE_MODE === "true";
 const DISCLAIMER_STORAGE_KEY = "gnw_disclaimer_dismissed_v2";
@@ -283,7 +284,9 @@ function PageHeader() {
         >
           {[
             {
-              href: "/app?ff=dashboard",
+              // Thread-aware: with a live conversation, land on its thread
+              // URL (which preserves state) instead of the resetting /app.
+              href: mapTabHref(currentThreadId),
               label: "Map",
               icon: <MapTrifoldIcon size={14} />,
               active: onMap,

--- a/app/components/PageHeader.tsx
+++ b/app/components/PageHeader.tsx
@@ -39,7 +39,11 @@ import { usePathname } from "next/navigation";
 import { useLogout } from "@/app/hooks/useLogout";
 import { useThreadsInfinite } from "@/app/hooks/useThreadsInfinite";
 import { useFeatureFlag } from "@/src/shared/lib/feature-flags";
-import { mapTabHref } from "@/app/utils/threadNavigation";
+import {
+  mapTabHref,
+  newConversationTarget,
+} from "@/app/utils/threadNavigation";
+import useMapStore from "../store/mapStore";
 
 const isPrototype = process.env.NEXT_PUBLIC_PROTOTYPE_MODE === "true";
 const DISCLAIMER_STORAGE_KEY = "gnw_disclaimer_dismissed_v2";
@@ -56,6 +60,15 @@ function PageHeader() {
   const onMap = pathname.startsWith("/app");
   const onDashboards = pathname.startsWith("/dashboards");
   const dashboardFeatureEnabled = useFeatureFlag("dashboard");
+
+  const newConvo = newConversationTarget(pathname, dashboardFeatureEnabled);
+  // Mirrors the /app NewThread mount reset. In place because the dashboard
+  // page hosts its own chat panel and its URL doesn't carry the conversation
+  // (ADR-003) — navigating would leave the page the user is working on.
+  const startNewConversationInPlace = () => {
+    useChatStore.getState().reset();
+    useMapStore.getState().reset();
+  };
 
   const currentThread = currentThreadId
     ? threads.find((t) => t.id === currentThreadId)
@@ -261,18 +274,32 @@ function PageHeader() {
             </Text>
           )}
           <Tooltip content="New conversation" showArrow>
-            <IconButton
-              asChild
-              size="xs"
-              variant="ghost"
-              color={inverseColor}
-              _hover={{ bg: inverseHoverBg }}
-              _focusVisible={focusRing}
-            >
-              <Link href="/app" aria-label="New conversation">
+            {newConvo.kind === "reset-in-place" ? (
+              <IconButton
+                size="xs"
+                variant="ghost"
+                color={inverseColor}
+                _hover={{ bg: inverseHoverBg }}
+                _focusVisible={focusRing}
+                aria-label="New conversation"
+                onClick={startNewConversationInPlace}
+              >
                 <PlusIcon size={16} />
-              </Link>
-            </IconButton>
+              </IconButton>
+            ) : (
+              <IconButton
+                asChild
+                size="xs"
+                variant="ghost"
+                color={inverseColor}
+                _hover={{ bg: inverseHoverBg }}
+                _focusVisible={focusRing}
+              >
+                <Link href={newConvo.href} aria-label="New conversation">
+                  <PlusIcon size={16} />
+                </Link>
+              </IconButton>
+            )}
           </Tooltip>
         </Flex>
       </Flex>

--- a/app/components/PageHeader.tsx
+++ b/app/components/PageHeader.tsx
@@ -118,7 +118,10 @@ function PageHeader() {
       color={isPrototype ? "#1f2937" : "#131E47"}
       borderTop={isPrototype ? undefined : "4px solid #E3F37F"}
       zIndex={1300}
-      position="relative"
+      // Pinned to the viewport top on scrolling pages (e.g. dashboards);
+      // inert on the map layout, whose grid cells don't scroll.
+      position="sticky"
+      top={0}
     >
       <Flex gap="5" alignItems="center" minW={0}>
         <Flex gap="2" alignItems="center">

--- a/app/components/SamplePrompts.tsx
+++ b/app/components/SamplePrompts.tsx
@@ -21,7 +21,11 @@ export default function SamplePrompts() {
   const submitPrompt = async (prompt: string) => {
     const result = await sendMessage(prompt);
     if (result.isNew) {
-      const redirect = firstMessageRedirectPath(pathname, result.id);
+      const redirect = firstMessageRedirectPath(
+        pathname,
+        result.id,
+        window.location.search
+      );
       if (redirect) router.replace(redirect);
     }
   };

--- a/app/components/SamplePrompts.tsx
+++ b/app/components/SamplePrompts.tsx
@@ -2,13 +2,15 @@ import { Box } from "@chakra-ui/react";
 import { useEffect, useState } from "react";
 import { usePromptStore } from "../store/promptStore";
 import useChatStore from "../store/chatStore";
-import { useRouter } from "next/navigation";
+import { useRouter, usePathname } from "next/navigation";
+import { firstMessageRedirectPath } from "../utils/threadNavigation";
 
 export default function SamplePrompts() {
   const { prompts } = usePromptStore();
   const { sendMessage } = useChatStore();
   const [samplePrompts, setSamplePrompts] = useState<string[]>([]);
   const router = useRouter();
+  const pathname = usePathname();
 
   useEffect(() => {
     if (prompts.length > 0 && samplePrompts.length === 0) {
@@ -19,7 +21,8 @@ export default function SamplePrompts() {
   const submitPrompt = async (prompt: string) => {
     const result = await sendMessage(prompt);
     if (result.isNew) {
-      router.replace(`/app/threads/${result.id}`);
+      const redirect = firstMessageRedirectPath(pathname, result.id);
+      if (redirect) router.replace(redirect);
     }
   };
   function getRandomFromArray<T>(arr: T[], count: number): T[] {

--- a/app/components/WidgetMessage.tsx
+++ b/app/components/WidgetMessage.tsx
@@ -38,6 +38,7 @@ import TableWidget from "./widgets/TableWidget";
 import DatasetCardWidget from "./widgets/DatasetCardWidget";
 import ChartWidget, { AXIS_FIT_TYPES } from "./widgets/ChartWidget";
 import { WidgetIcons } from "../utils/widgetIcons";
+import AddToDashboardToggle from "@/src/features/dashboards/ui/AddToDashboardToggle";
 import InsightProvenanceDrawer from "./InsightProvenanceDrawer";
 import VisualizationDisclaimer from "./VisualizationDisclaimer";
 import WidgetErrorBoundary from "./widgets/WidgetErrorBoundary";
@@ -421,6 +422,11 @@ export default function WidgetMessage({
                 </Menu.Content>
               </Menu.Positioner>
             </Menu.Root>
+            {/* Chat cards only: workspace/dashboard cards manage widgets via
+                their own shell (drag/resize/remove), so no toggle there. */}
+            {!inWorkspace && widget.insightId && (
+              <AddToDashboardToggle insightId={widget.insightId} />
+            )}
           </Flex>
         )}
         {showDisclaimer && !inWorkspace && <VisualizationDisclaimer />}

--- a/app/components/WidgetMessage.tsx
+++ b/app/components/WidgetMessage.tsx
@@ -175,7 +175,9 @@ export default function WidgetMessage({
     <Box
       rounded="md"
       border="1px solid"
-      borderColor={inWorkspace ? "border.emphasized" : "blue.fg"}
+      // Workspace/dashboard cards sit inside the light-blue Analysis shell,
+      // whose design pairs the white card with the blue-10 border (#DDE2F5).
+      borderColor={inWorkspace ? "#DDE2F5" : "blue.fg"}
       overflow="hidden"
       bg="neutral.100"
     >

--- a/app/components/legend/LayerEntry.tsx
+++ b/app/components/legend/LayerEntry.tsx
@@ -36,6 +36,8 @@ export function LayerEntry(
     onLayerAction: LayerActionHandler;
     expanded?: boolean;
     onToggleExpand?: () => void;
+    /** Tighter type and spacing for small hosts (dashboard map widgets). */
+    compact?: boolean;
   }
 ) {
   const {
@@ -52,6 +54,7 @@ export function LayerEntry(
     info,
     expanded = false,
     onToggleExpand,
+    compact,
   } = props;
 
   return (
@@ -88,7 +91,7 @@ export function LayerEntry(
           >
             <CaretDownIcon size={12} />
           </IconButton>
-          <Heading as="h3" size="sm" m={0} truncate>
+          <Heading as="h3" size={compact ? "xs" : "sm"} m={0} truncate>
             {title}
           </Heading>
         </Flex>
@@ -99,8 +102,8 @@ export function LayerEntry(
           flexShrink={0}
           css={{
             "& button": {
-              h: 6,
-              minW: 6,
+              h: compact ? 5 : 6,
+              minW: compact ? 5 : 6,
             },
           }}
         >
@@ -156,7 +159,12 @@ export function LayerEntry(
       {/* Collapsible body — symbology → params → within → notes */}
       <Collapsible.Root open={expanded}>
         <Collapsible.Content css={{ transition: "height 0.15s ease" }}>
-          <Flex flexDir="column" gap={2} pt={2} pr={4}>
+          <Flex
+            flexDir="column"
+            gap={compact ? 1.5 : 2}
+            pt={compact ? 1.5 : 2}
+            pr={compact ? 2 : 4}
+          >
             {symbology}
             {params && params.length > 0 && (
               <Flex gap={1} flexWrap="wrap" alignItems="center">

--- a/app/components/legend/Legend.tsx
+++ b/app/components/legend/Legend.tsx
@@ -31,6 +31,8 @@ interface LegendProps {
   onLayerAction?: LayerActionHandler;
   aois?: LegendAoi[];
   onRemoveAoi?: (layerId: string) => void;
+  /** Tighter type and spacing for small hosts (dashboard map widgets). */
+  compact?: boolean;
 }
 
 /**
@@ -40,7 +42,7 @@ interface LegendProps {
  * @param props.layers - Array of LegendLayer objects to display.
  */
 export function Legend(props: LegendProps) {
-  const { layers, onLayerAction, aois, onRemoveAoi } = props;
+  const { layers, onLayerAction, aois, onRemoveAoi, compact } = props;
 
   // Controls whether the whole legend body is collapsed to just the header.
   const [isCollapsed, setIsCollapsed] = useState(false);
@@ -114,7 +116,7 @@ export function Legend(props: LegendProps) {
       {/* Always-visible header — 28px section header per Figma */}
       <Flex
         h="28px"
-        px="16px"
+        px={compact ? "12px" : "16px"}
         py="6px"
         gap="8px"
         alignItems="center"
@@ -173,12 +175,13 @@ export function Legend(props: LegendProps) {
               m={0}
               w="100%"
               overflowY="auto"
-              maxH="200px"
+              maxH={compact ? "160px" : "200px"}
             >
               {layers.map((item) => (
                 <Item
                   key={item.id}
                   item={item}
+                  compact={compact}
                   expanded={expandedIds.has(item.id)}
                   onToggleExpand={() =>
                     setExpandedIds((prev) => {
@@ -239,8 +242,9 @@ function Item(props: {
   expanded: boolean;
   onToggleExpand: () => void;
   onLayerAction: LayerActionHandler;
+  compact?: boolean;
 }) {
-  const { item, expanded, onToggleExpand, onLayerAction } = props;
+  const { item, expanded, onToggleExpand, onLayerAction, compact } = props;
   const dragControls = useDragControls();
 
   return (
@@ -249,7 +253,7 @@ function Item(props: {
       id={item}
       dragListener={false}
       dragControls={dragControls}
-      p={2}
+      p={compact ? 1.5 : 2}
       pl={1}
       display="flex"
       gap={1}
@@ -272,6 +276,7 @@ function Item(props: {
       </IconButton>
       <LayerEntry
         {...item}
+        compact={compact}
         expanded={expanded}
         onToggleExpand={onToggleExpand}
         onLayerAction={onLayerAction}

--- a/app/components/legend/useLegendHook.tsx
+++ b/app/components/legend/useLegendHook.tsx
@@ -35,8 +35,10 @@ const PARAMETER_FORMATTERS: Record<string, (v: unknown) => string> = {
 /**
  * Converts a layer's raw parameters object into structured LegendParam chips.
  * Each entry becomes a { label, value } pair rendered as a badge in the card.
+ * Exported for the dashboard map-widget legend, which builds its entries from
+ * widget configs instead of mapStore layers.
  */
-function buildParams(
+export function buildParams(
   params: Record<string, unknown>,
   yearParam?: YearParam
 ): LegendParam[] {
@@ -56,7 +58,7 @@ function buildParams(
   return result;
 }
 
-function renderLegendSymbology(legend: DatasetLegendConfig) {
+export function renderLegendSymbology(legend: DatasetLegendConfig) {
   const { type, items, color, unit } = legend;
 
   return type === "categorical" && items ? (

--- a/app/components/map/layers/GeoJsonLayers.tsx
+++ b/app/components/map/layers/GeoJsonLayers.tsx
@@ -12,7 +12,12 @@ import {
 import { BasemapTheme } from "../BasemapSelector";
 import bbox from "@turf/bbox";
 import { createBboxPolygon, unionAoiBboxes } from "@/app/utils/bboxUtils";
-import { aoiBoundaryColors, aoiCasingPaint, aoiLinePaint } from "./aoiStyle";
+import {
+  aoiBboxLinePaint,
+  aoiBoundaryColors,
+  aoiCasingPaint,
+  aoiLinePaint,
+} from "./aoiStyle";
 
 // Compute the combined bbox of a list of features
 function computeCombinedBbox(
@@ -223,11 +228,7 @@ function GeoJsonLayerGroup({
           <MapLayer
             id={`bbox-line-${groupId}-solid`}
             type="line"
-            paint={{
-              "line-color": mainLineColor,
-              "line-width": 1.5,
-              "line-opacity": 0.75 * lineOpacity,
-            }}
+            paint={aoiBboxLinePaint(mainLineColor, lineOpacity)}
           />
         </Source>
       )}

--- a/app/components/map/layers/GeoJsonLayers.tsx
+++ b/app/components/map/layers/GeoJsonLayers.tsx
@@ -12,6 +12,7 @@ import {
 import { BasemapTheme } from "../BasemapSelector";
 import bbox from "@turf/bbox";
 import { createBboxPolygon, unionAoiBboxes } from "@/app/utils/bboxUtils";
+import { aoiBoundaryColors, aoiCasingPaint, aoiLinePaint } from "./aoiStyle";
 
 // Compute the combined bbox of a list of features
 function computeCombinedBbox(
@@ -129,11 +130,10 @@ function GeoJsonLayerGroup({
 
   const isMultiArea = !!layer.selectionName;
 
-  // On dark basemaps (dark, satellite) boundaries use white lines + blue casing
-  // to maximise contrast. On light basemaps the colours are inverted.
-  const casingColor = basemapTheme === "dark" ? "#172B7A" : "#FFFFFF";
-  const mainLineColor =
-    basemapTheme === "dark" ? "#FFFFFF" : isMultiArea ? "#8EA4E8" : "#172B7A";
+  const { casingColor, mainLineColor } = aoiBoundaryColors(
+    basemapTheme,
+    isMultiArea
+  );
 
   const handleRemove = () => removeLayer(layer.id);
   // Prefer backend-provided bbox (handles antimeridian); fall back to turf.
@@ -180,21 +180,7 @@ function GeoJsonLayerGroup({
             <MapLayer
               id={casingLayerId}
               type="line"
-              paint={{
-                "line-color": casingColor,
-                "line-width": [
-                  "interpolate",
-                  ["linear"],
-                  ["zoom"],
-                  3,
-                  3.5,
-                  6,
-                  7,
-                  10,
-                  11,
-                ],
-                "line-opacity": lineOpacity,
-              }}
+              paint={aoiCasingPaint(casingColor, lineOpacity)}
               filter={[
                 "any",
                 ["==", ["geometry-type"], "Polygon"],
@@ -204,21 +190,7 @@ function GeoJsonLayerGroup({
             <MapLayer
               id={lineLayerId}
               type="line"
-              paint={{
-                "line-color": mainLineColor,
-                "line-width": [
-                  "interpolate",
-                  ["linear"],
-                  ["zoom"],
-                  3,
-                  1,
-                  6,
-                  1.5,
-                  10,
-                  2,
-                ],
-                "line-opacity": lineOpacity,
-              }}
+              paint={aoiLinePaint(mainLineColor, lineOpacity)}
               filter={[
                 "any",
                 ["==", ["geometry-type"], "Polygon"],

--- a/app/components/map/layers/aoiStyle.ts
+++ b/app/components/map/layers/aoiStyle.ts
@@ -1,0 +1,39 @@
+import type { LineLayerSpecification } from "maplibre-gl";
+
+import type { BasemapTheme } from "../BasemapSelector";
+
+type LinePaint = NonNullable<LineLayerSpecification["paint"]>;
+
+/**
+ * AOI boundary styling shared by the explorer map (GeoJsonLayers) and the
+ * dashboard map widgets: a wide contrasting casing rendered beneath the main
+ * line, both with zoom-interpolated widths.
+ */
+
+// On dark basemaps (dark, satellite) boundaries use white lines + blue casing
+// to maximise contrast. On light basemaps the colours are inverted.
+export function aoiBoundaryColors(
+  basemapTheme: BasemapTheme,
+  isMultiArea = false
+) {
+  const casingColor = basemapTheme === "dark" ? "#172B7A" : "#FFFFFF";
+  const mainLineColor =
+    basemapTheme === "dark" ? "#FFFFFF" : isMultiArea ? "#8EA4E8" : "#172B7A";
+  return { casingColor, mainLineColor };
+}
+
+export function aoiCasingPaint(color: string, opacity = 1): LinePaint {
+  return {
+    "line-color": color,
+    "line-width": ["interpolate", ["linear"], ["zoom"], 3, 3.5, 6, 7, 10, 11],
+    "line-opacity": opacity,
+  };
+}
+
+export function aoiLinePaint(color: string, opacity = 1): LinePaint {
+  return {
+    "line-color": color,
+    "line-width": ["interpolate", ["linear"], ["zoom"], 3, 1, 6, 1.5, 10, 2],
+    "line-opacity": opacity,
+  };
+}

--- a/app/components/map/layers/aoiStyle.ts
+++ b/app/components/map/layers/aoiStyle.ts
@@ -37,3 +37,12 @@ export function aoiLinePaint(color: string, opacity = 1): LinePaint {
     "line-opacity": opacity,
   };
 }
+
+/** The solid rectangle drawn around an AOI's bounding box. */
+export function aoiBboxLinePaint(color: string, opacity = 1): LinePaint {
+  return {
+    "line-color": color,
+    "line-width": 1.5,
+    "line-opacity": 0.75 * opacity,
+  };
+}

--- a/app/dashboards/[id]/page.tsx
+++ b/app/dashboards/[id]/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import ConversationHistoryDrawer from "@/app/components/ConversationHistoryDrawer";
 import PageHeader from "@/app/components/PageHeader";
 import { useAuthGuard } from "@/app/hooks/useAuthGuard";
 import {
@@ -14,6 +15,7 @@ export default function DashboardDetailRoute() {
   return (
     <DashboardFeatureGate>
       <PageHeader />
+      <ConversationHistoryDrawer />
       <DashboardDetailPage />
     </DashboardFeatureGate>
   );

--- a/app/dashboards/page.tsx
+++ b/app/dashboards/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import ConversationHistoryDrawer from "@/app/components/ConversationHistoryDrawer";
 import PageHeader from "@/app/components/PageHeader";
 import { useAuthGuard } from "@/app/hooks/useAuthGuard";
 import {
@@ -14,6 +15,7 @@ export default function DashboardsRoute() {
   return (
     <DashboardFeatureGate>
       <PageHeader />
+      <ConversationHistoryDrawer />
       <DashboardsPage />
     </DashboardFeatureGate>
   );

--- a/app/explorationLayout.ts
+++ b/app/explorationLayout.ts
@@ -73,6 +73,19 @@ export function getMapAreaToolsLeftPx(
   return 0;
 }
 
+/**
+ * Left inset for dashboard page content beside the fixed chat overlay.
+ * Only the full-size panel needs clearance — it spans the full viewport
+ * height, so the centered content must re-center in the remaining space.
+ * The compact panel is bottom-anchored and intentionally allowed to float
+ * over the content, matching its behaviour over the map.
+ */
+export function getDashboardContentLeftPx(isChatFullSize: boolean): number {
+  return isChatFullSize
+    ? FULLSIZE_CHAT_PANEL_WIDTH_PX + EXPLORATION_PANEL_GAP_PX
+    : 0;
+}
+
 /** Left offset for map feedback toasts (selection mode, draw validation). */
 export function getMapFeedbackLeftPx(
   isChatFullSize: boolean,

--- a/app/lib/__tests__/parse-stream-message.test.ts
+++ b/app/lib/__tests__/parse-stream-message.test.ts
@@ -106,6 +106,22 @@ describe("parseStreamMessage — tool response_metadata write signals", () => {
     });
   });
 
+  it("carries insight_updated through on tool messages", () => {
+    // update_insight_display (rename a chart, change its type) signals with
+    // insight_updated — the dashboard page relies on it to refetch widgets
+    // whose embedded insight changed.
+    const msg = parseStreamMessage(
+      toolUpdate("update_insight_display", {
+        msg_type: "insight_updated",
+        insight_id: "ins-1",
+      }),
+      "tools",
+      TS
+    );
+    expect(msg?.type).toBe("tool");
+    expect(msg?.msg_type).toBe("insight_updated");
+  });
+
   it("keeps the signal when the tool message is classified as an error", () => {
     const update = toolUpdate("add_to_dashboard", {
       msg_type: "dashboard_updated",

--- a/app/lib/__tests__/parse-stream-message.test.ts
+++ b/app/lib/__tests__/parse-stream-message.test.ts
@@ -106,6 +106,17 @@ describe("parseStreamMessage — tool response_metadata write signals", () => {
     });
   });
 
+  it("extracts a state-level insight_id on tool messages", () => {
+    // generate_insights streams the persisted insight uuid alongside
+    // charts_data — the handle for the chat-side "Add to dashboard" toggle.
+    const update = toolUpdate("generate_insights");
+    (update as unknown as { insight_id: string }).insight_id = "ins-1";
+
+    const msg = parseStreamMessage(update, "tools", TS);
+    expect(msg?.type).toBe("tool");
+    expect(msg?.insight_id).toBe("ins-1");
+  });
+
   it("carries insight_updated through on tool messages", () => {
     // update_insight_display (rename a chart, change its type) signals with
     // insight_updated — the dashboard page relies on it to refetch widgets

--- a/app/lib/__tests__/parse-stream-message.test.ts
+++ b/app/lib/__tests__/parse-stream-message.test.ts
@@ -33,6 +33,58 @@ function agentUpdate(
   } as unknown as LangChainUpdate;
 }
 
+/**
+ * Build a minimal tool-result LangChainUpdate with the given
+ * response_metadata (how the backend signals writes like dashboard_updated).
+ */
+function toolUpdate(
+  name: string,
+  responseMetadata: Record<string, unknown> = {}
+): LangChainUpdate {
+  return {
+    messages: [
+      {
+        lc: 1,
+        type: "constructor",
+        id: ["x"],
+        kwargs: {
+          content: "ok",
+          response_metadata: responseMetadata,
+          type: "tool",
+          name,
+          id: "msg-1",
+        },
+      },
+    ],
+  } as unknown as LangChainUpdate;
+}
+
+describe("parseStreamMessage — tool response_metadata write signals", () => {
+  it("carries msg_type and dashboard_id through on tool messages", () => {
+    const msg = parseStreamMessage(
+      toolUpdate("add_to_dashboard", {
+        msg_type: "dashboard_updated",
+        dashboard_id: "5c9f7dd8-0000-0000-0000-000000000000",
+      }),
+      "tools",
+      TS
+    );
+    expect(msg).toMatchObject({
+      type: "tool",
+      name: "add_to_dashboard",
+      msg_type: "dashboard_updated",
+      dashboard_id: "5c9f7dd8-0000-0000-0000-000000000000",
+    });
+  });
+
+  it("leaves the signal fields undefined for ordinary tool messages", () => {
+    const msg = parseStreamMessage(toolUpdate("pull_data"), "tools", TS);
+    expect(msg?.type).toBe("tool");
+    expect(msg?.msg_type).toBeUndefined();
+    expect(msg?.dashboard_id).toBeUndefined();
+  });
+});
+
 describe("parseStreamMessage — agent tool_calls", () => {
   it("attaches tool_calls names to a text message", () => {
     const msg = parseStreamMessage(

--- a/app/lib/__tests__/parse-stream-message.test.ts
+++ b/app/lib/__tests__/parse-stream-message.test.ts
@@ -83,6 +83,42 @@ describe("parseStreamMessage — tool response_metadata write signals", () => {
     expect(msg?.msg_type).toBeUndefined();
     expect(msg?.dashboard_id).toBeUndefined();
   });
+
+  it("finds the signal on an earlier message when the update ends with narration", () => {
+    // The signal-bearing tool result and the agent's follow-up can arrive in
+    // one update; only the last message decides the StreamMessage type, but
+    // the write signal must not be lost.
+    const signalBearing = toolUpdate("add_to_dashboard", {
+      msg_type: "dashboard_updated",
+      dashboard_id: "dash-1",
+    }).messages[0];
+    const narration = agentUpdate("Added it to your dashboard.").messages[0];
+    const update = {
+      messages: [signalBearing, narration],
+    } as unknown as LangChainUpdate;
+
+    const msg = parseStreamMessage(update, "agent", TS);
+    expect(msg).toMatchObject({
+      type: "text",
+      text: "Added it to your dashboard.",
+      msg_type: "dashboard_updated",
+      dashboard_id: "dash-1",
+    });
+  });
+
+  it("keeps the signal when the tool message is classified as an error", () => {
+    const update = toolUpdate("add_to_dashboard", {
+      msg_type: "dashboard_updated",
+      dashboard_id: "dash-1",
+    });
+    // Content mentioning "Error:" routes the message down the error branch.
+    update.messages[0].kwargs.content = "Recovered from Error: retried ok";
+
+    const msg = parseStreamMessage(update, "tools", TS);
+    expect(msg?.type).toBe("error");
+    expect(msg?.msg_type).toBe("dashboard_updated");
+    expect(msg?.dashboard_id).toBe("dash-1");
+  });
 });
 
 describe("parseStreamMessage — agent tool_calls", () => {

--- a/app/lib/parse-stream-message.ts
+++ b/app/lib/parse-stream-message.ts
@@ -82,6 +82,7 @@ export function parseStreamMessage(
       suggested_datasets: langChainMessage.suggested_datasets || undefined,
       insights: langChainMessage.insights || [],
       charts_data: langChainMessage.charts_data || [],
+      insight_id: langChainMessage.insight_id || undefined,
       codeact_parts: langChainMessage.codeact_parts || [],
       source_urls: langChainMessage.source_urls || [],
       cited_articles: langChainMessage.cited_articles || undefined,

--- a/app/lib/parse-stream-message.ts
+++ b/app/lib/parse-stream-message.ts
@@ -22,8 +22,9 @@ export function parseStreamMessage(
   const content = kwargs.content;
   // Extract trace identifier from response metadata (canonical field)
   const responseMetadata =
-    (kwargs.response_metadata as { trace_id?: string } | undefined) ||
-    undefined;
+    (kwargs.response_metadata as
+      | { trace_id?: string; msg_type?: string; dashboard_id?: string }
+      | undefined) || undefined;
   const traceId = responseMetadata?.trace_id;
 
   if (messageType === "human") {
@@ -69,6 +70,10 @@ export function parseStreamMessage(
       aoi_selection: langChainMessage.aoi_selection || undefined,
       timestamp: timestamp.toISOString(),
       trace_id: traceId,
+      // Write signals (e.g. dashboard_updated) ride along so the client can
+      // refetch what the agent just changed.
+      msg_type: responseMetadata?.msg_type,
+      dashboard_id: responseMetadata?.dashboard_id,
     };
   } else if (messageType === "agent") {
     // For AI messages, handle different content formats

--- a/app/lib/parse-stream-message.ts
+++ b/app/lib/parse-stream-message.ts
@@ -27,6 +27,25 @@ export function parseStreamMessage(
       | undefined) || undefined;
   const traceId = responseMetadata?.trace_id;
 
+  // A write signal (e.g. dashboard_updated) rides on a tool message's
+  // response_metadata, but that message is not necessarily the last one in
+  // the update (the agent's narration can follow it in the same update), and
+  // the carrying message may be classified as an error. Scan every message so
+  // the signal rides on whatever StreamMessage this update produces.
+  let writeSignal: { msg_type: string; dashboard_id?: string } | undefined;
+  for (const message of langChainMessage.messages ?? []) {
+    const meta = message?.kwargs?.response_metadata as
+      | { msg_type?: string; dashboard_id?: string }
+      | undefined;
+    if (meta?.msg_type) {
+      writeSignal = {
+        msg_type: meta.msg_type,
+        dashboard_id: meta.dashboard_id,
+      };
+      break;
+    }
+  }
+
   if (messageType === "human") {
     return {
       type: "human",
@@ -50,6 +69,7 @@ export function parseStreamMessage(
         content: typeof content === "string" ? content : String(content),
         timestamp: timestamp.toISOString(),
         trace_id: traceId,
+        ...(writeSignal ?? {}),
       };
     }
 
@@ -72,8 +92,8 @@ export function parseStreamMessage(
       trace_id: traceId,
       // Write signals (e.g. dashboard_updated) ride along so the client can
       // refetch what the agent just changed.
-      msg_type: responseMetadata?.msg_type,
-      dashboard_id: responseMetadata?.dashboard_id,
+      msg_type: writeSignal?.msg_type,
+      dashboard_id: writeSignal?.dashboard_id,
     };
   } else if (messageType === "agent") {
     // For AI messages, handle different content formats
@@ -133,6 +153,7 @@ export function parseStreamMessage(
         timestamp: timestamp.toISOString(),
         trace_id: traceId,
         ...(toolCalls.length ? { tool_calls: toolCalls } : {}),
+        ...(writeSignal ?? {}),
       };
     }
 

--- a/app/sidebar.tsx
+++ b/app/sidebar.tsx
@@ -1,4 +1,5 @@
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { usePathname } from "next/navigation";
 import {
   Button,
   Flex,
@@ -28,13 +29,32 @@ import {
 import useSidebarStore from "./store/sidebarStore";
 import useAuthStore from "./store/authStore";
 import useChatStore from "./store/chatStore";
+import useMapStore from "./store/mapStore";
 import { useLogout } from "./hooks/useLogout";
 import ThreadActionsMenu from "./components/ThreadActionsMenu";
 import LclLogo from "./components/LclLogo";
 import { useThreadsInfinite } from "./hooks/useThreadsInfinite";
 import { useIntersectionObserver } from "./hooks/useIntersectionObserver";
+import { useFeatureFlag } from "@/src/shared/lib/feature-flags";
+import {
+  newConversationTarget,
+  threadClickTarget,
+} from "./utils/threadNavigation";
 
-function ThreadLink(props: LinkProps & { isActive?: boolean; href: string }) {
+/**
+ * The current `location.search`, captured once on mount (mirroring
+ * `useFeatureFlag`): the URL only exists client-side, and the first-message
+ * thread rewrite can drop query params mid-session — the mount-time value is
+ * the trustworthy one.
+ */
+function useMountSearch(): string | null {
+  const [search] = useState(() =>
+    typeof window === "undefined" ? null : window.location.search
+  );
+  return search;
+}
+
+function ThreadLink(props: LinkProps & { isActive?: boolean; href?: string }) {
   const { href, children, isActive, ...rest } = props;
   return (
     <ChLink
@@ -47,6 +67,7 @@ function ThreadLink(props: LinkProps & { isActive?: boolean; href: string }) {
       display="block"
       flex="1"
       outline="none"
+      cursor="pointer"
       {...(isActive
         ? {
             color: "primary.fg",
@@ -55,9 +76,18 @@ function ThreadLink(props: LinkProps & { isActive?: boolean; href: string }) {
       {...rest}
       asChild
     >
-      <Link href={href} style={{ display: "block", width: "100%" }}>
-        {children}
-      </Link>
+      {href ? (
+        <Link href={href} style={{ display: "block", width: "100%" }}>
+          {children}
+        </Link>
+      ) : (
+        <button
+          type="button"
+          style={{ display: "block", width: "100%", textAlign: "left" }}
+        >
+          {children}
+        </button>
+      )}
     </ChLink>
   );
 }
@@ -81,6 +111,22 @@ function ThreadSection({
   footer?: React.ReactNode;
 }) {
   const { toggleSidebar } = useSidebarStore();
+  const pathname = usePathname();
+  const search = useMountSearch();
+
+  // On a dashboard detail page the conversation isn't in the URL (ADR-003),
+  // so resuming one loads it into the global chat store in place — the same
+  // reset the map's thread page performs on navigation, minus the navigation.
+  const openThreadInPlace = (threadId: string) => {
+    const chat = useChatStore.getState();
+    if (chat.currentThreadId !== threadId) {
+      chat.reset();
+      useMapStore.getState().reset();
+      chat.fetchThread(threadId);
+    }
+    toggleSidebar();
+  };
+
   if (!threads.length && !footer) return null;
   return (
     <Accordion.Item value={value} border="none">
@@ -100,6 +146,7 @@ function ThreadSection({
         <Stack gap="1" mt="1">
           {threads.map((thread) => {
             const isActive = currentThreadId === thread.id;
+            const target = threadClickTarget(pathname, thread.id, search);
             return (
               <Flex
                 key={thread.id}
@@ -121,14 +168,24 @@ function ThreadSection({
                 }}
                 {...(isActive ? { bg: "bg", color: "blue.fg" } : {})}
               >
-                <ThreadLink
-                  href={`/app/threads/${thread.id}`}
-                  isActive={isActive}
-                  _hover={{ textDecor: "none" }}
-                  onClick={toggleSidebar}
-                >
-                  {thread.name}
-                </ThreadLink>
+                {target.kind === "navigate" ? (
+                  <ThreadLink
+                    href={target.href}
+                    isActive={isActive}
+                    _hover={{ textDecor: "none" }}
+                    onClick={toggleSidebar}
+                  >
+                    {thread.name}
+                  </ThreadLink>
+                ) : (
+                  <ThreadLink
+                    isActive={isActive}
+                    _hover={{ textDecor: "none" }}
+                    onClick={() => openThreadInPlace(thread.id)}
+                  >
+                    {thread.name}
+                  </ThreadLink>
+                )}
                 <div onClick={(e) => e.stopPropagation()}>
                   <ThreadActionsMenu thread={thread} />
                 </div>
@@ -166,6 +223,17 @@ export function Sidebar() {
   }, [fetchApiStatus]);
 
   const { logout, isLoggingOut } = useLogout();
+
+  const pathname = usePathname();
+  const dashboardFeatureEnabled = useFeatureFlag("dashboard");
+  const newConvo = newConversationTarget(pathname, dashboardFeatureEnabled);
+  // Mirrors PageHeader's in-place reset: a dashboard detail page hosts its
+  // own chat panel, so starting a new conversation must not navigate away.
+  const startNewConversationInPlace = () => {
+    useChatStore.getState().reset();
+    useMapStore.getState().reset();
+    toggleSidebar();
+  };
 
   const hasTodayThreads = threadGroups.today.length > 0;
   const hasPreviousWeekThreads = threadGroups.previousWeek.length > 0;
@@ -230,19 +298,33 @@ export function Sidebar() {
         bg="bg.subtle"
         boxShadow="xs"
       >
-        <Button
-          asChild
-          variant="outline"
-          colorPalette="primary"
-          size="sm"
-          w={{ base: "full", md: "auto" }}
-          onClick={toggleSidebar}
-        >
-          <Link href="/app" aria-label="New conversation">
+        {newConvo.kind === "reset-in-place" ? (
+          <Button
+            variant="outline"
+            colorPalette="primary"
+            size="sm"
+            w={{ base: "full", md: "auto" }}
+            aria-label="New conversation"
+            onClick={startNewConversationInPlace}
+          >
             New Conversation
             <NotePencilIcon />
-          </Link>
-        </Button>
+          </Button>
+        ) : (
+          <Button
+            asChild
+            variant="outline"
+            colorPalette="primary"
+            size="sm"
+            w={{ base: "full", md: "auto" }}
+            onClick={toggleSidebar}
+          >
+            <Link href={newConvo.href} aria-label="New conversation">
+              New Conversation
+              <NotePencilIcon />
+            </Link>
+          </Button>
+        )}
         <Tooltip
           content="Close sidebar"
           positioning={{ placement: "right" }}

--- a/app/store/__tests__/chatStore.test.ts
+++ b/app/store/__tests__/chatStore.test.ts
@@ -20,6 +20,7 @@ vi.mock("@/app/components/ui/toaster", () => ({
 }));
 
 import useChatStore from "../chatStore";
+import useViewContextStore from "../viewContextStore";
 import { apiFetch } from "@/app/lib/api-client";
 import type {
   AnalyseSuggestion,
@@ -124,6 +125,53 @@ describe("chatStore cancellation", () => {
       expect(messages.some((m) => m.type === "stopped")).toBe(false);
       expect(useChatStore.getState().isLoading).toBe(false);
     });
+  });
+});
+
+describe("chatStore view_context", () => {
+  beforeEach(() => {
+    useChatStore.getState().reset();
+    useViewContextStore.setState({ viewContext: null });
+    vi.mocked(apiFetch).mockReset();
+    // A failed response ends sendMessage on its error path immediately; the
+    // request body we assert on has already been built by then.
+    vi.mocked(apiFetch).mockResolvedValue({
+      ok: false,
+      status: 500,
+      headers: new Headers(),
+    } as unknown as Response);
+  });
+
+  afterEach(() => {
+    useViewContextStore.setState({ viewContext: null });
+    vi.clearAllMocks();
+  });
+
+  const sentBody = (): Record<string, unknown> => {
+    const init = vi.mocked(apiFetch).mock.calls[0]?.[1];
+    return JSON.parse((init?.body as string) ?? "{}");
+  };
+
+  it("includes view_context in the POST body when a surface is registered", async () => {
+    useViewContextStore.getState().setViewContext({
+      page: "dashboard",
+      dashboard_id: "5c9f7dd8-0000-0000-0000-000000000000",
+      dashboard_name: "Paraná",
+    });
+
+    await useChatStore.getState().sendMessage("refine this dashboard");
+
+    expect(sentBody().view_context).toEqual({
+      page: "dashboard",
+      dashboard_id: "5c9f7dd8-0000-0000-0000-000000000000",
+      dashboard_name: "Paraná",
+    });
+  });
+
+  it("omits view_context when no surface has registered", async () => {
+    await useChatStore.getState().sendMessage("hello");
+
+    expect(sentBody()).not.toHaveProperty("view_context");
   });
 });
 

--- a/app/store/chat-tools/__tests__/generateInsights.test.ts
+++ b/app/store/chat-tools/__tests__/generateInsights.test.ts
@@ -74,6 +74,26 @@ describe("generateInsightsTool", () => {
     expect(pendingBatch[0].title).toBe("Tree Cover");
   });
 
+  it("attaches the streamed insight_id to every chart's widget", () => {
+    generateInsightsTool(
+      baseMessage({
+        charts_data: [chartData("Tree Cover"), chartData("Fires")],
+        insight_id: "ins-1",
+      }),
+      addMessage
+    );
+    const { insights } = useInsightStore.getState();
+    expect(insights.map((w) => w.insightId)).toEqual(["ins-1", "ins-1"]);
+  });
+
+  it("leaves insightId unset when the stream carries no insight_id", () => {
+    generateInsightsTool(
+      baseMessage({ charts_data: [chartData()] }),
+      addMessage
+    );
+    expect(useInsightStore.getState().insights[0].insightId).toBeUndefined();
+  });
+
   it("does nothing when charts_data is absent", () => {
     generateInsightsTool(baseMessage(), addMessage);
     expect(useInsightStore.getState().insights).toHaveLength(0);

--- a/app/store/chat-tools/generateInsights.ts
+++ b/app/store/chat-tools/generateInsights.ts
@@ -118,6 +118,11 @@ export function generateInsightsTool(
             source_urls: streamMessage.source_urls,
           },
           ...(hasParams ? { analysisParams } : {}),
+          // Shared by all charts of the analysis — the handle for the
+          // "Add to dashboard" toggle (REST widget add, no chat round trip).
+          ...(streamMessage.insight_id
+            ? { insightId: streamMessage.insight_id }
+            : {}),
         };
       });
 

--- a/app/store/chatStore.ts
+++ b/app/store/chatStore.ts
@@ -33,6 +33,7 @@ import { pickAoiTool } from "./chat-tools/pickAoi";
 import { pickDatasetTool } from "./chat-tools/pickDataset";
 import { pullDataTool } from "./chat-tools/pullData";
 import { queryClient } from "@/app/lib/query-client";
+import { dashboardKeys } from "@/src/features/dashboards/ui/dashboardQueries";
 import {
   showApiError,
   showError,
@@ -278,6 +279,13 @@ async function processStreamMessage(
   } else if (streamMessage.type === "tool") {
     if (streamMessage.cited_articles?.length) {
       mergeCitedArticles(streamMessage.cited_articles);
+    }
+
+    // The agent wrote to a dashboard (created it or added a widget) — refetch
+    // it. Keyed on the metadata signal rather than the tool name so new
+    // backend dashboard tools work without a dispatch entry here.
+    if (streamMessage.msg_type === "dashboard_updated") {
+      queryClient.invalidateQueries({ queryKey: dashboardKeys.all });
     }
 
     // Add tool step to reasoning display

--- a/app/store/chatStore.ts
+++ b/app/store/chatStore.ts
@@ -42,6 +42,7 @@ import useAuthStore from "./authStore";
 import useInsightStore from "./insightStore";
 import { effectiveAgentProfile } from "@/app/config/feature-flags";
 import useAgentProfileStore from "./agentProfileStore";
+import useViewContextStore from "./viewContextStore";
 
 interface ChatState {
   messages: ChatMessage[];
@@ -519,6 +520,7 @@ const useChatStore = create<ChatState & ChatActions>((set, get) => ({
       useAgentProfileStore.getState().agentProfile,
       useAuthStore.getState().userType
     );
+    const viewContext = useViewContextStore.getState().viewContext;
     const prompt: ChatPrompt = {
       query: message,
       query_type: queryType,
@@ -545,6 +547,9 @@ const useChatStore = create<ChatState & ChatActions>((set, get) => ({
         body: JSON.stringify({
           ...prompt,
           ...(Object.keys(ui_context).length > 0 && { ui_context }),
+          // Ambient surface snapshot (map vs dashboard) — lets the backend
+          // scope "here"/"this dashboard" per turn. See viewContextStore.
+          ...(viewContext && { view_context: viewContext }),
         }),
         signal: abortController.signal,
       });

--- a/app/store/chatStore.ts
+++ b/app/store/chatStore.ts
@@ -197,7 +197,13 @@ async function processStreamMessage(
   // dashboard tools work without a dispatch entry here; checked before the
   // type branching because the signal can ride on a tool result, an
   // error-classified message, or the agent narration in the same update.
-  if (streamMessage.msg_type === "dashboard_updated") {
+  // insight_updated (update_insight_display: chart renamed, retyped or
+  // remapped) also invalidates dashboards: the dashboard detail cache embeds
+  // the expanded insight, so its widgets render stale titles otherwise.
+  if (
+    streamMessage.msg_type === "dashboard_updated" ||
+    streamMessage.msg_type === "insight_updated"
+  ) {
     queryClient.invalidateQueries({ queryKey: dashboardKeys.all });
   }
 

--- a/app/store/chatStore.ts
+++ b/app/store/chatStore.ts
@@ -41,7 +41,11 @@ import {
 } from "@/app/hooks/useErrorHandler";
 import useAuthStore from "./authStore";
 import useInsightStore from "./insightStore";
-import { effectiveAgentProfile } from "@/app/config/feature-flags";
+import {
+  canUseFeatureFlags,
+  effectiveAgentProfile,
+  EXPERIMENTAL_PROFILE,
+} from "@/app/config/feature-flags";
 import useAgentProfileStore from "./agentProfileStore";
 import useViewContextStore from "./viewContextStore";
 
@@ -188,6 +192,15 @@ async function processStreamMessage(
   mergeCitedArticles: (articles: BlogArticle[]) => void,
   setGeneratingInsight: (generating: boolean) => void
 ) {
+  // The agent wrote to a dashboard (created it or added a widget) — refetch
+  // it. Keyed on the metadata signal rather than the tool name so new backend
+  // dashboard tools work without a dispatch entry here; checked before the
+  // type branching because the signal can ride on a tool result, an
+  // error-classified message, or the agent narration in the same update.
+  if (streamMessage.msg_type === "dashboard_updated") {
+    queryClient.invalidateQueries({ queryKey: dashboardKeys.all });
+  }
+
   // Capture standalone trace metadata sent as a separate stream message
   if (streamMessage.type === "other" && streamMessage.name === "trace") {
     if (streamMessage.trace_id) {
@@ -279,13 +292,6 @@ async function processStreamMessage(
   } else if (streamMessage.type === "tool") {
     if (streamMessage.cited_articles?.length) {
       mergeCitedArticles(streamMessage.cited_articles);
-    }
-
-    // The agent wrote to a dashboard (created it or added a widget) — refetch
-    // it. Keyed on the metadata signal rather than the tool name so new
-    // backend dashboard tools work without a dispatch entry here.
-    if (streamMessage.msg_type === "dashboard_updated") {
-      queryClient.invalidateQueries({ queryKey: dashboardKeys.all });
     }
 
     // Add tool step to reasoning display
@@ -524,11 +530,21 @@ const useChatStore = create<ChatState & ChatActions>((set, get) => ({
 
     // Send the agent profile as `ff` only when a profile is selected and the
     // user type is allowed to use feature flags (else the backend 403s).
-    const ff = effectiveAgentProfile(
-      useAgentProfileStore.getState().agentProfile,
-      useAuthStore.getState().userType
-    );
+    const userType = useAuthStore.getState().userType;
     const viewContext = useViewContextStore.getState().viewContext;
+    // The dashboard agent tools (create_dashboard / add_to_dashboard) live in
+    // the backend's experimental profile (dashboards-frontend-handoff.md), so
+    // on a dashboard surface default to it — otherwise "add this to my
+    // dashboard" silently no-ops unless the user happened to have visited
+    // with ?agent_profile=experimental. Same user-type gate as above.
+    const ff =
+      effectiveAgentProfile(
+        useAgentProfileStore.getState().agentProfile,
+        userType
+      ) ??
+      (viewContext?.page === "dashboard" && canUseFeatureFlags(userType)
+        ? EXPERIMENTAL_PROFILE
+        : null);
     const prompt: ChatPrompt = {
       query: message,
       query_type: queryType,

--- a/app/store/viewContextStore.ts
+++ b/app/store/viewContextStore.ts
@@ -1,0 +1,31 @@
+import { create } from "zustand";
+
+/**
+ * Ambient view state reported to the backend with every chat request
+ * (`ChatRequest.view_context`). Unlike `ui_context` (deliberate user
+ * actions), this is reference material: the backend renders a per-turn scope
+ * line from `page` (+ dashboard fields) and tools like `add_to_dashboard`
+ * default from it, but it is never merged into the agent's selections (see
+ * project-zeno docs/view-context-pages.md).
+ *
+ * Each chat surface sets its context on mount and does NOT clear it on
+ * unmount: effect ordering across a route transition is not guaranteed, so a
+ * departing page's cleanup could wipe the value the arriving page just set.
+ * A stale value can therefore only be read by a surface that failed to set
+ * its own on mount.
+ */
+export type ViewContext =
+  | { page: "map" }
+  | { page: "dashboard"; dashboard_id: string; dashboard_name?: string };
+
+interface ViewContextState {
+  viewContext: ViewContext | null;
+  setViewContext: (viewContext: ViewContext) => void;
+}
+
+const useViewContextStore = create<ViewContextState>((set) => ({
+  viewContext: null,
+  setViewContext: (viewContext) => set({ viewContext }),
+}));
+
+export default useViewContextStore;

--- a/app/types/chat.ts
+++ b/app/types/chat.ts
@@ -77,6 +77,10 @@ export interface InsightWidget {
   datasetName?: string;
   generation?: InsightGeneration; // Optional provenance for how the widget was generated
   analysisParams?: AnalysisParams; // Parameters used by the agent to produce this insight
+  // Persisted insight UUID (streamed with generate_insights). All charts of
+  // one analysis share it; it is the handle for REST widget adds
+  // (POST /api/dashboards/:id/widgets).
+  insightId?: string;
 }
 
 // Parameters the agent used to produce an insight (read-only transparency)
@@ -159,6 +163,9 @@ export interface StreamMessage {
   source_urls?: string[];
   cited_articles?: BlogArticle[];
   insight_count?: number;
+  // Persisted insight UUID riding on generate_insights (and recall/restyle)
+  // state updates — the handle for adding the analysis to a dashboard.
+  insight_id?: string;
   // Names of the tools an AI message is about to call. The agent announces a
   // tool call before its result streams back, so this is the earliest signal
   // that e.g. an insight is being generated.
@@ -292,6 +299,7 @@ export interface LangChainUpdate {
   end_date?: string;
   insights: object[];
   charts_data: object[];
+  insight_id?: string;
   // Optional provenance fields emitted by tools
   codeact_parts?: CodeActPart[];
   source_urls?: string[];

--- a/app/types/chat.ts
+++ b/app/types/chat.ts
@@ -167,6 +167,11 @@ export interface StreamMessage {
   start_date?: string;
   end_date?: string;
   trace_id?: string;
+  // Backend write signal carried in a tool message's response_metadata
+  // (e.g. "dashboard_updated" after create_dashboard / add_to_dashboard) —
+  // tells the client to refetch the named resource.
+  msg_type?: string;
+  dashboard_id?: string;
 }
 
 export interface AOI {

--- a/app/utils/__tests__/threadNavigation.test.ts
+++ b/app/utils/__tests__/threadNavigation.test.ts
@@ -4,6 +4,7 @@ import {
   firstMessageRedirectPath,
   isAppRoute,
   mapTabHref,
+  newConversationTarget,
 } from "../threadNavigation";
 
 describe("isAppRoute", () => {
@@ -64,6 +65,39 @@ describe("firstMessageRedirectPath", () => {
 
   it("stays put when the pathname is unknown", () => {
     expect(firstMessageRedirectPath(null, "t-1")).toBeNull();
+  });
+});
+
+describe("newConversationTarget", () => {
+  it("resets in place on a dashboard detail page", () => {
+    expect(newConversationTarget("/dashboards/abc", true)).toEqual({
+      kind: "reset-in-place",
+    });
+  });
+
+  it("navigates from the dashboards list (no chat panel there)", () => {
+    expect(newConversationTarget("/dashboards", true)).toEqual({
+      kind: "navigate",
+      href: "/app?ff=dashboard",
+    });
+  });
+
+  it("keeps the dashboards feature gate open when navigating", () => {
+    expect(newConversationTarget("/app/threads/t-1", true)).toEqual({
+      kind: "navigate",
+      href: "/app?ff=dashboard",
+    });
+  });
+
+  it("navigates plainly when the feature gate is closed", () => {
+    expect(newConversationTarget("/app", false)).toEqual({
+      kind: "navigate",
+      href: "/app",
+    });
+    expect(newConversationTarget(null, false)).toEqual({
+      kind: "navigate",
+      href: "/app",
+    });
   });
 });
 

--- a/app/utils/__tests__/threadNavigation.test.ts
+++ b/app/utils/__tests__/threadNavigation.test.ts
@@ -5,6 +5,7 @@ import {
   isAppRoute,
   mapTabHref,
   newConversationTarget,
+  threadClickTarget,
 } from "../threadNavigation";
 
 describe("isAppRoute", () => {
@@ -97,6 +98,48 @@ describe("newConversationTarget", () => {
     expect(newConversationTarget(null, false)).toEqual({
       kind: "navigate",
       href: "/app",
+    });
+  });
+});
+
+describe("threadClickTarget", () => {
+  it("loads in place on a dashboard detail page", () => {
+    expect(
+      threadClickTarget("/dashboards/abc", "t-1", "?ff=dashboard")
+    ).toEqual({
+      kind: "load-in-place",
+    });
+  });
+
+  it("navigates from the dashboards list, keeping the feature gate open", () => {
+    expect(threadClickTarget("/dashboards", "t-1", "?ff=dashboard")).toEqual({
+      kind: "navigate",
+      href: "/app/threads/t-1?ff=dashboard",
+    });
+  });
+
+  it("navigates on the map surface, carrying the current ff flags", () => {
+    expect(threadClickTarget("/app", "t-1", "?ff=dashboard,analysis")).toEqual({
+      kind: "navigate",
+      href: "/app/threads/t-1?ff=dashboard%2Canalysis",
+    });
+  });
+
+  it("navigates plainly without flags or a known pathname", () => {
+    expect(threadClickTarget("/app", "t-1")).toEqual({
+      kind: "navigate",
+      href: "/app/threads/t-1",
+    });
+    expect(threadClickTarget(null, "t-1", null)).toEqual({
+      kind: "navigate",
+      href: "/app/threads/t-1",
+    });
+  });
+
+  it("does not carry unrelated params into the thread link", () => {
+    expect(threadClickTarget("/app", "t-1", "?prompt=hello")).toEqual({
+      kind: "navigate",
+      href: "/app/threads/t-1",
     });
   });
 });

--- a/app/utils/__tests__/threadNavigation.test.ts
+++ b/app/utils/__tests__/threadNavigation.test.ts
@@ -30,6 +30,30 @@ describe("firstMessageRedirectPath", () => {
     );
   });
 
+  it("keeps the hidden-feature flags across the rewrite", () => {
+    expect(firstMessageRedirectPath("/app", "t-1", "?ff=dashboard")).toBe(
+      "/app/threads/t-1?ff=dashboard"
+    );
+  });
+
+  it("keeps multi-flag ff values intact", () => {
+    const path = firstMessageRedirectPath(
+      "/app",
+      "t-1",
+      "?ff=dashboard,analysis"
+    );
+    expect(path).toBe("/app/threads/t-1?ff=dashboard%2Canalysis");
+    // Round-trips through URLSearchParams to the original flag list.
+    const query = new URLSearchParams(path!.split("?")[1]);
+    expect(query.get("ff")).toBe("dashboard,analysis");
+  });
+
+  it("does not carry unrelated params across the rewrite", () => {
+    expect(firstMessageRedirectPath("/app", "t-1", "?prompt=hello")).toBe(
+      "/app/threads/t-1"
+    );
+  });
+
   it("stays put on a dashboard page", () => {
     expect(firstMessageRedirectPath("/dashboards/abc", "t-1")).toBeNull();
   });

--- a/app/utils/__tests__/threadNavigation.test.ts
+++ b/app/utils/__tests__/threadNavigation.test.ts
@@ -1,6 +1,23 @@
 import { describe, it, expect } from "vitest";
 
-import { firstMessageRedirectPath, mapTabHref } from "../threadNavigation";
+import {
+  firstMessageRedirectPath,
+  isAppRoute,
+  mapTabHref,
+} from "../threadNavigation";
+
+describe("isAppRoute", () => {
+  it("matches the app root and its subroutes", () => {
+    expect(isAppRoute("/app")).toBe(true);
+    expect(isAppRoute("/app/threads/t-1")).toBe(true);
+  });
+
+  it("rejects other surfaces and /app-prefixed lookalikes", () => {
+    expect(isAppRoute("/dashboards/abc")).toBe(false);
+    expect(isAppRoute("/application")).toBe(false);
+    expect(isAppRoute(null)).toBe(false);
+  });
+});
 
 describe("firstMessageRedirectPath", () => {
   it("rewrites to the thread URL from the app root", () => {

--- a/app/utils/__tests__/threadNavigation.test.ts
+++ b/app/utils/__tests__/threadNavigation.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+
+import { firstMessageRedirectPath, mapTabHref } from "../threadNavigation";
+
+describe("firstMessageRedirectPath", () => {
+  it("rewrites to the thread URL from the app root", () => {
+    expect(firstMessageRedirectPath("/app", "t-1")).toBe("/app/threads/t-1");
+  });
+
+  it("rewrites to the thread URL from app subroutes", () => {
+    expect(firstMessageRedirectPath("/app/threads/old", "t-1")).toBe(
+      "/app/threads/t-1"
+    );
+  });
+
+  it("stays put on a dashboard page", () => {
+    expect(firstMessageRedirectPath("/dashboards/abc", "t-1")).toBeNull();
+  });
+
+  it("does not treat /apple-like prefixes as the app surface", () => {
+    expect(firstMessageRedirectPath("/application", "t-1")).toBeNull();
+  });
+
+  it("stays put when the pathname is unknown", () => {
+    expect(firstMessageRedirectPath(null, "t-1")).toBeNull();
+  });
+});
+
+describe("mapTabHref", () => {
+  it("links to the live thread when a conversation is under way", () => {
+    expect(mapTabHref("t-1")).toBe("/app/threads/t-1?ff=dashboard");
+  });
+
+  it("links to the resetting new-thread page when idle", () => {
+    expect(mapTabHref(null)).toBe("/app?ff=dashboard");
+  });
+});

--- a/app/utils/threadNavigation.ts
+++ b/app/utils/threadNavigation.ts
@@ -1,4 +1,14 @@
 /**
+ * Whether the pathname is inside the /app route group — the map surface.
+ * The chat renders on other surfaces too (dashboard pages), where
+ * map-coupled behaviours (thread URL rewriting, the catalog/areas panel
+ * toggles and the layout offset they drive) must not apply.
+ */
+export function isAppRoute(pathname: string | null): boolean {
+  return pathname === "/app" || !!pathname?.startsWith("/app/");
+}
+
+/**
  * Where to send the browser after the first message of a new thread.
  *
  * Only the map surface rewrites its URL to the canonical thread route.
@@ -11,11 +21,7 @@ export function firstMessageRedirectPath(
   pathname: string | null,
   threadId: string
 ): string | null {
-  if (!pathname) return null;
-  if (pathname === "/app" || pathname.startsWith("/app/")) {
-    return `/app/threads/${threadId}`;
-  }
-  return null;
+  return isAppRoute(pathname) ? `/app/threads/${threadId}` : null;
 }
 
 /**

--- a/app/utils/threadNavigation.ts
+++ b/app/utils/threadNavigation.ts
@@ -1,0 +1,34 @@
+/**
+ * Where to send the browser after the first message of a new thread.
+ *
+ * Only the map surface rewrites its URL to the canonical thread route.
+ * On other chat surfaces (dashboard pages) the conversation lives in the
+ * chat store and the user stays where they are — returning to the map via
+ * the header's thread-aware Map tab lands on the thread URL with state
+ * intact. Returns null when no navigation should happen.
+ */
+export function firstMessageRedirectPath(
+  pathname: string | null,
+  threadId: string
+): string | null {
+  if (!pathname) return null;
+  if (pathname === "/app" || pathname.startsWith("/app/")) {
+    return `/app/threads/${threadId}`;
+  }
+  return null;
+}
+
+/**
+ * The header Map tab's destination. `/app` mounts the new-thread page, which
+ * resets the chat and map stores — correct when nothing is under way, but it
+ * would wipe a live conversation when returning from a dashboard. With an
+ * active thread the tab links to its canonical URL instead: the thread page
+ * skips its reset when the store already holds that thread. The `ff`
+ * param keeps the dashboards feature gate open across navigation (the tab
+ * only renders when that gate is on).
+ */
+export function mapTabHref(currentThreadId: string | null): string {
+  return currentThreadId
+    ? `/app/threads/${currentThreadId}?ff=dashboard`
+    : "/app?ff=dashboard";
+}

--- a/app/utils/threadNavigation.ts
+++ b/app/utils/threadNavigation.ts
@@ -9,6 +9,20 @@ export function isAppRoute(pathname: string | null): boolean {
 }
 
 /**
+ * The canonical map URL for a thread, carrying the hidden-feature flags
+ * (?ff=…) from the given `location.search` — dropping them closes the
+ * dashboards feature gate on the next navigation or refresh. Other params
+ * are deliberately not carried over (e.g. a landing ?prompt= must not ride
+ * along).
+ */
+export function threadHref(threadId: string, search?: string | null): string {
+  const ff = search ? new URLSearchParams(search).get("ff") : null;
+  return ff
+    ? `/app/threads/${threadId}?${new URLSearchParams({ ff })}`
+    : `/app/threads/${threadId}`;
+}
+
+/**
  * Where to send the browser after the first message of a new thread.
  *
  * Only the map surface rewrites its URL to the canonical thread route.
@@ -16,11 +30,6 @@ export function isAppRoute(pathname: string | null): boolean {
  * chat store and the user stays where they are — returning to the map via
  * the header's thread-aware Map tab lands on the thread URL with state
  * intact. Returns null when no navigation should happen.
- *
- * Pass the current `location.search` so the hidden-feature flags (?ff=…)
- * survive the rewrite — dropping them closes the dashboards feature gate on
- * the next navigation or refresh. Other params are deliberately not carried
- * over (e.g. a landing ?prompt= must not ride along).
  */
 export function firstMessageRedirectPath(
   pathname: string | null,
@@ -28,10 +37,28 @@ export function firstMessageRedirectPath(
   search?: string | null
 ): string | null {
   if (!isAppRoute(pathname)) return null;
-  const ff = search ? new URLSearchParams(search).get("ff") : null;
-  return ff
-    ? `/app/threads/${threadId}?${new URLSearchParams({ ff })}`
-    : `/app/threads/${threadId}`;
+  return threadHref(threadId, search);
+}
+
+/**
+ * What clicking a conversation in the history sidebar should do.
+ *
+ * A dashboard detail page hosts its own chat panel, and its URL doesn't
+ * encode the conversation (ADR-003) — so resuming a past conversation there
+ * loads the thread into the global chat store in place, keeping the user on
+ * the dashboard. Everywhere else (map, dashboards list — which has no chat
+ * panel) the click navigates to the thread's canonical map URL, carrying
+ * `?ff=…` so hidden feature gates stay open.
+ */
+export function threadClickTarget(
+  pathname: string | null,
+  threadId: string,
+  search?: string | null
+): { kind: "load-in-place" } | { kind: "navigate"; href: string } {
+  if (/^\/dashboards\/./.test(pathname ?? "")) {
+    return { kind: "load-in-place" };
+  }
+  return { kind: "navigate", href: threadHref(threadId, search) };
 }
 
 /**

--- a/app/utils/threadNavigation.ts
+++ b/app/utils/threadNavigation.ts
@@ -16,12 +16,22 @@ export function isAppRoute(pathname: string | null): boolean {
  * chat store and the user stays where they are — returning to the map via
  * the header's thread-aware Map tab lands on the thread URL with state
  * intact. Returns null when no navigation should happen.
+ *
+ * Pass the current `location.search` so the hidden-feature flags (?ff=…)
+ * survive the rewrite — dropping them closes the dashboards feature gate on
+ * the next navigation or refresh. Other params are deliberately not carried
+ * over (e.g. a landing ?prompt= must not ride along).
  */
 export function firstMessageRedirectPath(
   pathname: string | null,
-  threadId: string
+  threadId: string,
+  search?: string | null
 ): string | null {
-  return isAppRoute(pathname) ? `/app/threads/${threadId}` : null;
+  if (!isAppRoute(pathname)) return null;
+  const ff = search ? new URLSearchParams(search).get("ff") : null;
+  return ff
+    ? `/app/threads/${threadId}?${new URLSearchParams({ ff })}`
+    : `/app/threads/${threadId}`;
 }
 
 /**

--- a/app/utils/threadNavigation.ts
+++ b/app/utils/threadNavigation.ts
@@ -35,6 +35,29 @@ export function firstMessageRedirectPath(
 }
 
 /**
+ * What the header's "New conversation" (+) control should do.
+ *
+ * A dashboard detail page hosts its own chat panel, so starting a new
+ * conversation there must not navigate away — the conversation is global
+ * session state that dashboard URLs don't encode (see ADR-003), so the
+ * caller resets the stores in place instead. Everywhere else the button
+ * navigates to the map's new-thread route, carrying `?ff=dashboard` when the
+ * feature gate is open so the navigation doesn't close it.
+ */
+export function newConversationTarget(
+  pathname: string | null,
+  dashboardFeatureEnabled: boolean
+): { kind: "reset-in-place" } | { kind: "navigate"; href: string } {
+  if (/^\/dashboards\/./.test(pathname ?? "")) {
+    return { kind: "reset-in-place" };
+  }
+  return {
+    kind: "navigate",
+    href: dashboardFeatureEnabled ? "/app?ff=dashboard" : "/app",
+  };
+}
+
+/**
  * The header Map tab's destination. `/app` mounts the new-thread page, which
  * resets the chat and map stores — correct when nothing is under way, but it
  * would wipe a live conversation when returning from a dashboard. With an

--- a/src/features/analysis/ui/__tests__/ViewAnalysisNudge.test.tsx
+++ b/src/features/analysis/ui/__tests__/ViewAnalysisNudge.test.tsx
@@ -64,7 +64,7 @@ describe("ViewAnalysisNudge", () => {
 
     expect(
       screen.getByRole("button", {
-        name: /View Analysis for Tree cover loss in Pará, Brazil/i,
+        name: /View Tree cover loss Analysis for Pará, Brazil/i,
       })
     ).toBeTruthy();
   });
@@ -107,7 +107,9 @@ describe("ViewAnalysisNudge", () => {
     analysisState.status = "running";
     renderNudge(<ViewAnalysisNudge messageId="m1" suggestion={suggestion} />);
 
-    expect(screen.getByText("Analyzing…")).toBeTruthy();
+    expect(
+      screen.getByText(/Loading chart data for "Pará, Brazil"/)
+    ).toBeTruthy();
   });
 
   it("shows the error message on failure", () => {

--- a/src/features/dashboards/api/dashboards.ts
+++ b/src/features/dashboards/api/dashboards.ts
@@ -80,6 +80,20 @@ export async function updateWidget(
   );
 }
 
+// Adds a persisted insight to a dashboard (the chat-side "Add to dashboard"
+// toggle). The backend is idempotent for duplicate insight adds and returns
+// the dashboard without insight expansion — callers invalidate and refetch.
+export async function addInsightWidget(
+  dashboardId: string,
+  insightId: string
+): Promise<void> {
+  await readJson<unknown>(`/api/dashboards/${dashboardId}/widgets`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ widget_type: "insight", insight_id: insightId }),
+  });
+}
+
 export async function deleteWidget(
   dashboardId: string,
   widgetId: string

--- a/src/features/dashboards/api/dashboards.ts
+++ b/src/features/dashboards/api/dashboards.ts
@@ -44,6 +44,19 @@ export function createDashboardPayloadFromAoi(
   return aoiToDashboardCreateRequest(aoi);
 }
 
+// The PATCH response comes back without insight expansion, so callers must
+// not write it into the detail cache — invalidate and refetch instead.
+export async function renameDashboard(
+  dashboardId: string,
+  name: string
+): Promise<void> {
+  await readJson<unknown>(`/api/dashboards/${dashboardId}`, {
+    method: "PATCH",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ name }),
+  });
+}
+
 export interface WidgetUpdate {
   position?: number;
   // Replaced whole by the backend (not merged) — always send the full config.

--- a/src/features/dashboards/api/dashboards.ts
+++ b/src/features/dashboards/api/dashboards.ts
@@ -57,6 +57,18 @@ export async function renameDashboard(
   });
 }
 
+export async function deleteDashboard(dashboardId: string): Promise<void> {
+  // 204 No Content — bypass readJson, which would choke on the empty body.
+  const res = await apiFetch(`/api/dashboards/${dashboardId}`, {
+    method: "DELETE",
+  });
+  if (!res.ok) {
+    const error = new Error(`Failed to delete dashboard: ${res.statusText}`);
+    (error as Error & { status?: number }).status = res.status;
+    throw error;
+  }
+}
+
 export interface WidgetUpdate {
   position?: number;
   // Replaced whole by the backend (not merged) — always send the full config.

--- a/src/features/dashboards/api/dashboards.ts
+++ b/src/features/dashboards/api/dashboards.ts
@@ -7,6 +7,7 @@ import {
   type DashboardCreateRequest,
 } from "./schemas";
 import { readJson } from "./http";
+import { apiFetch } from "@/app/lib/api-client";
 import { aoiToDashboardCreateRequest } from "../lib/aoi";
 
 export async function listDashboards(): Promise<Dashboard[]> {
@@ -41,4 +42,43 @@ export function createDashboardPayloadFromAoi(
   aoi: AoiSearchResult
 ): DashboardCreateRequest {
   return aoiToDashboardCreateRequest(aoi);
+}
+
+export interface WidgetUpdate {
+  position?: number;
+  // Replaced whole by the backend (not merged) — always send the full config.
+  config?: Record<string, unknown>;
+}
+
+// The PATCH response is the dashboard without insight expansion — callers
+// invalidate and refetch the detail endpoint to render, so it is ignored.
+export async function updateWidget(
+  dashboardId: string,
+  widgetId: string,
+  patch: WidgetUpdate
+): Promise<void> {
+  await readJson<unknown>(
+    `/api/dashboards/${dashboardId}/widgets/${widgetId}`,
+    {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(patch),
+    }
+  );
+}
+
+export async function deleteWidget(
+  dashboardId: string,
+  widgetId: string
+): Promise<void> {
+  // 204 No Content — bypass readJson, which would choke on the empty body.
+  const res = await apiFetch(
+    `/api/dashboards/${dashboardId}/widgets/${widgetId}`,
+    { method: "DELETE" }
+  );
+  if (!res.ok) {
+    const error = new Error(`Failed to remove widget: ${res.statusText}`);
+    (error as Error & { status?: number }).status = res.status;
+    throw error;
+  }
 }

--- a/src/features/dashboards/api/schemas.ts
+++ b/src/features/dashboards/api/schemas.ts
@@ -22,6 +22,27 @@ export const DashboardAoiResponseSchema = DashboardAoiSchema.extend({
   position: z.number(),
 });
 
+// One chart of a widget's expanded insight (GET /api/dashboards/:id).
+// Deliberately lenient — everything the UI doesn't strictly need has a
+// default, so a new backend field or a missing one never fails the page.
+export const DashboardInsightChartSchema = z.object({
+  id: z.string(),
+  position: z.number().default(0),
+  title: z.string().default(""),
+  chart_type: z.string().default("table"),
+  x_axis: z.string().default(""),
+  y_axis: z.string().default(""),
+  series_fields: z.array(z.string()).nullable().optional(),
+  chart_data: z.unknown(),
+});
+
+export const DashboardInsightSchema = z.object({
+  id: z.string(),
+  insight_text: z.string().nullable().optional(),
+  codeact_parts: z.array(z.unknown()).nullable().optional(),
+  charts: z.array(DashboardInsightChartSchema).default([]),
+});
+
 export const DashboardWidgetResponseSchema = z.object({
   id: z.string(),
   position: z.number(),
@@ -29,7 +50,9 @@ export const DashboardWidgetResponseSchema = z.object({
   insight_id: z.string().nullable().optional(),
   config: z.record(z.string(), z.unknown()).default({}),
   created_at: z.string(),
-  insight: z.unknown().nullable().optional(),
+  // A malformed insight payload degrades to the "not available" placeholder
+  // (catch → null) rather than failing the whole dashboard parse.
+  insight: DashboardInsightSchema.nullable().optional().catch(null),
 });
 
 export const DashboardResponseSchema = z.object({
@@ -55,6 +78,8 @@ export const DashboardCreateRequestSchema = z.object({
 export type AoiSearchResult = z.infer<typeof AoiSearchResultSchema>;
 export type DashboardAoi = z.infer<typeof DashboardAoiSchema>;
 export type Dashboard = z.infer<typeof DashboardResponseSchema>;
+export type DashboardWidget = z.infer<typeof DashboardWidgetResponseSchema>;
+export type DashboardInsight = z.infer<typeof DashboardInsightSchema>;
 export type DashboardCreateRequest = z.infer<
   typeof DashboardCreateRequestSchema
 >;

--- a/src/features/dashboards/lib/__tests__/mapWidgets.test.ts
+++ b/src/features/dashboards/lib/__tests__/mapWidgets.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+
+import { mapWidgetLayer, mapWidgetViewportBbox } from "../mapWidgets";
+
+const datasetConfig = (overrides: Record<string, unknown> = {}) => ({
+  default_view: "map",
+  dataset: {
+    dataset_id: 4,
+    dataset_name: "Tree cover loss",
+    tile_url: "https://tiles.example.org/tcl/{z}/{x}/{y}.png?tcd=30",
+    context_layer: null,
+    context_layers: [],
+    ...overrides,
+  },
+});
+
+describe("mapWidgetLayer — dataset configs", () => {
+  it("parses a dataset config into a renderable layer", () => {
+    const layer = mapWidgetLayer(datasetConfig());
+    expect(layer).toEqual({
+      kind: "dataset",
+      title: "Tree cover loss",
+      tileUrl: "https://tiles.example.org/tcl/{z}/{x}/{y}.png?tcd=30",
+    });
+  });
+
+  it("prefers the config.title override for the card header", () => {
+    const layer = mapWidgetLayer({
+      ...datasetConfig(),
+      title: "Loss over Paraná",
+    });
+    expect(layer?.title).toBe("Loss over Paraná");
+  });
+
+  it("resolves the active context layer's tiles by name", () => {
+    const layer = mapWidgetLayer(
+      datasetConfig({
+        context_layer: "driver",
+        context_layers: [
+          { name: "other", tile_url: "https://tiles.example.org/other" },
+          { name: "driver", tile_url: "https://tiles.example.org/driver" },
+        ],
+      })
+    );
+    expect(layer?.contextTileUrl).toBe("https://tiles.example.org/driver");
+  });
+
+  it("omits the context layer when the active name has no entry", () => {
+    const layer = mapWidgetLayer(
+      datasetConfig({ context_layer: "driver", context_layers: [] })
+    );
+    expect(layer?.contextTileUrl).toBeUndefined();
+  });
+
+  it("routes primary-forest tiles through the pf:// protocol", () => {
+    const layer = mapWidgetLayer(
+      datasetConfig({
+        tile_url:
+          "https://tiles.example.org/umd_regional_primary_forest/{z}/{x}/{y}.png",
+      })
+    );
+    expect(layer?.tileUrl).toMatch(/^pf:\/\//);
+  });
+
+  it("returns null when the dataset has no tile_url", () => {
+    expect(mapWidgetLayer(datasetConfig({ tile_url: "" }))).toBeNull();
+  });
+});
+
+describe("mapWidgetLayer — imagery configs", () => {
+  it("parses an imagery config with a date-stamped fallback title", () => {
+    const layer = mapWidgetLayer({
+      imagery: {
+        tile_url: "https://tiles.example.org/mosaic/{z}/{x}/{y}.png?url=abc",
+        target_date: "2024-06-01",
+      },
+    });
+    expect(layer).toEqual({
+      kind: "imagery",
+      title: "Sentinel-2 imagery, 2024-06-01",
+      tileUrl: "https://tiles.example.org/mosaic/{z}/{x}/{y}.png?url=abc",
+    });
+  });
+
+  it("falls back to a generic title without a target_date", () => {
+    const layer = mapWidgetLayer({
+      imagery: { tile_url: "https://tiles.example.org/mosaic" },
+    });
+    expect(layer?.title).toBe("Sentinel-2 imagery");
+  });
+
+  it("returns null when neither dataset nor imagery is present", () => {
+    expect(mapWidgetLayer({ default_view: "map" })).toBeNull();
+  });
+});
+
+describe("mapWidgetViewportBbox", () => {
+  it("returns the override bbox when well-formed", () => {
+    expect(
+      mapWidgetViewportBbox({ viewport: { bbox: [-54, -27, -48, -22] } })
+    ).toEqual([-54, -27, -48, -22]);
+  });
+
+  it("returns null for absent or malformed viewports", () => {
+    expect(mapWidgetViewportBbox({})).toBeNull();
+    expect(mapWidgetViewportBbox({ viewport: { zoom: 4 } })).toBeNull();
+    expect(
+      mapWidgetViewportBbox({ viewport: { bbox: [-54, -27, -48] } })
+    ).toBeNull();
+    expect(
+      mapWidgetViewportBbox({ viewport: { bbox: [-54, -27, -48, "x"] } })
+    ).toBeNull();
+  });
+});

--- a/src/features/dashboards/lib/__tests__/mapWidgets.test.ts
+++ b/src/features/dashboards/lib/__tests__/mapWidgets.test.ts
@@ -21,6 +21,7 @@ describe("mapWidgetLayer — dataset configs", () => {
       kind: "dataset",
       title: "Tree cover loss",
       tileUrl: "https://tiles.example.org/tcl/{z}/{x}/{y}.png?tcd=30",
+      datasetId: 4,
     });
   });
 
@@ -43,6 +44,7 @@ describe("mapWidgetLayer — dataset configs", () => {
       })
     );
     expect(layer?.contextTileUrl).toBe("https://tiles.example.org/driver");
+    expect(layer?.contextLayerName).toBe("driver");
   });
 
   it("omits the context layer when the active name has no entry", () => {
@@ -50,6 +52,39 @@ describe("mapWidgetLayer — dataset configs", () => {
       datasetConfig({ context_layer: "driver", context_layers: [] })
     );
     expect(layer?.contextTileUrl).toBeUndefined();
+    expect(layer?.contextLayerName).toBeUndefined();
+  });
+
+  it("reduces config parameters to a first-value record for the legend", () => {
+    const layer = mapWidgetLayer(
+      datasetConfig({
+        parameters: [
+          { name: "canopy_cover", values: [30] },
+          { name: "empty", values: [] },
+          { name: 42, values: [1] },
+          "junk",
+        ],
+      })
+    );
+    expect(layer?.parameters).toEqual({ canopy_cover: 30 });
+  });
+
+  it("omits parameters when the config has none worth showing", () => {
+    expect(mapWidgetLayer(datasetConfig())?.parameters).toBeUndefined();
+    expect(
+      mapWidgetLayer(datasetConfig({ parameters: [] }))?.parameters
+    ).toBeUndefined();
+    expect(
+      mapWidgetLayer(datasetConfig({ parameters: null }))?.parameters
+    ).toBeUndefined();
+  });
+
+  it("carries the config's date range for the legend chip", () => {
+    const layer = mapWidgetLayer(
+      datasetConfig({ start_date: "2024-01-01", end_date: "2024-12-31" })
+    );
+    expect(layer?.startDate).toBe("2024-01-01");
+    expect(layer?.endDate).toBe("2024-12-31");
   });
 
   it("routes primary-forest tiles through the pf:// protocol", () => {

--- a/src/features/dashboards/lib/__tests__/widgets.test.ts
+++ b/src/features/dashboards/lib/__tests__/widgets.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  computeReorder,
+  dashboardWidgetToInsightWidgets,
+  widgetSize,
+  withSize,
+} from "../widgets";
+import type { DashboardWidget } from "../../api/schemas";
+
+function chart(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "c-1",
+    position: 0,
+    title: "Annual tree cover loss",
+    chart_type: "bar",
+    x_axis: "year",
+    y_axis: "loss_ha",
+    series_fields: null,
+    chart_data: [{ year: 2020, loss_ha: 5 }],
+    ...overrides,
+  };
+}
+
+function widget(overrides: Partial<DashboardWidget> = {}): DashboardWidget {
+  return {
+    id: "w-1",
+    position: 0,
+    widget_type: "insight",
+    insight_id: "ins-1",
+    config: {},
+    created_at: "2026-07-03T14:10:00",
+    insight: {
+      id: "ins-1",
+      insight_text: "Loss rose 12%.",
+      codeact_parts: null,
+      charts: [chart()],
+    },
+    ...overrides,
+  };
+}
+
+describe("widgetSize / withSize", () => {
+  it("defaults to single and honours double", () => {
+    expect(widgetSize({})).toBe("single");
+    expect(widgetSize({ size: "double" })).toBe("double");
+    expect(widgetSize({ size: "garbage" })).toBe("single");
+  });
+
+  it("withSize preserves the other config keys (config is replaced whole)", () => {
+    expect(withSize({ default_view: "chart", title: "T" }, "double")).toEqual({
+      default_view: "chart",
+      title: "T",
+      size: "double",
+    });
+  });
+});
+
+describe("dashboardWidgetToInsightWidgets", () => {
+  it("returns [] for a hidden insight or no charts", () => {
+    expect(dashboardWidgetToInsightWidgets(widget({ insight: null }))).toEqual(
+      []
+    );
+    expect(
+      dashboardWidgetToInsightWidgets(
+        widget({
+          insight: { id: "i", insight_text: null, charts: [] },
+        })
+      )
+    ).toEqual([]);
+  });
+
+  it("maps API chart fields to the InsightWidget shape", () => {
+    const [card] = dashboardWidgetToInsightWidgets(widget());
+    expect(card).toMatchObject({
+      id: "c-1",
+      type: "bar",
+      title: "Annual tree cover loss",
+      description: "Loss rose 12%.",
+      data: [{ year: 2020, loss_ha: 5 }],
+      xAxis: "year",
+      yAxis: "loss_ha",
+    });
+    expect(card.seriesFields).toBeUndefined();
+  });
+
+  it("sorts charts by position and applies narrative/title only to the first", () => {
+    const cards = dashboardWidgetToInsightWidgets(
+      widget({
+        config: { title: "Renamed" },
+        insight: {
+          id: "ins-1",
+          insight_text: "Narrative.",
+          codeact_parts: null,
+          charts: [
+            chart({ id: "c-2", position: 1, title: "Second" }),
+            chart({ id: "c-1", position: 0, title: "First" }),
+          ],
+        },
+      })
+    );
+    expect(cards.map((c) => c.id)).toEqual(["c-1", "c-2"]);
+    expect(cards[0].title).toBe("Renamed");
+    expect(cards[0].description).toBe("Narrative.");
+    expect(cards[1].title).toBe("Second");
+    expect(cards[1].description).toBe("");
+  });
+
+  it("falls back to table for unknown chart types", () => {
+    const cards = dashboardWidgetToInsightWidgets(
+      widget({
+        insight: {
+          id: "ins-1",
+          insight_text: null,
+          codeact_parts: null,
+          charts: [chart({ chart_type: "hexbin-3d" })],
+        },
+      })
+    );
+    expect(cards[0].type).toBe("table");
+  });
+
+  it("threads codeact provenance into generation", () => {
+    const cards = dashboardWidgetToInsightWidgets(
+      widget({
+        insight: {
+          id: "ins-1",
+          insight_text: null,
+          codeact_parts: [{ type: "code_block", content: "cHJpbnQoKQ==" }],
+          charts: [chart()],
+        },
+      })
+    );
+    expect(cards[0].generation?.codeact_parts).toHaveLength(1);
+  });
+});
+
+describe("computeReorder", () => {
+  const widgets = [
+    widget({ id: "a", position: 0 }),
+    widget({ id: "b", position: 1 }),
+    widget({ id: "c", position: 2 }),
+  ];
+
+  it("moves a widget and patches only positions that changed", () => {
+    const { order, patches } = computeReorder(widgets, 0, 2);
+    expect(order.map((w) => w.id)).toEqual(["b", "c", "a"]);
+    expect(patches).toEqual([
+      { id: "b", position: 0 },
+      { id: "c", position: 1 },
+      { id: "a", position: 2 },
+    ]);
+  });
+
+  it("is a no-op when from equals to", () => {
+    const { order, patches } = computeReorder(widgets, 1, 1);
+    expect(order.map((w) => w.id)).toEqual(["a", "b", "c"]);
+    expect(patches).toEqual([]);
+  });
+
+  it("normalises non-contiguous server positions", () => {
+    const sparse = [
+      widget({ id: "a", position: 0 }),
+      widget({ id: "b", position: 3 }),
+    ];
+    const { patches } = computeReorder(sparse, 0, 0);
+    expect(patches).toEqual([{ id: "b", position: 1 }]);
+  });
+
+  it("ignores out-of-range indices but still normalises", () => {
+    const { order, patches } = computeReorder(widgets, 5, 0);
+    expect(order.map((w) => w.id)).toEqual(["a", "b", "c"]);
+    expect(patches).toEqual([]);
+  });
+});

--- a/src/features/dashboards/lib/__tests__/widgets.test.ts
+++ b/src/features/dashboards/lib/__tests__/widgets.test.ts
@@ -1,9 +1,11 @@
 import { describe, it, expect } from "vitest";
 
 import {
+  chartSize,
   computeReorder,
   dashboardWidgetToInsightWidgets,
   widgetSize,
+  withChartSize,
   withSize,
 } from "../widgets";
 import type { DashboardWidget } from "../../api/schemas";
@@ -52,6 +54,25 @@ describe("widgetSize / withSize", () => {
       default_view: "chart",
       title: "T",
       size: "double",
+    });
+  });
+});
+
+describe("chartSize / withChartSize", () => {
+  it("reads the per-chart size and falls back to the widget size", () => {
+    expect(chartSize({}, "c-1")).toBe("single");
+    expect(chartSize({ size: "double" }, "c-1")).toBe("double");
+    expect(chartSize({ sizes: { "c-1": "double" } }, "c-1")).toBe("double");
+    expect(chartSize({ sizes: { "c-1": "double" } }, "c-2")).toBe("single");
+    expect(chartSize({ sizes: { "c-1": "garbage" } }, "c-1")).toBe("single");
+  });
+
+  it("withChartSize preserves other config keys and sibling chart sizes", () => {
+    expect(
+      withChartSize({ title: "T", sizes: { "c-1": "double" } }, "c-2", "double")
+    ).toEqual({
+      title: "T",
+      sizes: { "c-1": "double", "c-2": "double" },
     });
   });
 });
@@ -132,6 +153,27 @@ describe("dashboardWidgetToInsightWidgets", () => {
       })
     );
     expect(cards[0].generation?.codeact_parts).toHaveLength(1);
+  });
+
+  it("attaches the dashboard area as analysis params on every card", () => {
+    const cards = dashboardWidgetToInsightWidgets(
+      widget({
+        insight: {
+          id: "ins-1",
+          insight_text: null,
+          codeact_parts: null,
+          charts: [chart({ id: "c-1" }), chart({ id: "c-2", position: 1 })],
+        },
+      }),
+      { areaName: "Paraná, Brazil" }
+    );
+    expect(cards[0].analysisParams).toEqual({ areas: ["Paraná, Brazil"] });
+    expect(cards[1].analysisParams).toEqual({ areas: ["Paraná, Brazil"] });
+  });
+
+  it("omits analysis params when no area name is given", () => {
+    const [card] = dashboardWidgetToInsightWidgets(widget());
+    expect(card.analysisParams).toBeUndefined();
   });
 });
 

--- a/src/features/dashboards/lib/mapWidgets.ts
+++ b/src/features/dashboards/lib/mapWidgets.ts
@@ -13,10 +13,38 @@ export interface MapWidgetLayer {
   tileUrl: string;
   /** The active context sub-layer's tiles, rendered beneath the main layer. */
   contextTileUrl?: string;
+  /** The active context sub-layer's name — set only with `contextTileUrl`. */
+  contextLayerName?: string;
+  // Dataset-kind fields that drive the widget's legend (DashboardMapLegend).
+  datasetId?: number;
+  /** Display parameters as a record, e.g. `{ canopy_cover: 30 }`. */
+  parameters?: Record<string, unknown>;
+  startDate?: string;
+  endDate?: string;
 }
 
 const str = (value: unknown): string | undefined =>
   typeof value === "string" && value.trim() ? value : undefined;
+
+// Config parameters are `[{ name, values }]` (per the handoff); the legend
+// wants a `{ name: firstValue }` record — same reduction the explorer's
+// getDatasetLayerContextProps applies to DatasetInfo.parameters.
+function parametersRecord(
+  parameters: unknown
+): Record<string, unknown> | undefined {
+  if (!Array.isArray(parameters)) return undefined;
+  const entries = parameters
+    .filter(
+      (p): p is { name: string; values: unknown[] } =>
+        !!p &&
+        typeof p === "object" &&
+        typeof (p as { name?: unknown }).name === "string" &&
+        Array.isArray((p as { values?: unknown }).values) &&
+        (p as { values: unknown[] }).values.length > 0
+    )
+    .map((p) => [p.name, p.values[0]] as const);
+  return entries.length > 0 ? Object.fromEntries(entries) : undefined;
+}
 
 // Primary forest tiles ship black-background PNGs; the pf:// protocol
 // rewrites black to alpha (same patch the explorer applies).
@@ -46,6 +74,7 @@ export function mapWidgetLayer(
     // Resolve the active context layer by name. Raster-only: vector (MVT)
     // context layers need a source_layer the persisted config doesn't carry.
     let contextTileUrl: string | undefined;
+    let contextLayerName: string | undefined;
     const activeName = str(d.context_layer);
     if (activeName && Array.isArray(d.context_layers)) {
       const entry = d.context_layers.find(
@@ -55,14 +84,25 @@ export function mapWidgetLayer(
           (l as { name?: unknown }).name === activeName
       );
       const entryUrl = str(entry?.tile_url);
-      if (entryUrl) contextTileUrl = patchPrimaryForest(entryUrl);
+      if (entryUrl) {
+        contextTileUrl = patchPrimaryForest(entryUrl);
+        contextLayerName = activeName;
+      }
     }
+
+    const parameters = parametersRecord(d.parameters);
+    const startDate = str(d.start_date);
+    const endDate = str(d.end_date);
 
     return {
       kind: "dataset",
       title: titleOverride ?? str(d.dataset_name) ?? "Map layer",
       tileUrl: patchPrimaryForest(tileUrl),
-      ...(contextTileUrl ? { contextTileUrl } : {}),
+      ...(contextTileUrl ? { contextTileUrl, contextLayerName } : {}),
+      ...(typeof d.dataset_id === "number" ? { datasetId: d.dataset_id } : {}),
+      ...(parameters ? { parameters } : {}),
+      ...(startDate ? { startDate } : {}),
+      ...(endDate ? { endDate } : {}),
     };
   }
 

--- a/src/features/dashboards/lib/mapWidgets.ts
+++ b/src/features/dashboards/lib/mapWidgets.ts
@@ -1,0 +1,108 @@
+import { wrapPrimaryForestTileUrl } from "@/app/utils/primaryForestTileProtocol";
+
+/**
+ * A renderable map-widget layer parsed from a `widget_type: "map"` config
+ * (dashboards-map-widgets-handoff.md). Configs are self-contained snapshots:
+ * exactly one of `config.dataset` / `config.imagery`, each carrying a fully
+ * resolved `tile_url` to render directly — no catalog lookup.
+ */
+export interface MapWidgetLayer {
+  kind: "dataset" | "imagery";
+  /** Card header: `config.title` override, else a kind-specific fallback. */
+  title: string;
+  tileUrl: string;
+  /** The active context sub-layer's tiles, rendered beneath the main layer. */
+  contextTileUrl?: string;
+}
+
+const str = (value: unknown): string | undefined =>
+  typeof value === "string" && value.trim() ? value : undefined;
+
+// Primary forest tiles ship black-background PNGs; the pf:// protocol
+// rewrites black to alpha (same patch the explorer applies).
+function patchPrimaryForest(url: string): string {
+  return url.includes("umd_regional_primary_forest")
+    ? wrapPrimaryForestTileUrl(url)
+    : url;
+}
+
+/**
+ * Parses a map widget's config into a renderable layer, or null when there is
+ * nothing to render (no dataset/imagery sub-object, or no tile_url — the
+ * caller shows a placeholder). The backend validates these on create, so null
+ * here means a malformed or future config shape.
+ */
+export function mapWidgetLayer(
+  config: Record<string, unknown>
+): MapWidgetLayer | null {
+  const titleOverride = str(config.title);
+
+  const dataset = config.dataset;
+  if (dataset && typeof dataset === "object") {
+    const d = dataset as Record<string, unknown>;
+    const tileUrl = str(d.tile_url);
+    if (!tileUrl) return null;
+
+    // Resolve the active context layer by name. Raster-only: vector (MVT)
+    // context layers need a source_layer the persisted config doesn't carry.
+    let contextTileUrl: string | undefined;
+    const activeName = str(d.context_layer);
+    if (activeName && Array.isArray(d.context_layers)) {
+      const entry = d.context_layers.find(
+        (l): l is Record<string, unknown> =>
+          !!l &&
+          typeof l === "object" &&
+          (l as { name?: unknown }).name === activeName
+      );
+      const entryUrl = str(entry?.tile_url);
+      if (entryUrl) contextTileUrl = patchPrimaryForest(entryUrl);
+    }
+
+    return {
+      kind: "dataset",
+      title: titleOverride ?? str(d.dataset_name) ?? "Map layer",
+      tileUrl: patchPrimaryForest(tileUrl),
+      ...(contextTileUrl ? { contextTileUrl } : {}),
+    };
+  }
+
+  const imagery = config.imagery;
+  if (imagery && typeof imagery === "object") {
+    const im = imagery as Record<string, unknown>;
+    const tileUrl = str(im.tile_url);
+    if (!tileUrl) return null;
+    const targetDate = str(im.target_date);
+    return {
+      kind: "imagery",
+      title:
+        titleOverride ??
+        (targetDate
+          ? `Sentinel-2 imagery, ${targetDate}`
+          : "Sentinel-2 imagery"),
+      tileUrl,
+    };
+  }
+
+  return null;
+}
+
+/**
+ * The reserved `config.viewport` manual override — the backend never writes
+ * it, but per the handoff it wins over the AOI fit when present. Only a
+ * `bbox: [west, south, east, north]` shape is honoured.
+ */
+export function mapWidgetViewportBbox(
+  config: Record<string, unknown>
+): [number, number, number, number] | null {
+  const viewport = config.viewport;
+  if (!viewport || typeof viewport !== "object") return null;
+  const bbox = (viewport as { bbox?: unknown }).bbox;
+  if (
+    Array.isArray(bbox) &&
+    bbox.length === 4 &&
+    bbox.every((n) => typeof n === "number" && Number.isFinite(n))
+  ) {
+    return bbox as [number, number, number, number];
+  }
+  return null;
+}

--- a/src/features/dashboards/lib/widgets.ts
+++ b/src/features/dashboards/lib/widgets.ts
@@ -35,6 +35,36 @@ export function withSize(
 }
 
 /**
+ * Per-chart column span. A widget's charts render as individual grid cards,
+ * so each chart carries its own span under `config.sizes[chartId]`; the
+ * widget-level `size` is the pre-split fallback for older configs.
+ */
+export function chartSize(
+  config: Record<string, unknown>,
+  chartId: string
+): WidgetSize {
+  const sizes = config.sizes;
+  if (sizes && typeof sizes === "object") {
+    const own = (sizes as Record<string, unknown>)[chartId];
+    if (own === "double" || own === "single") return own;
+  }
+  return widgetSize(config);
+}
+
+/** The full config to PATCH for a per-chart size change (config is replaced whole). */
+export function withChartSize(
+  config: Record<string, unknown>,
+  chartId: string,
+  size: WidgetSize
+): Record<string, unknown> {
+  const sizes =
+    config.sizes && typeof config.sizes === "object"
+      ? (config.sizes as Record<string, unknown>)
+      : {};
+  return { ...config, sizes: { ...sizes, [chartId]: size } };
+}
+
+/**
  * Maps a dashboard insight widget (snake_case REST shape) to the
  * `InsightWidget`s consumed by `WidgetMessage` — the persisted counterpart
  * of `generateInsightsTool`, which produces one card per chart. Returns `[]`
@@ -44,10 +74,13 @@ export function withSize(
  *
  * The widget's `config.title` override and the insight narrative apply to
  * the first chart (the card's visual header); provenance parts feed the
- * "view how this was generated" drawer.
+ * "view how this was generated" drawer. The API insight carries no analysis
+ * parameters, but a dashboard is scoped to exactly one area — pass its name
+ * as `areaName` so every card gets an AREA param chip.
  */
 export function dashboardWidgetToInsightWidgets(
-  widget: DashboardWidget
+  widget: DashboardWidget,
+  { areaName }: { areaName?: string } = {}
 ): InsightWidget[] {
   const insight = widget.insight;
   if (!insight?.charts?.length) return [];
@@ -57,6 +90,7 @@ export function dashboardWidgetToInsightWidgets(
     : undefined;
   const titleOverride =
     typeof widget.config.title === "string" ? widget.config.title : undefined;
+  const analysisParams = areaName ? { areas: [areaName] } : undefined;
 
   return [...insight.charts]
     .sort((a, b) => a.position - b.position)
@@ -74,6 +108,7 @@ export function dashboardWidgetToInsightWidgets(
         yAxis: chart.y_axis,
         ...(seriesFields?.length ? { seriesFields } : {}),
         ...(generation ? { generation } : {}),
+        ...(analysisParams ? { analysisParams } : {}),
       };
     });
 }

--- a/src/features/dashboards/lib/widgets.ts
+++ b/src/features/dashboards/lib/widgets.ts
@@ -85,9 +85,16 @@ export function dashboardWidgetToInsightWidgets(
   const insight = widget.insight;
   if (!insight?.charts?.length) return [];
 
-  const generation = insight.codeact_parts?.length
-    ? { codeact_parts: insight.codeact_parts as CodeActPart[] }
-    : undefined;
+  const codeactParts = Array.isArray(insight.codeact_parts)
+    ? insight.codeact_parts.filter(
+        (p): p is CodeActPart =>
+          typeof p === "object" &&
+          p !== null &&
+          typeof (p as CodeActPart).type === "string" &&
+          typeof (p as CodeActPart).content === "string"
+      )
+    : [];
+  const generation = codeactParts.length ? { codeact_parts: codeactParts } : undefined;
   const titleOverride =
     typeof widget.config.title === "string" ? widget.config.title : undefined;
   const analysisParams = areaName ? { areas: [areaName] } : undefined;

--- a/src/features/dashboards/lib/widgets.ts
+++ b/src/features/dashboards/lib/widgets.ts
@@ -1,0 +1,113 @@
+import type { CodeActPart, InsightWidget } from "@/app/types/chat";
+import type { DashboardWidget } from "../api/schemas";
+
+// Chart types the chart widget can render (InsightWidget["type"] minus
+// "dataset-card", which never comes from the dashboards API). Unknown types
+// fall back to "table" so the data stays visible.
+const CHART_TYPES = new Set([
+  "line",
+  "bar",
+  "table",
+  "pie",
+  "stacked-bar",
+  "grouped-bar",
+  "area",
+  "scatter",
+]);
+
+export type WidgetSize = "single" | "double";
+
+/** The widget's persisted column span; anything but "double" is single. */
+export function widgetSize(config: Record<string, unknown>): WidgetSize {
+  return config.size === "double" ? "double" : "single";
+}
+
+/**
+ * The full config to PATCH for a size change. The backend replaces config
+ * whole (no merge), so presentation keys like default_view/title must ride
+ * along.
+ */
+export function withSize(
+  config: Record<string, unknown>,
+  size: WidgetSize
+): Record<string, unknown> {
+  return { ...config, size };
+}
+
+/**
+ * Maps a dashboard insight widget (snake_case REST shape) to the
+ * `InsightWidget`s consumed by `WidgetMessage` — the persisted counterpart
+ * of `generateInsightsTool`, which produces one card per chart. Returns `[]`
+ * when there is nothing to render (insight hidden from this viewer, or no
+ * charts); the caller shows a "not available" placeholder per the API
+ * contract.
+ *
+ * The widget's `config.title` override and the insight narrative apply to
+ * the first chart (the card's visual header); provenance parts feed the
+ * "view how this was generated" drawer.
+ */
+export function dashboardWidgetToInsightWidgets(
+  widget: DashboardWidget
+): InsightWidget[] {
+  const insight = widget.insight;
+  if (!insight?.charts?.length) return [];
+
+  const generation = insight.codeact_parts?.length
+    ? { codeact_parts: insight.codeact_parts as CodeActPart[] }
+    : undefined;
+  const titleOverride =
+    typeof widget.config.title === "string" ? widget.config.title : undefined;
+
+  return [...insight.charts]
+    .sort((a, b) => a.position - b.position)
+    .map((chart, index) => {
+      const seriesFields = chart.series_fields ?? undefined;
+      return {
+        id: chart.id,
+        type: CHART_TYPES.has(chart.chart_type)
+          ? (chart.chart_type as InsightWidget["type"])
+          : "table",
+        title: (index === 0 && titleOverride) || chart.title,
+        description: index === 0 ? (insight.insight_text ?? "") : "",
+        data: chart.chart_data,
+        xAxis: chart.x_axis,
+        yAxis: chart.y_axis,
+        ...(seriesFields?.length ? { seriesFields } : {}),
+        ...(generation ? { generation } : {}),
+      };
+    });
+}
+
+export interface WidgetPositionPatch {
+  id: string;
+  position: number;
+}
+
+/**
+ * Moves a widget within the given render order and computes the widget
+ * `position` PATCHes needed to persist it. The backend PATCH sets only the
+ * targeted widget's position (no sibling renumbering), so every widget whose
+ * stored position differs from its new index gets a patch — this also
+ * normalises non-contiguous server positions (e.g. after deletions).
+ */
+export function computeReorder(
+  widgets: DashboardWidget[],
+  fromIndex: number,
+  toIndex: number
+): { order: DashboardWidget[]; patches: WidgetPositionPatch[] } {
+  const order = [...widgets];
+  if (
+    fromIndex !== toIndex &&
+    fromIndex >= 0 &&
+    fromIndex < order.length &&
+    toIndex >= 0 &&
+    toIndex < order.length
+  ) {
+    const [moved] = order.splice(fromIndex, 1);
+    order.splice(toIndex, 0, moved);
+  }
+  const patches = order.flatMap((widget, index) =>
+    widget.position === index ? [] : [{ id: widget.id, position: index }]
+  );
+  return { order, patches };
+}

--- a/src/features/dashboards/ui/AddToDashboardToggle.tsx
+++ b/src/features/dashboards/ui/AddToDashboardToggle.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { Button } from "@chakra-ui/react";
+import { CheckIcon, SquaresFourIcon } from "@phosphor-icons/react";
+
+import { toaster } from "@/app/components/ui/toaster";
+import useAuthStore from "@/app/store/authStore";
+import useViewContextStore from "@/app/store/viewContextStore";
+import {
+  useAddInsightWidget,
+  useDashboard,
+  useDeleteWidget,
+} from "./dashboardQueries";
+
+/**
+ * Chat-side "Add to dashboard" toggle (per the MVP handoff: a plain REST
+ * widget add/remove with the analysis's persisted insight id — no chat round
+ * trip). The target dashboard comes from the ambient view context, so the
+ * toggle renders only while the user is on a dashboard page they own; on
+ * other surfaces it renders nothing. Toggle state derives from the dashboard
+ * detail cache — all charts of one analysis share the insight, so one toggle
+ * adds/removes the whole analysis.
+ */
+export default function AddToDashboardToggle({
+  insightId,
+}: {
+  insightId: string;
+}) {
+  const viewContext = useViewContextStore((s) => s.viewContext);
+  const dashboardId =
+    viewContext?.page === "dashboard" ? viewContext.dashboard_id : "";
+  const userId = useAuthStore((s) => s.userId);
+  // Disabled (and dataless) when dashboardId is "" — off dashboard surfaces
+  // the hook never fetches and the component renders nothing.
+  const { data: dashboard } = useDashboard(dashboardId);
+  const addWidget = useAddInsightWidget(dashboardId);
+  const deleteWidget = useDeleteWidget(dashboardId);
+
+  if (!dashboard || !userId || userId !== dashboard.user_id) return null;
+
+  const existing = dashboard.widgets.find((w) => w.insight_id === insightId);
+  const pending = addWidget.isPending || deleteWidget.isPending;
+
+  const onToggle = () => {
+    if (pending) return;
+    if (existing) {
+      deleteWidget.mutate(existing.id, {
+        onError: () =>
+          toaster.create({
+            title: "Couldn't remove from dashboard",
+            description: "The widget wasn't removed. Please try again.",
+            type: "error",
+            duration: 4000,
+          }),
+      });
+    } else {
+      addWidget.mutate(insightId, {
+        onError: () =>
+          toaster.create({
+            title: "Couldn't add to dashboard",
+            description: "The analysis wasn't added. Please try again.",
+            type: "error",
+            duration: 4000,
+          }),
+      });
+    }
+  };
+
+  return (
+    <Button
+      size="xs"
+      variant={existing ? "solid" : "outline"}
+      colorPalette={existing ? "primary" : undefined}
+      onClick={onToggle}
+      h={6}
+      rounded="sm"
+      color={existing ? undefined : "neutral.500"}
+      loading={pending}
+      aria-pressed={!!existing}
+      title={
+        existing
+          ? "Remove this analysis from the dashboard"
+          : "Add this analysis to the dashboard"
+      }
+    >
+      {existing ? <CheckIcon size={12} /> : <SquaresFourIcon size={12} />}
+      {existing ? "On dashboard" : "Add to dashboard"}
+    </Button>
+  );
+}

--- a/src/features/dashboards/ui/DashboardActionsMenu.tsx
+++ b/src/features/dashboards/ui/DashboardActionsMenu.tsx
@@ -93,18 +93,22 @@ export default function DashboardActionsMenu({
           </Menu.Content>
         </Menu.Positioner>
       </Menu.Root>
-      <DashboardRenameDialog
-        name={dashboard.name}
-        isOpen={renameOpen}
-        onOpenChange={setRenameOpen}
-        onRename={onRename}
-      />
-      <DashboardDeleteDialog
-        dashboardName={dashboard.name}
-        isOpen={deleteOpen}
-        onOpenChange={setDeleteOpen}
-        onConfirm={onDelete}
-      />
+      {renameOpen && (
+        <DashboardRenameDialog
+          name={dashboard.name}
+          isOpen={renameOpen}
+          onOpenChange={setRenameOpen}
+          onRename={onRename}
+        />
+      )}
+      {deleteOpen && (
+        <DashboardDeleteDialog
+          dashboardName={dashboard.name}
+          isOpen={deleteOpen}
+          onOpenChange={setDeleteOpen}
+          onConfirm={onDelete}
+        />
+      )}
     </>
   );
 }

--- a/src/features/dashboards/ui/DashboardActionsMenu.tsx
+++ b/src/features/dashboards/ui/DashboardActionsMenu.tsx
@@ -1,0 +1,229 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import {
+  Button,
+  Dialog,
+  IconButton,
+  Input,
+  Menu,
+  Portal,
+} from "@chakra-ui/react";
+import {
+  DotsThreeVerticalIcon,
+  PencilSimpleIcon,
+  TrashIcon,
+} from "@phosphor-icons/react";
+
+import { toaster } from "@/app/components/ui/toaster";
+import type { Dashboard } from "../api/schemas";
+import { useDeleteDashboard, useRenameDashboard } from "./dashboardQueries";
+
+export default function DashboardActionsMenu({
+  dashboard,
+}: {
+  dashboard: Dashboard;
+}) {
+  const [renameOpen, setRenameOpen] = useState(false);
+  const [deleteOpen, setDeleteOpen] = useState(false);
+  const renameDashboard = useRenameDashboard(dashboard.id);
+  const deleteDashboard = useDeleteDashboard();
+
+  const onRename = (name: string) => {
+    if (!name || name === dashboard.name) return;
+    renameDashboard.mutate(name, {
+      onError: () =>
+        toaster.create({
+          title: "Rename failed",
+          description:
+            "The dashboard name couldn't be saved. Please try again.",
+          type: "error",
+          duration: 4000,
+        }),
+    });
+  };
+
+  const onDelete = () => {
+    deleteDashboard.mutate(dashboard.id, {
+      onError: () =>
+        toaster.create({
+          title: "Delete failed",
+          description: "The dashboard couldn't be deleted. Please try again.",
+          type: "error",
+          duration: 4000,
+        }),
+    });
+  };
+
+  return (
+    <>
+      <Menu.Root positioning={{ strategy: "fixed", hideWhenDetached: true }}>
+        <Menu.Trigger asChild>
+          <IconButton
+            aria-label={`Dashboard actions for ${dashboard.name}`}
+            variant="ghost"
+            size="xs"
+            rounded="sm"
+            color="fg.muted"
+            bg="whiteAlpha.500"
+            _hover={{ bg: "blackAlpha.50" }}
+          >
+            <DotsThreeVerticalIcon size={16} weight="bold" />
+          </IconButton>
+        </Menu.Trigger>
+        <Menu.Positioner>
+          <Menu.Content>
+            <Menu.Item
+              value="rename dashboard"
+              color="fg.muted"
+              onSelect={() => setRenameOpen(true)}
+            >
+              <PencilSimpleIcon />
+              Rename
+            </Menu.Item>
+            <Menu.Item
+              value="delete dashboard"
+              color="fg.error"
+              _hover={{ bg: "bg.error", color: "fg.error" }}
+              onSelect={() => setDeleteOpen(true)}
+            >
+              <TrashIcon />
+              Delete
+            </Menu.Item>
+          </Menu.Content>
+        </Menu.Positioner>
+      </Menu.Root>
+      <DashboardRenameDialog
+        name={dashboard.name}
+        isOpen={renameOpen}
+        onOpenChange={setRenameOpen}
+        onRename={onRename}
+      />
+      <DashboardDeleteDialog
+        dashboardName={dashboard.name}
+        isOpen={deleteOpen}
+        onOpenChange={setDeleteOpen}
+        onConfirm={onDelete}
+      />
+    </>
+  );
+}
+
+function DashboardRenameDialog({
+  name,
+  isOpen,
+  onOpenChange,
+  onRename,
+}: {
+  name: string;
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+  onRename: (newName: string) => void;
+}) {
+  const ref = useRef<HTMLInputElement>(null);
+  const [draft, setDraft] = useState("");
+
+  useEffect(() => {
+    setDraft(name);
+  }, [name, isOpen]);
+
+  return (
+    <Dialog.Root
+      initialFocusEl={() => ref.current}
+      open={isOpen}
+      onOpenChange={({ open }) => onOpenChange(open)}
+    >
+      <Portal>
+        <Dialog.Backdrop />
+        <Dialog.Positioner>
+          <Dialog.Content
+            as="form"
+            onSubmit={(e) => {
+              e.preventDefault();
+              if (!draft.trim()) return;
+              onRename(draft.trim());
+              onOpenChange(false);
+            }}
+          >
+            <Dialog.Header>
+              <Dialog.Title>Rename dashboard</Dialog.Title>
+            </Dialog.Header>
+            <Dialog.Body pb="4">
+              <Input
+                ref={ref}
+                value={draft}
+                onChange={(e) => setDraft(e.target.value)}
+              />
+            </Dialog.Body>
+            <Dialog.Footer>
+              <Dialog.ActionTrigger asChild>
+                <Button variant="outline">Cancel</Button>
+              </Dialog.ActionTrigger>
+              <Button
+                colorPalette="blue"
+                disabled={!draft.trim()}
+                type="submit"
+              >
+                Save
+              </Button>
+            </Dialog.Footer>
+          </Dialog.Content>
+        </Dialog.Positioner>
+      </Portal>
+    </Dialog.Root>
+  );
+}
+
+function DashboardDeleteDialog({
+  dashboardName,
+  isOpen,
+  onOpenChange,
+  onConfirm,
+}: {
+  dashboardName: string;
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: () => void;
+}) {
+  return (
+    <Dialog.Root
+      role="alertdialog"
+      open={isOpen}
+      onOpenChange={({ open }) => onOpenChange(open)}
+    >
+      <Portal>
+        <Dialog.Backdrop />
+        <Dialog.Positioner>
+          <Dialog.Content>
+            <Dialog.Header>
+              <Dialog.Title>Are you sure?</Dialog.Title>
+            </Dialog.Header>
+            <Dialog.Body>
+              <p>
+                This action cannot be undone. This will permanently delete the
+                dashboard <strong>{dashboardName}</strong> and its widgets.
+                Insights referenced by the dashboard are kept.
+              </p>
+            </Dialog.Body>
+            <Dialog.Footer>
+              <Dialog.ActionTrigger asChild>
+                <Button variant="outline">Cancel</Button>
+              </Dialog.ActionTrigger>
+              <Dialog.ActionTrigger asChild>
+                <Button
+                  colorPalette="red"
+                  onClick={() => {
+                    onOpenChange(false);
+                    onConfirm();
+                  }}
+                >
+                  Delete
+                </Button>
+              </Dialog.ActionTrigger>
+            </Dialog.Footer>
+          </Dialog.Content>
+        </Dialog.Positioner>
+      </Portal>
+    </Dialog.Root>
+  );
+}

--- a/src/features/dashboards/ui/DashboardActionsMenu.tsx
+++ b/src/features/dashboards/ui/DashboardActionsMenu.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useRef, useState } from "react";
 import {
   Button,
   Dialog,
@@ -121,11 +121,14 @@ function DashboardRenameDialog({
   onRename: (newName: string) => void;
 }) {
   const ref = useRef<HTMLInputElement>(null);
-  const [draft, setDraft] = useState("");
-
-  useEffect(() => {
-    setDraft(name);
-  }, [name, isOpen]);
+  const [draft, setDraft] = useState(name);
+  // Re-seed the draft from the current name each time the dialog opens
+  // (render-time derived state, not an effect, to avoid a cascading render).
+  const [prevOpen, setPrevOpen] = useState(isOpen);
+  if (prevOpen !== isOpen) {
+    setPrevOpen(isOpen);
+    if (isOpen) setDraft(name);
+  }
 
   return (
     <Dialog.Root

--- a/src/features/dashboards/ui/DashboardCard.tsx
+++ b/src/features/dashboards/ui/DashboardCard.tsx
@@ -2,72 +2,78 @@
 
 import Link from "next/link";
 import { Box, Flex, Heading, Link as ChakraLink, Text } from "@chakra-ui/react";
-import { MapPinIcon } from "@phosphor-icons/react";
+import { LockIcon, PolygonIcon } from "@phosphor-icons/react";
 
 import type { Dashboard } from "../api/schemas";
-import { sourceLabel } from "../lib/aoi";
 import { updatedLabel } from "../lib/dates";
+import DashboardActionsMenu from "./DashboardActionsMenu";
 
 export default function DashboardCard({ dashboard }: { dashboard: Dashboard }) {
   const primaryAoi = dashboard.aois[0];
-  const widgetCount = dashboard.widgets.length;
 
   return (
-    <ChakraLink
-      asChild
-      display="flex"
-      flexDir="column"
-      minH="180px"
-      bg="white"
-      borderWidth="1px"
-      borderColor="border"
-      borderTopWidth="2px"
-      borderTopColor="primary.solid"
-      borderRadius="sm"
-      overflow="hidden"
-      transition="border-color 0.16s ease, box-shadow 0.16s ease"
-      _hover={{
-        borderColor: "primary.solid",
-        boxShadow: "sm",
-        textDecor: "none",
-      }}
-      _focusVisible={{
-        outline: "2px solid",
-        outlineColor: "primary.focusRing",
-        outlineOffset: "2px",
-      }}
-    >
-      <Link href={`/dashboards/${dashboard.id}?ff=dashboard`}>
-        <Flex
-          flex="1"
-          direction="column"
-          justify="flex-end"
-          gap={3}
-          p={4}
-          pt={12}
-        >
-          {primaryAoi && (
-            <Flex align="center" gap={1.5} color="primary.solid" fontSize="xs">
-              <MapPinIcon size={14} />
-              <Text lineClamp={1}>{primaryAoi.name}</Text>
-            </Flex>
-          )}
-          <Box>
-            <Heading as="h2" size="sm" fontWeight="medium" lineClamp={2}>
+    <Box position="relative" display="flex" flexDir="column">
+      <ChakraLink
+        asChild
+        display="flex"
+        flexDir="column"
+        flex="1"
+        minH="308px"
+        bg="white"
+        borderWidth="1px"
+        borderColor="border"
+        borderTopWidth="2px"
+        borderTopColor="primary.solid"
+        borderRadius="sm"
+        overflow="hidden"
+        transition="border-color 0.16s ease, box-shadow 0.16s ease"
+        _hover={{
+          borderColor: "primary.solid",
+          boxShadow: "sm",
+          textDecor: "none",
+        }}
+        _focusVisible={{
+          outline: "2px solid",
+          outlineColor: "primary.focusRing",
+          outlineOffset: "2px",
+        }}
+      >
+        <Link href={`/dashboards/${dashboard.id}?ff=dashboard`}>
+          <Flex
+            flex="1"
+            direction="column"
+            justify="flex-end"
+            gap={2}
+            p={5}
+            pt={16}
+          >
+            {primaryAoi && (
+              <Flex align="center" gap={2} color="primary.solid" fontSize="xs">
+                <PolygonIcon size={16} />
+                <Text lineClamp={1}>{primaryAoi.name}</Text>
+              </Flex>
+            )}
+            <Heading
+              as="h2"
+              fontSize="lg"
+              fontWeight="normal"
+              lineHeight="1.4"
+              lineClamp={3}
+            >
               {dashboard.name}
             </Heading>
-            {primaryAoi && (
-              <Text color="fg.muted" fontSize="xs" mt={1} lineClamp={1}>
-                {sourceLabel(primaryAoi.source)}
-              </Text>
-            )}
-          </Box>
-          <Text color="fg.muted" fontSize="xs">
-            {updatedLabel(dashboard.updated_at)}
-            {widgetCount > 0 ? ` · ${widgetCount} widgets` : ""}
-          </Text>
-        </Flex>
-      </Link>
-    </ChakraLink>
+            <Flex align="center" gap={2} color="fg.muted" fontSize="xs">
+              {!dashboard.is_public && <LockIcon size={16} />}
+              <Text>{updatedLabel(dashboard.updated_at)}</Text>
+            </Flex>
+          </Flex>
+        </Link>
+      </ChakraLink>
+      {/* Sibling of the link, not a child — a button inside an anchor would
+          trigger navigation on menu clicks. */}
+      <Box position="absolute" top={5} right={5}>
+        <DashboardActionsMenu dashboard={dashboard} />
+      </Box>
+    </Box>
   );
 }

--- a/src/features/dashboards/ui/DashboardCard.tsx
+++ b/src/features/dashboards/ui/DashboardCard.tsx
@@ -7,6 +7,7 @@ import { LockIcon, PolygonIcon } from "@phosphor-icons/react";
 import type { Dashboard } from "../api/schemas";
 import { updatedLabel } from "../lib/dates";
 import DashboardActionsMenu from "./DashboardActionsMenu";
+import { HERO_GRID_IMAGE } from "./heroGrid";
 
 export default function DashboardCard({ dashboard }: { dashboard: Dashboard }) {
   const primaryAoi = dashboard.aois[0];
@@ -17,9 +18,14 @@ export default function DashboardCard({ dashboard }: { dashboard: Dashboard }) {
         asChild
         display="flex"
         flexDir="column"
+        // Chakra's Link defaults to align-items: center, which would centre
+        // the column content; the design is left-justified.
+        alignItems="stretch"
+        textAlign="left"
         flex="1"
         minH="308px"
         bg="white"
+        backgroundImage={HERO_GRID_IMAGE}
         borderWidth="1px"
         borderColor="border"
         borderTopWidth="2px"

--- a/src/features/dashboards/ui/DashboardChatNudges.tsx
+++ b/src/features/dashboards/ui/DashboardChatNudges.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import { Box, Flex, Heading, Text } from "@chakra-ui/react";
+
+import useChatStore from "@/app/store/chatStore";
+import useViewContextStore from "@/app/store/viewContextStore";
+import { useDashboard } from "./dashboardQueries";
+
+/**
+ * The dashboard surface's chat greeting (Figma node 1317-4279), rendered in
+ * place of the map welcome message. Copy is deliberately generic — no
+ * dataset/AOI templating yet — and every chip maps to an action the
+ * experimental agent profile can actually take (generate_insights +
+ * add_to_dashboard, show_imagery + add_map_widget, inspect_view_context,
+ * search_blogs). The variant flips on widget count: an empty dashboard gets
+ * "start building" framing, a populated one "refine".
+ */
+const NUDGE_VARIANTS = {
+  build: {
+    heading: "Start building this dashboard",
+    body: "I can help you add analyses, maps, and context to this dashboard.",
+    chips: [
+      "Analyse recent tree cover loss in this area and add it to the dashboard",
+      "Add a satellite imagery map of this area",
+      "What's driving recent forest loss in this area?",
+    ],
+  },
+  refine: {
+    heading: "Refine this dashboard",
+    body: "I can help you add new analyses, maps, or context to make this dashboard more useful.",
+    chips: [
+      "Summarize what this dashboard shows",
+      "Analyse land cover change in this area and add it to the dashboard",
+      "Add a satellite imagery map of this area",
+    ],
+  },
+} as const;
+
+interface DashboardChatNudgesProps {
+  /**
+   * Chips belong to the naked (pre-first-prompt) state only; the greeting
+   * itself persists as the conversation's first block, like the map welcome.
+   */
+  showChips: boolean;
+}
+
+export default function DashboardChatNudges({
+  showChips,
+}: DashboardChatNudgesProps) {
+  const viewContext = useViewContextStore((s) => s.viewContext);
+  const dashboardId =
+    viewContext?.page === "dashboard" ? viewContext.dashboard_id : "";
+  const { data: dashboard } = useDashboard(dashboardId);
+  const sendMessage = useChatStore((s) => s.sendMessage);
+
+  // The detail page's own useDashboard call keeps this cache warm; until it
+  // resolves neither variant is right, so render nothing rather than flash.
+  if (!dashboard) return null;
+
+  const variant =
+    dashboard.widgets.length === 0
+      ? NUDGE_VARIANTS.build
+      : NUDGE_VARIANTS.refine;
+
+  return (
+    <Flex direction="column" gap={4} mt={2} mb={2}>
+      <Box>
+        {/* blue/blue-70 per the Figma page shell, as elsewhere in the feature */}
+        <Heading
+          as="h2"
+          fontSize="md"
+          fontWeight="medium"
+          color="#0049AA"
+          mb={2}
+        >
+          {variant.heading}
+        </Heading>
+        <Text fontSize="xs">{variant.body}</Text>
+      </Box>
+      {showChips && (
+        <Flex direction="column" gap={3}>
+          <Text fontSize="xs" color="fg.muted">
+            You might want to:
+          </Text>
+          <Flex direction="column" gap={2}>
+            {variant.chips.map((chip) => (
+              <Box
+                as="button"
+                key={chip}
+                px={3}
+                py={2}
+                rounded="lg"
+                border="1px solid"
+                borderColor="border.emphasized"
+                fontSize="xs"
+                textAlign="left"
+                bg="bg"
+                transition="all 0.24s ease"
+                _hover={{
+                  cursor: "pointer",
+                  bg: "bg.subtle",
+                  borderColor: "primary.solid",
+                }}
+                onClick={() => sendMessage(chip)}
+              >
+                {chip}
+              </Box>
+            ))}
+          </Flex>
+        </Flex>
+      )}
+    </Flex>
+  );
+}

--- a/src/features/dashboards/ui/DashboardChatNudges.tsx
+++ b/src/features/dashboards/ui/DashboardChatNudges.tsx
@@ -100,9 +100,7 @@ export default function DashboardChatNudges({
                   cursor: "pointer",
                   bg: "bg.subtle",
                   borderColor: "primary.solid",
-                }}
-                onClick={() => sendMessage(chip)}
-              >
+                onClick={() => void sendMessage(chip)}
                 {chip}
               </Box>
             ))}

--- a/src/features/dashboards/ui/DashboardChatNudges.tsx
+++ b/src/features/dashboards/ui/DashboardChatNudges.tsx
@@ -100,7 +100,9 @@ export default function DashboardChatNudges({
                   cursor: "pointer",
                   bg: "bg.subtle",
                   borderColor: "primary.solid",
+                }}
                 onClick={() => void sendMessage(chip)}
+              >
                 {chip}
               </Box>
             ))}

--- a/src/features/dashboards/ui/DashboardDetailPage.tsx
+++ b/src/features/dashboards/ui/DashboardDetailPage.tsx
@@ -24,6 +24,16 @@ import { useDashboard } from "./dashboardQueries";
 import DashboardHeader from "./DashboardHeader";
 import DashboardWidgetsGrid from "./DashboardWidgetsGrid";
 
+// Graph-paper hero per the Figma page shell (node 1317-3730): minor 1px
+// #FCFCFC lines every 7px with a stronger #F9F9FA line every 70px, on white.
+// Major lines listed first so they paint over coincident minor lines.
+const HERO_GRID_IMAGE = [
+  "repeating-linear-gradient(to right, #F9F9FA 0 1px, transparent 1px 70px)",
+  "repeating-linear-gradient(to bottom, #F9F9FA 0 1px, transparent 1px 70px)",
+  "repeating-linear-gradient(to right, #FCFCFC 0 1px, transparent 1px 7px)",
+  "repeating-linear-gradient(to bottom, #FCFCFC 0 1px, transparent 1px 7px)",
+].join(",");
+
 export default function DashboardDetailPage() {
   const params = useParams<{ id: string }>();
   const dashboardId = params?.id ?? "";
@@ -59,7 +69,9 @@ export default function DashboardDetailPage() {
     <Box
       bg="#F4F5F6"
       minH="calc(100vh - 40px)"
-      py={{ base: 8, md: 10 }}
+      // 24px nav-to-breadcrumb per the Figma page shell; roomier bottom.
+      pt={6}
+      pb={{ base: 8, md: 10 }}
       pl={{
         base: 0,
         md: `${getDashboardContentLeftPx(isChatFullSize)}px`,
@@ -101,19 +113,25 @@ export default function DashboardDetailPage() {
               Could not load this dashboard.
             </Text>
           ) : (
+            // The Figma page shell: white card with a 2px blue accent and a
+            // 200px graph-paper hero band across the top.
             <Box
-              bg="white"
+              bgColor="white"
               minH="70vh"
+              backgroundImage={HERO_GRID_IMAGE}
+              backgroundRepeat="no-repeat"
+              backgroundSize="100% 200px"
               borderWidth="1px"
               borderTopWidth="2px"
-              borderTopColor="primary.solid"
+              borderTopColor="#0049AA"
               borderColor="rgba(19,22,25,0.1)"
               borderRadius="8px"
               px={{ base: 6, md: "46px" }}
               pt={{ base: 6, md: "38px" }}
               pb={{ base: 6, md: "46px" }}
             >
-              <Box mb={{ base: 8, md: 16 }}>
+              {/* 75px puts the widgets at the mock's 174px card offset. */}
+              <Box mb={{ base: 8, md: "75px" }}>
                 <DashboardHeader dashboard={dashboard} isOwner={isOwner} />
               </Box>
 

--- a/src/features/dashboards/ui/DashboardDetailPage.tsx
+++ b/src/features/dashboards/ui/DashboardDetailPage.tsx
@@ -15,7 +15,9 @@ import {
 import { MapPinIcon, SquaresFourIcon } from "@phosphor-icons/react";
 
 import ChatPanel from "@/app/ChatPanel";
+import { getDashboardContentLeftPx } from "@/app/explorationLayout";
 import useAgentProfileStore from "@/app/store/agentProfileStore";
+import useSidebarStore from "@/app/store/sidebarStore";
 import useViewContextStore from "@/app/store/viewContextStore";
 import { sourceLabel, subtypeLabel } from "../lib/aoi";
 import { updatedLabel } from "../lib/dates";
@@ -26,6 +28,7 @@ export default function DashboardDetailPage() {
   const params = useParams<{ id: string }>();
   const dashboardId = params?.id ?? "";
   const { data: dashboard, isLoading, isError } = useDashboard(dashboardId);
+  const isChatFullSize = useSidebarStore((s) => s.isChatFullSize);
 
   useEffect(() => {
     // The dashboard agent tools are gated behind ?agent_profile=…; capture it
@@ -48,7 +51,19 @@ export default function DashboardDetailPage() {
   }, [dashboardId, dashboard?.name]);
 
   return (
-    <Box bg="#F4F5F6" minH="calc(100vh - 40px)" py={{ base: 8, md: 10 }}>
+    // The full-size chat is a fixed, full-height overlay on the left, so the
+    // content pane pads past it and the centered container re-centers in the
+    // remaining space. Duration matches the chat's own resize animation.
+    <Box
+      bg="#F4F5F6"
+      minH="calc(100vh - 40px)"
+      py={{ base: 8, md: 10 }}
+      pl={{
+        base: 0,
+        md: `${getDashboardContentLeftPx(isChatFullSize)}px`,
+      }}
+      transition="padding-left 0.2s ease-in-out"
+    >
       {/* Chat overlay — the same conversation as the map app (chatStore is a
           singleton). Fixed below the 40px header so it stays put while the
           dashboard content scrolls. Desktop-only for now; the mobile bottom

--- a/src/features/dashboards/ui/DashboardDetailPage.tsx
+++ b/src/features/dashboards/ui/DashboardDetailPage.tsx
@@ -20,6 +20,7 @@ import useViewContextStore from "@/app/store/viewContextStore";
 import { sourceLabel, subtypeLabel } from "../lib/aoi";
 import { updatedLabel } from "../lib/dates";
 import { useDashboard } from "./dashboardQueries";
+import DashboardWidgetsGrid from "./DashboardWidgetsGrid";
 
 export default function DashboardDetailPage() {
   const params = useParams<{ id: string }>();
@@ -129,29 +130,33 @@ export default function DashboardDetailPage() {
                 </Flex>
               )}
 
-              <Flex
-                minH="320px"
-                align="center"
-                justify="center"
-                borderWidth="1px"
-                borderStyle="dashed"
-                borderColor="border"
-                borderRadius="sm"
-                bg="white"
-                px={6}
-                textAlign="center"
-              >
-                <Box maxW="md">
-                  <SquaresFourIcon size={32} color="#656E7B" />
-                  <Heading as="h2" size="md" mt={4} mb={2}>
-                    This dashboard is empty
-                  </Heading>
-                  <Text color="fg.muted">
-                    The dashboard has been created for this area. Widgets,
-                    analyses, and maps can be added in a later slice.
-                  </Text>
-                </Box>
-              </Flex>
+              {dashboard.widgets.length > 0 ? (
+                <DashboardWidgetsGrid dashboard={dashboard} />
+              ) : (
+                <Flex
+                  minH="320px"
+                  align="center"
+                  justify="center"
+                  borderWidth="1px"
+                  borderStyle="dashed"
+                  borderColor="border"
+                  borderRadius="sm"
+                  bg="white"
+                  px={6}
+                  textAlign="center"
+                >
+                  <Box maxW="md">
+                    <SquaresFourIcon size={32} color="#656E7B" />
+                    <Heading as="h2" size="md" mt={4} mb={2}>
+                      This dashboard is empty
+                    </Heading>
+                    <Text color="fg.muted">
+                      Ask the AI assistant to analyse this area — insights it
+                      adds to the dashboard will appear here.
+                    </Text>
+                  </Box>
+                </Flex>
+              )}
             </Box>
           )}
         </Flex>

--- a/src/features/dashboards/ui/DashboardDetailPage.tsx
+++ b/src/features/dashboards/ui/DashboardDetailPage.tsx
@@ -12,16 +12,16 @@ import {
   Text,
   Link as ChakraLink,
 } from "@chakra-ui/react";
-import { MapPinIcon, SquaresFourIcon } from "@phosphor-icons/react";
+import { SquaresFourIcon } from "@phosphor-icons/react";
 
 import ChatPanel from "@/app/ChatPanel";
 import { getDashboardContentLeftPx } from "@/app/explorationLayout";
 import useAgentProfileStore from "@/app/store/agentProfileStore";
+import useAuthStore from "@/app/store/authStore";
 import useSidebarStore from "@/app/store/sidebarStore";
 import useViewContextStore from "@/app/store/viewContextStore";
-import { sourceLabel, subtypeLabel } from "../lib/aoi";
-import { updatedLabel } from "../lib/dates";
 import { useDashboard } from "./dashboardQueries";
+import DashboardHeader from "./DashboardHeader";
 import DashboardWidgetsGrid from "./DashboardWidgetsGrid";
 
 export default function DashboardDetailPage() {
@@ -29,6 +29,8 @@ export default function DashboardDetailPage() {
   const dashboardId = params?.id ?? "";
   const { data: dashboard, isLoading, isError } = useDashboard(dashboardId);
   const isChatFullSize = useSidebarStore((s) => s.isChatFullSize);
+  const userId = useAuthStore((s) => s.userId);
+  const isOwner = !!userId && userId === dashboard?.user_id;
 
   useEffect(() => {
     // The dashboard agent tools are gated behind ?agent_profile=…; capture it
@@ -80,14 +82,14 @@ export default function DashboardDetailPage() {
       >
         <ChatPanel />
       </Box>
-      <Container maxW="6xl">
-        <Flex direction="column" gap={4}>
-          <Flex align="center" gap={2} color="fg.muted" fontSize="sm">
-            <ChakraLink asChild color="fg.muted">
+      <Container maxW="1232px">
+        <Flex direction="column" gap="12px">
+          <Flex align="center" gap="8px" fontSize="14px" lineHeight="16px">
+            <ChakraLink asChild color="#565E7B">
               <Link href="/dashboards?ff=dashboard">Dashboards</Link>
             </ChakraLink>
-            <Text>/</Text>
-            <Text color="fg">{dashboard?.name ?? "Dashboard"}</Text>
+            <Text color="#C2C7D0">/</Text>
+            <Text color="#565E7B">{dashboard?.name ?? "Dashboard"}</Text>
           </Flex>
 
           {isLoading ? (
@@ -105,45 +107,15 @@ export default function DashboardDetailPage() {
               borderWidth="1px"
               borderTopWidth="2px"
               borderTopColor="primary.solid"
-              borderColor="border"
-              borderRadius="sm"
-              p={{ base: 6, md: 10 }}
+              borderColor="rgba(19,22,25,0.1)"
+              borderRadius="8px"
+              px={{ base: 6, md: "46px" }}
+              pt={{ base: 6, md: "38px" }}
+              pb={{ base: 6, md: "46px" }}
             >
-              <Flex justify="space-between" align="flex-start" gap={6} mb={10}>
-                <Box>
-                  <Heading as="h1" size="2xl" fontWeight="normal">
-                    {dashboard.name}
-                  </Heading>
-                  <Text color="fg.muted" fontSize="xs" mt={2}>
-                    {updatedLabel(dashboard.updated_at)}
-                  </Text>
-                </Box>
-              </Flex>
-
-              {dashboard.aois[0] && (
-                <Flex
-                  align="center"
-                  gap={3}
-                  bg="bg.subtle"
-                  borderWidth="1px"
-                  borderColor="border"
-                  borderRadius="sm"
-                  p={4}
-                  mb={8}
-                  maxW="xl"
-                >
-                  <MapPinIcon size={20} color="#0049AA" />
-                  <Box>
-                    <Text fontWeight="medium">{dashboard.aois[0].name}</Text>
-                    <Text color="fg.muted" fontSize="sm">
-                      {sourceLabel(dashboard.aois[0].source)}
-                      {dashboard.aois[0].subtype
-                        ? ` · ${subtypeLabel(dashboard.aois[0].subtype)}`
-                        : ""}
-                    </Text>
-                  </Box>
-                </Flex>
-              )}
+              <Box mb={{ base: 8, md: 16 }}>
+                <DashboardHeader dashboard={dashboard} isOwner={isOwner} />
+              </Box>
 
               {dashboard.widgets.length > 0 ? (
                 <DashboardWidgetsGrid dashboard={dashboard} />

--- a/src/features/dashboards/ui/DashboardDetailPage.tsx
+++ b/src/features/dashboards/ui/DashboardDetailPage.tsx
@@ -23,16 +23,7 @@ import useViewContextStore from "@/app/store/viewContextStore";
 import { useDashboard } from "./dashboardQueries";
 import DashboardHeader from "./DashboardHeader";
 import DashboardWidgetsGrid from "./DashboardWidgetsGrid";
-
-// Graph-paper hero per the Figma page shell (node 1317-3730): minor 1px
-// #FCFCFC lines every 7px with a stronger #F9F9FA line every 70px, on white.
-// Major lines listed first so they paint over coincident minor lines.
-const HERO_GRID_IMAGE = [
-  "repeating-linear-gradient(to right, #F9F9FA 0 1px, transparent 1px 70px)",
-  "repeating-linear-gradient(to bottom, #F9F9FA 0 1px, transparent 1px 70px)",
-  "repeating-linear-gradient(to right, #FCFCFC 0 1px, transparent 1px 7px)",
-  "repeating-linear-gradient(to bottom, #FCFCFC 0 1px, transparent 1px 7px)",
-].join(",");
+import { HERO_GRID_IMAGE } from "./heroGrid";
 
 export default function DashboardDetailPage() {
   const params = useParams<{ id: string }>();

--- a/src/features/dashboards/ui/DashboardDetailPage.tsx
+++ b/src/features/dashboards/ui/DashboardDetailPage.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { useParams } from "next/navigation";
+import { useEffect } from "react";
 import {
   Box,
   Container,
@@ -13,6 +14,9 @@ import {
 } from "@chakra-ui/react";
 import { MapPinIcon, SquaresFourIcon } from "@phosphor-icons/react";
 
+import ChatPanel from "@/app/ChatPanel";
+import useAgentProfileStore from "@/app/store/agentProfileStore";
+import useViewContextStore from "@/app/store/viewContextStore";
 import { sourceLabel, subtypeLabel } from "../lib/aoi";
 import { updatedLabel } from "../lib/dates";
 import { useDashboard } from "./dashboardQueries";
@@ -22,8 +26,44 @@ export default function DashboardDetailPage() {
   const dashboardId = params?.id ?? "";
   const { data: dashboard, isLoading, isError } = useDashboard(dashboardId);
 
+  useEffect(() => {
+    // The dashboard agent tools are gated behind ?agent_profile=…; capture it
+    // here too, since a direct dashboard landing never mounts the app chat
+    // layout (the only other capture point).
+    useAgentProfileStore.getState().initFromUrl();
+  }, []);
+
+  useEffect(() => {
+    // Report this surface to the agent on every chat request ("this
+    // dashboard" scoping, add_to_dashboard default target). The name rides
+    // along once the query resolves so the agent can name the dashboard
+    // without a DB read.
+    if (!dashboardId) return;
+    useViewContextStore.getState().setViewContext({
+      page: "dashboard",
+      dashboard_id: dashboardId,
+      ...(dashboard?.name && { dashboard_name: dashboard.name }),
+    });
+  }, [dashboardId, dashboard?.name]);
+
   return (
     <Box bg="#F4F5F6" minH="calc(100vh - 40px)" py={{ base: 8, md: 10 }}>
+      {/* Chat overlay — the same conversation as the map app (chatStore is a
+          singleton). Fixed below the 40px header so it stays put while the
+          dashboard content scrolls. Desktop-only for now; the mobile bottom
+          sheet is a later slice. */}
+      <Box
+        position="fixed"
+        top="40px"
+        bottom={0}
+        left={0}
+        zIndex={1100}
+        display={{ base: "none", md: "flex" }}
+        flexDir="column"
+        pointerEvents="none"
+      >
+        <ChatPanel />
+      </Box>
       <Container maxW="6xl">
         <Flex direction="column" gap={4}>
           <Flex align="center" gap={2} color="fg.muted" fontSize="sm">

--- a/src/features/dashboards/ui/DashboardFeatureGate.tsx
+++ b/src/features/dashboards/ui/DashboardFeatureGate.tsx
@@ -1,10 +1,10 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 import type { ReactNode } from "react";
 import { useRouter } from "next/navigation";
 
-import { useFeatureFlag } from "@/src/shared/lib/feature-flags";
+import { isFeatureEnabled } from "@/src/shared/lib/feature-flags";
 
 export default function DashboardFeatureGate({
   children,
@@ -12,10 +12,20 @@ export default function DashboardFeatureGate({
   children: ReactNode;
 }) {
   const router = useRouter();
-  const enabled = useFeatureFlag("dashboard");
+  // null = not checked yet. The check must run post-commit: during a
+  // client-side navigation the first render still sees the *previous* URL
+  // (Next updates window.location on commit), so a render-time read closes
+  // the gate even when the destination URL carries ?ff=dashboard.
+  const [enabled, setEnabled] = useState<boolean | null>(null);
 
   useEffect(() => {
-    if (!enabled) router.replace("/app");
+    setEnabled(
+      isFeatureEnabled(new URLSearchParams(window.location.search), "dashboard")
+    );
+  }, []);
+
+  useEffect(() => {
+    if (enabled === false) router.replace("/app");
   }, [enabled, router]);
 
   if (!enabled) return null;

--- a/src/features/dashboards/ui/DashboardHeader.tsx
+++ b/src/features/dashboards/ui/DashboardHeader.tsx
@@ -1,0 +1,155 @@
+"use client";
+
+import { useState } from "react";
+import {
+  Box,
+  Button,
+  Flex,
+  Heading,
+  IconButton,
+  Input,
+  Text,
+} from "@chakra-ui/react";
+import {
+  FilePdfIcon,
+  PencilSimpleIcon,
+  ShareIcon,
+} from "@phosphor-icons/react";
+
+import { toaster } from "@/app/components/ui/toaster";
+import type { Dashboard } from "../api/schemas";
+import { updatedLabel } from "../lib/dates";
+import { useRenameDashboard } from "./dashboardQueries";
+
+/**
+ * Dashboard page header per the Figma "Dashboard default" frame: editable
+ * 30px title with a pencil affordance (owner only), the mono "Updated…"
+ * label, and Export / Share actions top-right. Export and Share are false
+ * doors — measure interest before building the real flows.
+ */
+export default function DashboardHeader({
+  dashboard,
+  isOwner,
+}: {
+  dashboard: Dashboard;
+  isOwner: boolean;
+}) {
+  const [draft, setDraft] = useState<string | null>(null);
+  const renameDashboard = useRenameDashboard(dashboard.id);
+  const editing = draft !== null;
+
+  const commit = () => {
+    const name = draft?.trim();
+    setDraft(null);
+    if (!name || name === dashboard.name) return;
+    renameDashboard.mutate(name, {
+      onError: () =>
+        toaster.create({
+          title: "Rename failed",
+          description:
+            "The dashboard name couldn't be saved. Please try again.",
+          type: "error",
+          duration: 4000,
+        }),
+    });
+  };
+
+  const falseDoor = (description: string) => () =>
+    toaster.create({
+      title: "Coming soon",
+      description,
+      type: "info",
+      duration: 3000,
+    });
+
+  const actionStyle = {
+    h: "24px",
+    px: "8px",
+    gap: "4px",
+    borderColor: "rgba(19,22,25,0.2)",
+    rounded: "sm",
+    fontSize: "12px",
+    fontWeight: "medium",
+    color: "rgba(19,22,25,0.7)",
+  } as const;
+
+  return (
+    <Flex justify="space-between" align="flex-start" gap={6}>
+      <Box minW={0} flex="1">
+        <Flex align="center" gap="12px">
+          {editing ? (
+            <Input
+              value={draft}
+              onChange={(e) => setDraft(e.target.value)}
+              onBlur={commit}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") commit();
+                if (e.key === "Escape") setDraft(null);
+              }}
+              autoFocus
+              aria-label="Dashboard name"
+              variant="flushed"
+              fontSize="30px"
+              lineHeight="36px"
+              h="40px"
+              maxW="2xl"
+            />
+          ) : (
+            <Heading
+              as="h1"
+              fontSize="30px"
+              lineHeight="36px"
+              fontWeight="normal"
+              color="#131619"
+              wordBreak="break-word"
+            >
+              {dashboard.name}
+            </Heading>
+          )}
+          {isOwner && !editing && (
+            <IconButton
+              aria-label="Rename dashboard"
+              title="Rename dashboard"
+              size="xs"
+              variant="ghost"
+              color="fg.muted"
+              onClick={() => setDraft(dashboard.name)}
+            >
+              <PencilSimpleIcon size={20} />
+            </IconButton>
+          )}
+        </Flex>
+        <Text
+          mt="7px"
+          fontFamily="mono"
+          fontSize="10px"
+          lineHeight="16px"
+          color="rgba(19,22,25,0.7)"
+        >
+          {updatedLabel(dashboard.updated_at)}
+        </Text>
+      </Box>
+
+      <Flex gap="12px" align="center" flexShrink={0}>
+        <Button
+          variant="outline"
+          {...actionStyle}
+          onClick={falseDoor(
+            "Exporting dashboards to PDF isn't available yet."
+          )}
+        >
+          <FilePdfIcon size={16} />
+          Export
+        </Button>
+        <Button
+          variant="outline"
+          {...actionStyle}
+          onClick={falseDoor("Sharing dashboards isn't available yet.")}
+        >
+          <ShareIcon size={16} />
+          Share
+        </Button>
+      </Flex>
+    </Flex>
+  );
+}

--- a/src/features/dashboards/ui/DashboardMapLegend.tsx
+++ b/src/features/dashboards/ui/DashboardMapLegend.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { Text } from "@chakra-ui/react";
+
+import { Legend } from "@/app/components/legend/Legend";
+import type {
+  LegendContextLayer,
+  LegendLayer,
+} from "@/app/components/legend/types";
+import {
+  buildParams,
+  renderLegendSymbology,
+} from "@/app/components/legend/useLegendHook";
+import {
+  CONTEXT_LAYER_METADATA,
+  DATASET_CARDS,
+} from "@/app/constants/datasets";
+import { buildYearParam } from "@/app/utils/formatYearRange";
+import type { MapWidgetLayer } from "../lib/mapWidgets";
+
+/** Per-sub-layer legend opacity, 0–100 (main dataset · context sub-layer). */
+export interface MapWidgetOpacity {
+  main: number;
+  context: number;
+}
+
+/**
+ * The explorer's Legend reused inside a dashboard map widget, built from the
+ * widget's config snapshot instead of mapStore layers. Dataset widgets only —
+ * imagery has no DATASET_CARDS entry — and no AOI chips (the dashboard's area
+ * is fixed, not removable). The layer itself isn't removable either (the
+ * card's ✕ removes the whole widget), so only opacity is actionable.
+ */
+export default function DashboardMapLegend({
+  layer,
+  opacity,
+  onOpacityChange,
+}: {
+  layer: MapWidgetLayer;
+  opacity: MapWidgetOpacity;
+  onOpacityChange: (target: keyof MapWidgetOpacity, value: number) => void;
+}) {
+  const card =
+    layer.datasetId != null
+      ? DATASET_CARDS.find((d) => d.dataset_id === layer.datasetId)
+      : undefined;
+  if (!card?.legend) return null;
+  const legend = card.legend;
+
+  // Same fallback the explorer applies (getDatasetLayerContextProps): configs
+  // without explicit parameters rendered with the card's default threshold.
+  const parameters =
+    layer.parameters ??
+    (typeof card.threshold === "number"
+      ? { canopy_cover: card.threshold }
+      : {});
+  const params = buildParams(
+    parameters,
+    buildYearParam(layer.startDate, layer.endDate)
+  );
+
+  let contextLayer: LegendContextLayer | undefined;
+  if (layer.contextTileUrl && layer.contextLayerName) {
+    const ctxLegend = CONTEXT_LAYER_METADATA[layer.contextLayerName]?.legend;
+    contextLayer = {
+      id: "context",
+      title: ctxLegend?.title ?? layer.contextLayerName,
+      color: ctxLegend?.items?.[0]?.color ?? ctxLegend?.color ?? "#888",
+      opacity: opacity.context,
+      info: ctxLegend?.info,
+    };
+  }
+
+  const entry: LegendLayer = {
+    id: "main",
+    title: legend.title,
+    opacity: opacity.main,
+    info: legend.info,
+    params: params.length > 0 ? params : undefined,
+    contextLayer,
+    symbology: renderLegendSymbology(legend),
+    children: legend.note ? (
+      <Text fontSize="xs">{legend.note}</Text>
+    ) : undefined,
+    hideRemoveControl: true,
+  };
+
+  return (
+    <Legend
+      layers={[entry]}
+      onLayerAction={({ action, payload }) => {
+        if (action === "opacity") {
+          onOpacityChange(
+            payload.id === "context" ? "context" : "main",
+            payload.opacity
+          );
+        }
+      }}
+    />
+  );
+}

--- a/src/features/dashboards/ui/DashboardMapLegend.tsx
+++ b/src/features/dashboards/ui/DashboardMapLegend.tsx
@@ -88,6 +88,7 @@ export default function DashboardMapLegend({
   return (
     <Legend
       layers={[entry]}
+      compact
       onLayerAction={({ action, payload }) => {
         if (action === "opacity") {
           onOpacityChange(

--- a/src/features/dashboards/ui/DashboardMapWidget.tsx
+++ b/src/features/dashboards/ui/DashboardMapWidget.tsx
@@ -10,6 +10,7 @@ import MapGl, {
   AttributionControl,
   Layer,
   Marker,
+  NavigationControl,
   Source,
   type MapRef,
 } from "react-map-gl/maplibre";
@@ -96,7 +97,11 @@ export default function DashboardMapWidget({
         [bounds[0], bounds[1]],
         [bounds[2], bounds[3]],
       ],
-      { padding: 24, duration: 0 }
+      {
+        // Extra top headroom: the area label chip hangs above the bbox corner.
+        padding: { top: 56, right: 32, bottom: 32, left: 32 },
+        duration: 0,
+      }
     );
   };
 
@@ -104,8 +109,27 @@ export default function DashboardMapWidget({
   // completes last (the effect covers late bounds, onLoad covers late maps).
   useEffect(fitToBounds, [bounds]);
 
+  // Re-centre the area whenever the card resizes (size toggle, grid reflow,
+  // window resize). The observer only sees the container; the latest fit
+  // callback rides in a ref so we never re-observe.
+  const containerRef = useRef<HTMLDivElement>(null);
+  const fitRef = useRef(fitToBounds);
+  fitRef.current = fitToBounds;
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+    const observer = new ResizeObserver(() => {
+      // Next frame, so MapLibre's own resize handling runs first.
+      requestAnimationFrame(() => fitRef.current());
+    });
+    observer.observe(container);
+    return () => observer.disconnect();
+  }, []);
+
   return (
     <Box
+      ref={containerRef}
       h={{ base: "280px", md: tall ? "520px" : "360px" }}
       rounded="md"
       overflow="hidden"
@@ -123,7 +147,9 @@ export default function DashboardMapWidget({
         dragRotate={false}
         attributionControl={false}
       >
-        {/* Bottom-left so the legend can occupy the design's bottom-right slot. */}
+        {/* Bottom-left so the legend can occupy the design's bottom-right
+            slot; the attribution stacks beneath the zoom buttons. */}
+        <NavigationControl position="bottom-left" showCompass={false} />
         <AttributionControl compact position="bottom-left" />
         <Source
           id="widget-basemap"

--- a/src/features/dashboards/ui/DashboardMapWidget.tsx
+++ b/src/features/dashboards/ui/DashboardMapWidget.tsx
@@ -12,6 +12,11 @@ import MapGl, {
   type MapRef,
 } from "react-map-gl/maplibre";
 
+import {
+  aoiBoundaryColors,
+  aoiCasingPaint,
+  aoiLinePaint,
+} from "@/app/components/map/layers/aoiStyle";
 import { buildBasemapTileUrl } from "@/app/utils/basemapTileUrl";
 import { fetchGeometry } from "@/app/utils/geometryClient";
 import { registerPrimaryForestProtocol } from "@/app/utils/primaryForestTileProtocol";
@@ -23,8 +28,8 @@ import DashboardMapLegend, {
 const MAPBOX_ACCESS_TOKEN = process.env.NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN;
 // The explorer's default light basemap style.
 const BASEMAP_STYLE = "devseed/cmazl5ws500bz01scaa27dqi4";
-// Boundary colour on light basemaps (matches the explorer's area layers).
-const OUTLINE_COLOR = "#172B7A";
+// The widget basemap is always light, and dashboards are single-area.
+const AOI_COLORS = aoiBoundaryColors("light");
 
 /**
  * The map body of a `widget_type: "map"` dashboard card. Self-contained per
@@ -157,10 +162,17 @@ export default function DashboardMapWidget({
         </Source>
         {geometry?.geometry && (
           <Source id="widget-aoi" type="geojson" data={geometry.geometry}>
+            {/* The explorer's boundary treatment: contrasting casing under
+                the main line (shared paints, zoom-interpolated widths). */}
+            <Layer
+              id="widget-aoi-casing"
+              type="line"
+              paint={aoiCasingPaint(AOI_COLORS.casingColor)}
+            />
             <Layer
               id="widget-aoi-line"
               type="line"
-              paint={{ "line-color": OUTLINE_COLOR, "line-width": 1.5 }}
+              paint={aoiLinePaint(AOI_COLORS.mainLineColor)}
             />
           </Source>
         )}

--- a/src/features/dashboards/ui/DashboardMapWidget.tsx
+++ b/src/features/dashboards/ui/DashboardMapWidget.tsx
@@ -1,0 +1,159 @@
+"use client";
+
+import "maplibre-gl/dist/maplibre-gl.css";
+import { useEffect, useMemo, useRef } from "react";
+import { Box } from "@chakra-ui/react";
+import { useQuery } from "@tanstack/react-query";
+import turfBbox from "@turf/bbox";
+import MapGl, {
+  AttributionControl,
+  Layer,
+  Source,
+  type MapRef,
+} from "react-map-gl/maplibre";
+
+import { buildBasemapTileUrl } from "@/app/utils/basemapTileUrl";
+import { fetchGeometry } from "@/app/utils/geometryClient";
+import { registerPrimaryForestProtocol } from "@/app/utils/primaryForestTileProtocol";
+import type { MapWidgetLayer } from "../lib/mapWidgets";
+
+const MAPBOX_ACCESS_TOKEN = process.env.NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN;
+// The explorer's default light basemap style.
+const BASEMAP_STYLE = "devseed/cmazl5ws500bz01scaa27dqi4";
+// Boundary colour on light basemaps (matches the explorer's area layers).
+const OUTLINE_COLOR = "#172B7A";
+
+/**
+ * The map body of a `widget_type: "map"` dashboard card. Self-contained per
+ * the handoff: renders the config's resolved `tile_url` directly (context
+ * sub-layer beneath it), outlines the dashboard's area, and fits the
+ * viewport to that area — or to the reserved `config.viewport` bbox
+ * override, which wins when present.
+ */
+export default function DashboardMapWidget({
+  layer,
+  aoi,
+  bboxOverride,
+  tall,
+}: {
+  layer: MapWidgetLayer;
+  /** The dashboard's (single) area — outline + default viewport fit. */
+  aoi: { source: string; src_id: string } | undefined;
+  bboxOverride: [number, number, number, number] | null;
+  /** Full-width cards get a taller map. */
+  tall?: boolean;
+}) {
+  const mapRef = useRef<MapRef>(null);
+
+  useEffect(() => {
+    // Idempotent; needed here because the dashboard page never mounts the
+    // main explorer map, which is the usual registration point.
+    registerPrimaryForestProtocol();
+  }, []);
+
+  // The area geometry — shared across the dashboard's map widgets via the
+  // query cache; geometries are immutable, so never refetch.
+  const { data: geometry } = useQuery({
+    queryKey: ["aoi-geometry", aoi?.source, aoi?.src_id],
+    queryFn: () => fetchGeometry(aoi!.source, aoi!.src_id),
+    enabled: !!aoi,
+    staleTime: Infinity,
+  });
+
+  const bounds = useMemo<[number, number, number, number] | null>(() => {
+    if (bboxOverride) return bboxOverride;
+    if (!geometry?.geometry) return null;
+    // Naive bbox — antimeridian-crossing areas get a wide box. Acceptable
+    // here: dashboard AOIs don't carry a backend bbox to prefer.
+    const [west, south, east, north] = turfBbox(geometry.geometry);
+    return [west, south, east, north];
+  }, [bboxOverride, geometry]);
+
+  const fitToBounds = () => {
+    if (!bounds || !mapRef.current) return;
+    mapRef.current.fitBounds(
+      [
+        [bounds[0], bounds[1]],
+        [bounds[2], bounds[3]],
+      ],
+      { padding: 24, duration: 0 }
+    );
+  };
+
+  // The map and the geometry load in either order — fit on whichever
+  // completes last (the effect covers late bounds, onLoad covers late maps).
+  useEffect(fitToBounds, [bounds]);
+
+  return (
+    <Box
+      h={{ base: "280px", md: tall ? "520px" : "360px" }}
+      rounded="md"
+      overflow="hidden"
+      borderWidth="1px"
+      borderColor="#DDE2F5"
+    >
+      <MapGl
+        ref={mapRef}
+        style={{ width: "100%", height: "100%" }}
+        initialViewState={{ longitude: 0, latitude: 0, zoom: 1 }}
+        onLoad={fitToBounds}
+        // No scroll-zoom: the widget sits in a scrolling page and must not
+        // trap the wheel. Pan/double-click zoom remain available.
+        scrollZoom={false}
+        dragRotate={false}
+        attributionControl={false}
+      >
+        <AttributionControl compact position="bottom-right" />
+        <Source
+          id="widget-basemap"
+          type="raster"
+          tiles={[
+            buildBasemapTileUrl(
+              BASEMAP_STYLE,
+              MAPBOX_ACCESS_TOKEN,
+              typeof window === "undefined" ? 1 : window.devicePixelRatio
+            ),
+          ]}
+        >
+          <Layer id="widget-basemap" type="raster" />
+        </Source>
+        {/* Declaration order is stacking order: context under main, outline on top. */}
+        {layer.contextTileUrl && (
+          <Source
+            id="widget-context"
+            type="raster"
+            tiles={[layer.contextTileUrl]}
+            tileSize={256}
+          >
+            <Layer
+              id="widget-context"
+              type="raster"
+              paint={{ "raster-opacity": 0.8 }}
+            />
+          </Source>
+        )}
+        <Source
+          id="widget-tiles"
+          type="raster"
+          tiles={[layer.tileUrl]}
+          tileSize={256}
+        >
+          <Layer
+            id="widget-tiles"
+            type="raster"
+            paint={{ "raster-opacity": 0.8 }}
+          />
+        </Source>
+        {geometry?.geometry && (
+          <Source id="widget-aoi" type="geojson" data={geometry.geometry}>
+            <Layer
+              id="widget-aoi-line"
+              type="line"
+              paint={{ "line-color": OUTLINE_COLOR, "line-width": 1.5 }}
+            />
+          </Source>
+        )}
+      </MapGl>
+    </Box>
+  );
+}

--- a/src/features/dashboards/ui/DashboardMapWidget.tsx
+++ b/src/features/dashboards/ui/DashboardMapWidget.tsx
@@ -2,22 +2,26 @@
 
 import "maplibre-gl/dist/maplibre-gl.css";
 import { useEffect, useMemo, useRef, useState } from "react";
-import { Box } from "@chakra-ui/react";
+import { Box, Tag } from "@chakra-ui/react";
+import { PolygonIcon } from "@phosphor-icons/react";
 import { useQuery } from "@tanstack/react-query";
 import turfBbox from "@turf/bbox";
 import MapGl, {
   AttributionControl,
   Layer,
+  Marker,
   Source,
   type MapRef,
 } from "react-map-gl/maplibre";
 
 import {
+  aoiBboxLinePaint,
   aoiBoundaryColors,
   aoiCasingPaint,
   aoiLinePaint,
 } from "@/app/components/map/layers/aoiStyle";
 import { buildBasemapTileUrl } from "@/app/utils/basemapTileUrl";
+import { createBboxPolygon } from "@/app/utils/bboxUtils";
 import { fetchGeometry } from "@/app/utils/geometryClient";
 import { registerPrimaryForestProtocol } from "@/app/utils/primaryForestTileProtocol";
 import type { MapWidgetLayer } from "../lib/mapWidgets";
@@ -45,8 +49,8 @@ export default function DashboardMapWidget({
   tall,
 }: {
   layer: MapWidgetLayer;
-  /** The dashboard's (single) area — outline + default viewport fit. */
-  aoi: { source: string; src_id: string } | undefined;
+  /** The dashboard's (single) area — outline, label + default viewport fit. */
+  aoi: { source: string; src_id: string; name: string } | undefined;
   bboxOverride: [number, number, number, number] | null;
   /** Full-width cards get a taller map. */
   tall?: boolean;
@@ -75,14 +79,15 @@ export default function DashboardMapWidget({
     staleTime: Infinity,
   });
 
-  const bounds = useMemo<[number, number, number, number] | null>(() => {
-    if (bboxOverride) return bboxOverride;
+  const aoiBbox = useMemo<[number, number, number, number] | null>(() => {
     if (!geometry?.geometry) return null;
     // Naive bbox — antimeridian-crossing areas get a wide box. Acceptable
     // here: dashboard AOIs don't carry a backend bbox to prefer.
     const [west, south, east, north] = turfBbox(geometry.geometry);
     return [west, south, east, north];
-  }, [bboxOverride, geometry]);
+  }, [geometry]);
+
+  const bounds = bboxOverride ?? aoiBbox;
 
   const fitToBounds = () => {
     if (!bounds || !mapRef.current) return;
@@ -175,6 +180,42 @@ export default function DashboardMapWidget({
               paint={aoiLinePaint(AOI_COLORS.mainLineColor)}
             />
           </Source>
+        )}
+        {aoiBbox && (
+          <Source
+            id="widget-aoi-bbox"
+            type="geojson"
+            data={createBboxPolygon(aoiBbox)}
+          >
+            <Layer
+              id="widget-aoi-bbox-line"
+              type="line"
+              paint={aoiBboxLinePaint(AOI_COLORS.mainLineColor)}
+            />
+          </Source>
+        )}
+        {/* Area label pinned to the bbox corner, as on the explorer map —
+            minus the close trigger: a dashboard's area is fixed. */}
+        {aoiBbox && aoi?.name && (
+          <Marker
+            longitude={aoiBbox[0]}
+            latitude={aoiBbox[3]}
+            anchor="bottom-left"
+          >
+            <Tag.Root
+              colorPalette="primary"
+              px={2}
+              py={1}
+              size="md"
+              variant="solid"
+              roundedBottom="none"
+            >
+              <Tag.StartElement>
+                <PolygonIcon />
+              </Tag.StartElement>
+              <Tag.Label fontWeight="medium">{aoi.name}</Tag.Label>
+            </Tag.Root>
+          </Marker>
         )}
         {/* Non-map children render as DOM overlays inside the map container
             (same pattern as the explorer's Map.tsx). */}

--- a/src/features/dashboards/ui/DashboardMapWidget.tsx
+++ b/src/features/dashboards/ui/DashboardMapWidget.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import "maplibre-gl/dist/maplibre-gl.css";
-import { useEffect, useMemo, useRef } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { Box } from "@chakra-ui/react";
 import { useQuery } from "@tanstack/react-query";
 import turfBbox from "@turf/bbox";
@@ -16,6 +16,9 @@ import { buildBasemapTileUrl } from "@/app/utils/basemapTileUrl";
 import { fetchGeometry } from "@/app/utils/geometryClient";
 import { registerPrimaryForestProtocol } from "@/app/utils/primaryForestTileProtocol";
 import type { MapWidgetLayer } from "../lib/mapWidgets";
+import DashboardMapLegend, {
+  type MapWidgetOpacity,
+} from "./DashboardMapLegend";
 
 const MAPBOX_ACCESS_TOKEN = process.env.NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN;
 // The explorer's default light basemap style.
@@ -44,6 +47,13 @@ export default function DashboardMapWidget({
   tall?: boolean;
 }) {
   const mapRef = useRef<MapRef>(null);
+
+  // Legend-controlled raster opacity (0–100). 80 matches the explorer's
+  // default dataset opacity and the legend's default display value.
+  const [opacity, setOpacity] = useState<MapWidgetOpacity>({
+    main: 80,
+    context: 80,
+  });
 
   useEffect(() => {
     // Idempotent; needed here because the dashboard page never mounts the
@@ -103,7 +113,8 @@ export default function DashboardMapWidget({
         dragRotate={false}
         attributionControl={false}
       >
-        <AttributionControl compact position="bottom-right" />
+        {/* Bottom-left so the legend can occupy the design's bottom-right slot. */}
+        <AttributionControl compact position="bottom-left" />
         <Source
           id="widget-basemap"
           type="raster"
@@ -128,7 +139,7 @@ export default function DashboardMapWidget({
             <Layer
               id="widget-context"
               type="raster"
-              paint={{ "raster-opacity": 0.8 }}
+              paint={{ "raster-opacity": opacity.context / 100 }}
             />
           </Source>
         )}
@@ -141,7 +152,7 @@ export default function DashboardMapWidget({
           <Layer
             id="widget-tiles"
             type="raster"
-            paint={{ "raster-opacity": 0.8 }}
+            paint={{ "raster-opacity": opacity.main / 100 }}
           />
         </Source>
         {geometry?.geometry && (
@@ -153,6 +164,24 @@ export default function DashboardMapWidget({
             />
           </Source>
         )}
+        {/* Non-map children render as DOM overlays inside the map container
+            (same pattern as the explorer's Map.tsx). */}
+        <Box
+          position="absolute"
+          bottom="8px"
+          right="8px"
+          zIndex={1}
+          w="400px"
+          maxW="calc(100% - 16px)"
+        >
+          <DashboardMapLegend
+            layer={layer}
+            opacity={opacity}
+            onOpacityChange={(target, value) =>
+              setOpacity((prev) => ({ ...prev, [target]: value }))
+            }
+          />
+        </Box>
       </MapGl>
     </Box>
   );

--- a/src/features/dashboards/ui/DashboardMapWidget.tsx
+++ b/src/features/dashboards/ui/DashboardMapWidget.tsx
@@ -224,7 +224,7 @@ export default function DashboardMapWidget({
           bottom="8px"
           right="8px"
           zIndex={1}
-          w="400px"
+          w="300px"
           maxW="calc(100% - 16px)"
         >
           <DashboardMapLegend

--- a/src/features/dashboards/ui/DashboardWidgetCard.tsx
+++ b/src/features/dashboards/ui/DashboardWidgetCard.tsx
@@ -1,0 +1,214 @@
+"use client";
+
+import { useState } from "react";
+import {
+  Box,
+  Button,
+  Dialog,
+  Flex,
+  Icon,
+  IconButton,
+  Portal,
+  Text,
+} from "@chakra-ui/react";
+import {
+  ArrowsOutLineHorizontalIcon,
+  ChartBarIcon,
+  ChatTeardropDotsIcon,
+  DotsSixVerticalIcon,
+  XIcon,
+} from "@phosphor-icons/react";
+
+import WidgetMessage from "@/app/components/WidgetMessage";
+import { toaster } from "@/app/components/ui/toaster";
+import type { DashboardWidget } from "../api/schemas";
+import { dashboardWidgetToInsightWidgets, widgetSize } from "../lib/widgets";
+
+/**
+ * One dashboard widget: a control strip (drag / add-to-conversation /
+ * resize / remove, owner-only) over the insight cards rendered by the
+ * existing WidgetMessage. Per the Figma AI-widget header, controls are:
+ * DotsSixVertical, ChatTeardropDots, ArrowsOutLineHorizontal, X.
+ */
+export default function DashboardWidgetCard({
+  widget,
+  isOwner,
+  onArmDrag,
+  onDisarmDrag,
+  onToggleSize,
+  onRemove,
+}: {
+  widget: DashboardWidget;
+  isOwner: boolean;
+  /** Pointer down on the drag handle — arms the grid item's HTML5 drag. */
+  onArmDrag: () => void;
+  onDisarmDrag: () => void;
+  onToggleSize: () => void;
+  onRemove: () => void;
+}) {
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const size = widgetSize(widget.config);
+  const cards =
+    widget.widget_type === "insight"
+      ? dashboardWidgetToInsightWidgets(widget)
+      : [];
+
+  const addToConversation = () => {
+    // False door — measure interest before building the real flow.
+    toaster.create({
+      title: "Coming soon",
+      description:
+        "Adding a widget to the AI conversation isn't available yet.",
+      type: "info",
+      duration: 3000,
+    });
+  };
+
+  const placeholder =
+    widget.widget_type !== "insight"
+      ? `This ${widget.widget_type} widget isn't supported here yet.`
+      : cards.length === 0
+        ? "This analysis is not available."
+        : null;
+
+  return (
+    <Flex
+      flexDir="column"
+      h="100%"
+      bg="bg"
+      borderWidth="1px"
+      borderColor="border"
+      borderRadius="sm"
+      overflow="hidden"
+    >
+      <Flex
+        align="center"
+        gap={1}
+        px={2}
+        py={1}
+        borderBottomWidth="1px"
+        borderColor="border"
+        bg="bg.subtle"
+      >
+        {isOwner && (
+          <Icon
+            as={DotsSixVerticalIcon}
+            boxSize="16px"
+            color="fg.muted"
+            cursor="grab"
+            aria-label="Drag to reposition"
+            onPointerDown={onArmDrag}
+            onPointerUp={onDisarmDrag}
+          />
+        )}
+        <Box flex="1" />
+        {isOwner && (
+          <>
+            <IconButton
+              aria-label="Add to AI conversation"
+              title="Add to AI conversation"
+              size="2xs"
+              variant="ghost"
+              color="fg.muted"
+              onClick={addToConversation}
+            >
+              <ChatTeardropDotsIcon size={14} />
+            </IconButton>
+            <IconButton
+              aria-label={
+                size === "double"
+                  ? "Shrink to one column"
+                  : "Expand to full width"
+              }
+              title={
+                size === "double"
+                  ? "Shrink to one column"
+                  : "Expand to full width"
+              }
+              size="2xs"
+              variant="ghost"
+              color="fg.muted"
+              onClick={onToggleSize}
+            >
+              <ArrowsOutLineHorizontalIcon size={14} />
+            </IconButton>
+            <IconButton
+              aria-label="Remove from dashboard"
+              title="Remove from dashboard"
+              size="2xs"
+              variant="ghost"
+              color="fg.muted"
+              onClick={() => setConfirmOpen(true)}
+            >
+              <XIcon size={14} />
+            </IconButton>
+          </>
+        )}
+      </Flex>
+
+      {placeholder ? (
+        <Flex
+          flex="1"
+          minH="160px"
+          align="center"
+          justify="center"
+          direction="column"
+          gap={2}
+          color="fg.muted"
+          px={6}
+          textAlign="center"
+        >
+          <ChartBarIcon size={24} />
+          <Text fontSize="sm">{placeholder}</Text>
+        </Flex>
+      ) : (
+        <Box px={2} pt={2} pb={2} flex="1" minW={0}>
+          {cards.map((card) => (
+            <WidgetMessage key={card.id} widget={card} inWorkspace />
+          ))}
+        </Box>
+      )}
+
+      <Dialog.Root
+        open={confirmOpen}
+        onOpenChange={(e) => setConfirmOpen(e.open)}
+        size="sm"
+        role="alertdialog"
+      >
+        <Portal>
+          <Dialog.Backdrop />
+          <Dialog.Positioner>
+            <Dialog.Content>
+              <Dialog.Header>
+                <Dialog.Title>Remove widget?</Dialog.Title>
+              </Dialog.Header>
+              <Dialog.Body>
+                <Text>
+                  The widget will be removed from this dashboard. The underlying
+                  analysis is not deleted.
+                </Text>
+              </Dialog.Body>
+              <Dialog.Footer>
+                <Dialog.ActionTrigger asChild>
+                  <Button variant="outline" size="sm">
+                    Cancel
+                  </Button>
+                </Dialog.ActionTrigger>
+                <Button
+                  colorPalette="red"
+                  size="sm"
+                  onClick={() => {
+                    setConfirmOpen(false);
+                    onRemove();
+                  }}
+                >
+                  Remove
+                </Button>
+              </Dialog.Footer>
+            </Dialog.Content>
+          </Dialog.Positioner>
+        </Portal>
+      </Dialog.Root>
+    </Flex>
+  );
+}

--- a/src/features/dashboards/ui/DashboardWidgetCard.tsx
+++ b/src/features/dashboards/ui/DashboardWidgetCard.tsx
@@ -26,11 +26,14 @@ import AnalysisParametersToggle, {
 import { buildChips } from "@/app/components/widgets/analysis-params-utils";
 import { toaster } from "@/app/components/ui/toaster";
 import type { InsightWidget } from "@/app/types/chat";
+import type { MapWidgetLayer } from "../lib/mapWidgets";
+import DashboardMapWidget from "./DashboardMapWidget";
 
 /**
  * One dashboard card — the Figma "Analysis" container: a light-blue shell
  * with a header row (drag handle · insight title · owner actions), a
- * "Show params" row, and the white chart card (`WidgetMessage`) inside.
+ * "Show params" row, and the white chart card (`WidgetMessage`) — or the
+ * map body (`DashboardMapWidget`) for map widgets — inside.
  * A widget whose insight has several charts renders one of these per chart,
  * so `card` is a single insight card, not a list. Header actions still act
  * on the underlying widget (per the API: position/config/DELETE are
@@ -39,6 +42,9 @@ import type { InsightWidget } from "@/app/types/chat";
 export default function DashboardWidgetCard({
   title,
   card,
+  map,
+  aoi,
+  viewportBbox,
   placeholder,
   chartCount,
   isOwner,
@@ -49,8 +55,14 @@ export default function DashboardWidgetCard({
   onRemove,
 }: {
   title: string;
-  /** The insight card to render, or null for a placeholder cell. */
+  /** The insight card to render, or null for a map/placeholder cell. */
   card: InsightWidget | null;
+  /** The map layer to render for `widget_type: "map"` cells. */
+  map?: MapWidgetLayer | null;
+  /** The dashboard's area — outline + viewport fit for map cells. */
+  aoi?: { source: string; src_id: string };
+  /** Reserved `config.viewport` bbox override for map cells. */
+  viewportBbox?: [number, number, number, number] | null;
   /** Placeholder copy when `card` is null (unsupported type / hidden insight). */
   placeholder: string | null;
   /** How many cards the underlying widget renders in total (its chart count). */
@@ -189,6 +201,15 @@ export default function DashboardWidgetCard({
           <ChartBarIcon size={24} />
           <Text fontSize="sm">{placeholder}</Text>
         </Flex>
+      ) : map ? (
+        <Box px="8px" pb="8px" flex="1" minW={0}>
+          <DashboardMapWidget
+            layer={map}
+            aoi={aoi}
+            bboxOverride={viewportBbox ?? null}
+            tall={isDouble}
+          />
+        </Box>
       ) : (
         card && (
           <Box px="8px" pb="8px" flex="1" minW={0}>

--- a/src/features/dashboards/ui/DashboardWidgetCard.tsx
+++ b/src/features/dashboards/ui/DashboardWidgetCard.tsx
@@ -20,26 +20,43 @@ import {
 } from "@phosphor-icons/react";
 
 import WidgetMessage from "@/app/components/WidgetMessage";
+import AnalysisParametersToggle, {
+  AnalysisParamsChips,
+} from "@/app/components/widgets/AnalysisParameters";
+import { buildChips } from "@/app/components/widgets/analysis-params-utils";
 import { toaster } from "@/app/components/ui/toaster";
-import type { DashboardWidget } from "../api/schemas";
-import { dashboardWidgetToInsightWidgets, widgetSize } from "../lib/widgets";
+import type { InsightWidget } from "@/app/types/chat";
 
 /**
- * One dashboard widget: a control strip (drag / add-to-conversation /
- * resize / remove, owner-only) over the insight cards rendered by the
- * existing WidgetMessage. Per the Figma AI-widget header, controls are:
- * DotsSixVertical, ChatTeardropDots, ArrowsOutLineHorizontal, X.
+ * One dashboard card — the Figma "Analysis" container: a light-blue shell
+ * with a header row (drag handle · insight title · owner actions), a
+ * "Show params" row, and the white chart card (`WidgetMessage`) inside.
+ * A widget whose insight has several charts renders one of these per chart,
+ * so `card` is a single insight card, not a list. Header actions still act
+ * on the underlying widget (per the API: position/config/DELETE are
+ * widget-level), which `chartCount` lets the remove dialog explain.
  */
 export default function DashboardWidgetCard({
-  widget,
+  title,
+  card,
+  placeholder,
+  chartCount,
   isOwner,
+  isDouble,
   onArmDrag,
   onDisarmDrag,
   onToggleSize,
   onRemove,
 }: {
-  widget: DashboardWidget;
+  title: string;
+  /** The insight card to render, or null for a placeholder cell. */
+  card: InsightWidget | null;
+  /** Placeholder copy when `card` is null (unsupported type / hidden insight). */
+  placeholder: string | null;
+  /** How many cards the underlying widget renders in total (its chart count). */
+  chartCount: number;
   isOwner: boolean;
+  isDouble: boolean;
   /** Pointer down on the drag handle — arms the grid item's HTML5 drag. */
   onArmDrag: () => void;
   onDisarmDrag: () => void;
@@ -47,11 +64,8 @@ export default function DashboardWidgetCard({
   onRemove: () => void;
 }) {
   const [confirmOpen, setConfirmOpen] = useState(false);
-  const size = widgetSize(widget.config);
-  const cards =
-    widget.widget_type === "insight"
-      ? dashboardWidgetToInsightWidgets(widget)
-      : [];
+  const [paramsExpanded, setParamsExpanded] = useState(false);
+  const chips = card?.analysisParams ? buildChips(card.analysisParams) : [];
 
   const addToConversation = () => {
     // False door — measure interest before building the real flow.
@@ -64,46 +78,44 @@ export default function DashboardWidgetCard({
     });
   };
 
-  const placeholder =
-    widget.widget_type !== "insight"
-      ? `This ${widget.widget_type} widget isn't supported here yet.`
-      : cards.length === 0
-        ? "This analysis is not available."
-        : null;
-
   return (
     <Flex
       flexDir="column"
       h="100%"
-      bg="bg"
+      bg="#F7F9FF"
       borderWidth="1px"
-      borderColor="border"
+      borderColor="#DDE2F5"
       borderRadius="sm"
       overflow="hidden"
     >
-      <Flex
-        align="center"
-        gap={1}
-        px={2}
-        py={1}
-        borderBottomWidth="1px"
-        borderColor="border"
-        bg="bg.subtle"
-      >
+      {/* Header — drag handle · title · actions (per the Figma LegendItemHeader) */}
+      <Flex align="center" gap="4px" pl="4px" pr="12px" pt="12px" pb="8px">
         {isOwner && (
           <Icon
             as={DotsSixVerticalIcon}
             boxSize="16px"
             color="fg.muted"
             cursor="grab"
+            flexShrink={0}
             aria-label="Drag to reposition"
             onPointerDown={onArmDrag}
             onPointerUp={onDisarmDrag}
           />
         )}
-        <Box flex="1" />
+        <Text
+          flex="1"
+          minW={0}
+          fontSize="14px"
+          fontWeight="medium"
+          lineHeight="16px"
+          color="#172B7A"
+          wordBreak="break-word"
+          pl={isOwner ? 0 : "8px"}
+        >
+          {title}
+        </Text>
         {isOwner && (
-          <>
+          <Flex align="center" gap="4px" flexShrink={0}>
             <IconButton
               aria-label="Add to AI conversation"
               title="Add to AI conversation"
@@ -112,25 +124,19 @@ export default function DashboardWidgetCard({
               color="fg.muted"
               onClick={addToConversation}
             >
-              <ChatTeardropDotsIcon size={14} />
+              <ChatTeardropDotsIcon size={16} />
             </IconButton>
             <IconButton
               aria-label={
-                size === "double"
-                  ? "Shrink to one column"
-                  : "Expand to full width"
+                isDouble ? "Shrink to one column" : "Expand to full width"
               }
-              title={
-                size === "double"
-                  ? "Shrink to one column"
-                  : "Expand to full width"
-              }
+              title={isDouble ? "Shrink to one column" : "Expand to full width"}
               size="2xs"
               variant="ghost"
               color="fg.muted"
               onClick={onToggleSize}
             >
-              <ArrowsOutLineHorizontalIcon size={14} />
+              <ArrowsOutLineHorizontalIcon size={16} />
             </IconButton>
             <IconButton
               aria-label="Remove from dashboard"
@@ -140,11 +146,33 @@ export default function DashboardWidgetCard({
               color="fg.muted"
               onClick={() => setConfirmOpen(true)}
             >
-              <XIcon size={14} />
+              <XIcon size={16} />
             </IconButton>
-          </>
+          </Flex>
         )}
       </Flex>
+
+      {/* Params row — "Show params" toggle over the analysis param chips */}
+      {chips.length > 0 && (
+        <Box px="8px" pb="8px">
+          <Flex
+            borderTopWidth="1px"
+            borderColor="rgba(19,22,25,0.05)"
+            pt="4px"
+            align="center"
+          >
+            <AnalysisParametersToggle
+              expanded={paramsExpanded}
+              onToggle={() => setParamsExpanded((v) => !v)}
+            />
+          </Flex>
+          {paramsExpanded && (
+            <Box pt="8px">
+              <AnalysisParamsChips chips={chips} />
+            </Box>
+          )}
+        </Box>
+      )}
 
       {placeholder ? (
         <Flex
@@ -162,11 +190,11 @@ export default function DashboardWidgetCard({
           <Text fontSize="sm">{placeholder}</Text>
         </Flex>
       ) : (
-        <Box px={2} pt={2} pb={2} flex="1" minW={0}>
-          {cards.map((card) => (
-            <WidgetMessage key={card.id} widget={card} inWorkspace />
-          ))}
-        </Box>
+        card && (
+          <Box px="8px" pb="8px" flex="1" minW={0}>
+            <WidgetMessage widget={card} inWorkspace />
+          </Box>
+        )
       )}
 
       <Dialog.Root
@@ -184,8 +212,9 @@ export default function DashboardWidgetCard({
               </Dialog.Header>
               <Dialog.Body>
                 <Text>
-                  The widget will be removed from this dashboard. The underlying
-                  analysis is not deleted.
+                  {chartCount > 1
+                    ? `This analysis has ${chartCount} charts shown as separate cards — removing it removes all of them. The underlying analysis is not deleted.`
+                    : "The widget will be removed from this dashboard. The underlying analysis is not deleted."}
                 </Text>
               </Dialog.Body>
               <Dialog.Footer>

--- a/src/features/dashboards/ui/DashboardWidgetCard.tsx
+++ b/src/features/dashboards/ui/DashboardWidgetCard.tsx
@@ -59,8 +59,8 @@ export default function DashboardWidgetCard({
   card: InsightWidget | null;
   /** The map layer to render for `widget_type: "map"` cells. */
   map?: MapWidgetLayer | null;
-  /** The dashboard's area — outline + viewport fit for map cells. */
-  aoi?: { source: string; src_id: string };
+  /** The dashboard's area — outline, label + viewport fit for map cells. */
+  aoi?: { source: string; src_id: string; name: string };
   /** Reserved `config.viewport` bbox override for map cells. */
   viewportBbox?: [number, number, number, number] | null;
   /** Placeholder copy when `card` is null (unsupported type / hidden insight). */

--- a/src/features/dashboards/ui/DashboardWidgetsGrid.tsx
+++ b/src/features/dashboards/ui/DashboardWidgetsGrid.tsx
@@ -4,8 +4,16 @@ import { useMemo, useState } from "react";
 import { Grid, GridItem } from "@chakra-ui/react";
 
 import useAuthStore from "@/app/store/authStore";
-import type { Dashboard } from "../api/schemas";
-import { computeReorder, widgetSize, withSize } from "../lib/widgets";
+import type { InsightWidget } from "@/app/types/chat";
+import type { Dashboard, DashboardWidget } from "../api/schemas";
+import {
+  chartSize,
+  computeReorder,
+  dashboardWidgetToInsightWidgets,
+  widgetSize,
+  withChartSize,
+  withSize,
+} from "../lib/widgets";
 import {
   useDeleteWidget,
   useReorderWidgets,
@@ -14,11 +22,62 @@ import {
 import DashboardWidgetCard from "./DashboardWidgetCard";
 
 /**
+ * One grid cell. A widget whose insight has several charts renders one cell
+ * per chart (each its own card, per design); placeholder cells (unsupported
+ * widget type, hidden insight) carry `card: null` and placeholder copy.
+ */
+interface GridCell {
+  key: string;
+  widget: DashboardWidget;
+  card: InsightWidget | null;
+  placeholder: string | null;
+  chartCount: number;
+}
+
+function cellsForWidget(
+  widget: DashboardWidget,
+  areaName: string | undefined
+): GridCell[] {
+  if (widget.widget_type !== "insight") {
+    return [
+      {
+        key: widget.id,
+        widget,
+        card: null,
+        placeholder: `This ${widget.widget_type} widget isn't supported here yet.`,
+        chartCount: 0,
+      },
+    ];
+  }
+  const cards = dashboardWidgetToInsightWidgets(widget, { areaName });
+  if (cards.length === 0) {
+    return [
+      {
+        key: widget.id,
+        widget,
+        card: null,
+        placeholder: "This analysis is not available.",
+        chartCount: 0,
+      },
+    ];
+  }
+  return cards.map((card) => ({
+    key: `${widget.id}:${card.id}`,
+    widget,
+    card,
+    placeholder: null,
+    chartCount: cards.length,
+  }));
+}
+
+/**
  * The dashboard's widget grid. Reordering is native HTML5 drag-and-drop,
  * armed only while the card's drag handle is pressed (so text selection and
  * chart interactions inside the card keep working); the drop target gets the
- * design's dashed outline. Position and column span persist via the widget
- * PATCH endpoint (optimistically, in dashboardQueries).
+ * design's dashed outline. Cells map 1:1 to charts, but position and column
+ * span persist on the underlying widget via the PATCH endpoint
+ * (optimistically, in dashboardQueries) — dragging any card of a multi-chart
+ * widget moves the whole widget, and its cards stay adjacent.
  */
 export default function DashboardWidgetsGrid({
   dashboard,
@@ -32,9 +91,9 @@ export default function DashboardWidgetsGrid({
   const deleteWidget = useDeleteWidget(dashboard.id);
   const reorderWidgets = useReorderWidgets(dashboard.id);
 
-  // grabbedId arms draggable on one grid item; dragIndex/overIndex track the
-  // HTML5 drag in flight.
-  const [grabbedId, setGrabbedId] = useState<string | null>(null);
+  // grabbedKey arms draggable on one grid item; dragIndex/overIndex track the
+  // HTML5 drag in flight (cell indices).
+  const [grabbedKey, setGrabbedKey] = useState<string | null>(null);
   const [dragIndex, setDragIndex] = useState<number | null>(null);
   const [overIndex, setOverIndex] = useState<number | null>(null);
 
@@ -42,16 +101,32 @@ export default function DashboardWidgetsGrid({
     () => [...dashboard.widgets].sort((a, b) => a.position - b.position),
     [dashboard.widgets]
   );
+  const areaName = dashboard.aois[0]?.name;
+  const cells = useMemo(
+    () => widgets.flatMap((widget) => cellsForWidget(widget, areaName)),
+    [widgets, areaName]
+  );
 
   const endDrag = () => {
-    setGrabbedId(null);
+    setGrabbedKey(null);
     setDragIndex(null);
     setOverIndex(null);
   };
 
+  // Cards of the same widget share a position — dropping on a sibling is a no-op.
+  const isDropTarget = (index: number) =>
+    dragIndex !== null &&
+    cells[dragIndex]?.widget.id !== cells[index]?.widget.id;
+
   const dropOn = (targetIndex: number) => {
-    if (dragIndex !== null && dragIndex !== targetIndex) {
-      const { patches } = computeReorder(widgets, dragIndex, targetIndex);
+    if (dragIndex !== null && isDropTarget(targetIndex)) {
+      const fromIndex = widgets.findIndex(
+        (w) => w.id === cells[dragIndex].widget.id
+      );
+      const toIndex = widgets.findIndex(
+        (w) => w.id === cells[targetIndex].widget.id
+      );
+      const { patches } = computeReorder(widgets, fromIndex, toIndex);
       if (patches.length > 0) reorderWidgets.mutate(patches);
     }
     endDrag();
@@ -59,51 +134,67 @@ export default function DashboardWidgetsGrid({
 
   return (
     <Grid templateColumns={{ base: "1fr", lg: "repeat(2, 1fr)" }} gap={4}>
-      {widgets.map((widget, i) => (
-        <GridItem
-          key={widget.id}
-          colSpan={{
-            base: 1,
-            lg: widgetSize(widget.config) === "double" ? 2 : 1,
-          }}
-          draggable={isOwner && grabbedId === widget.id}
-          onDragStart={() => setDragIndex(i)}
-          onDragEnd={endDrag}
-          onDragOver={(e) => {
-            if (dragIndex === null) return;
-            e.preventDefault();
-            setOverIndex(i);
-          }}
-          onDrop={() => dropOn(i)}
-          opacity={dragIndex === i ? 0.4 : 1}
-          outline={
-            overIndex === i && dragIndex !== null && dragIndex !== i
-              ? "2px dashed"
-              : undefined
-          }
-          outlineColor="primary.solid"
-          borderRadius="sm"
-        >
-          <DashboardWidgetCard
-            widget={widget}
-            isOwner={isOwner}
-            onArmDrag={() => setGrabbedId(widget.id)}
-            onDisarmDrag={() => setGrabbedId(null)}
-            onToggleSize={() =>
-              updateWidget.mutate({
-                widgetId: widget.id,
-                patch: {
-                  config: withSize(
-                    widget.config,
-                    widgetSize(widget.config) === "double" ? "single" : "double"
-                  ),
-                },
-              })
+      {cells.map((cell, i) => {
+        const { widget, card } = cell;
+        const size = card?.id
+          ? chartSize(widget.config, card.id)
+          : widgetSize(widget.config);
+        const title =
+          card?.title ??
+          (typeof widget.config.title === "string" ? widget.config.title : "");
+        return (
+          <GridItem
+            key={cell.key}
+            colSpan={{ base: 1, lg: size === "double" ? 2 : 1 }}
+            draggable={isOwner && grabbedKey === cell.key}
+            onDragStart={() => setDragIndex(i)}
+            onDragEnd={endDrag}
+            onDragOver={(e) => {
+              if (dragIndex === null) return;
+              e.preventDefault();
+              setOverIndex(i);
+            }}
+            onDrop={() => dropOn(i)}
+            opacity={dragIndex === i ? 0.4 : 1}
+            outline={
+              overIndex === i && dragIndex !== null && isDropTarget(i)
+                ? "2px dashed"
+                : undefined
             }
-            onRemove={() => deleteWidget.mutate(widget.id)}
-          />
-        </GridItem>
-      ))}
+            outlineColor="primary.solid"
+            borderRadius="sm"
+          >
+            <DashboardWidgetCard
+              title={title}
+              card={card}
+              placeholder={cell.placeholder}
+              chartCount={cell.chartCount}
+              isOwner={isOwner}
+              isDouble={size === "double"}
+              onArmDrag={() => setGrabbedKey(cell.key)}
+              onDisarmDrag={() => setGrabbedKey(null)}
+              onToggleSize={() =>
+                updateWidget.mutate({
+                  widgetId: widget.id,
+                  patch: {
+                    config: card?.id
+                      ? withChartSize(
+                          widget.config,
+                          card.id,
+                          size === "double" ? "single" : "double"
+                        )
+                      : withSize(
+                          widget.config,
+                          size === "double" ? "single" : "double"
+                        ),
+                  },
+                })
+              }
+              onRemove={() => deleteWidget.mutate(widget.id)}
+            />
+          </GridItem>
+        );
+      })}
     </Grid>
   );
 }

--- a/src/features/dashboards/ui/DashboardWidgetsGrid.tsx
+++ b/src/features/dashboards/ui/DashboardWidgetsGrid.tsx
@@ -15,6 +15,11 @@ import {
   withSize,
 } from "../lib/widgets";
 import {
+  mapWidgetLayer,
+  mapWidgetViewportBbox,
+  type MapWidgetLayer,
+} from "../lib/mapWidgets";
+import {
   useDeleteWidget,
   useReorderWidgets,
   useUpdateWidget,
@@ -23,13 +28,15 @@ import DashboardWidgetCard from "./DashboardWidgetCard";
 
 /**
  * One grid cell. A widget whose insight has several charts renders one cell
- * per chart (each its own card, per design); placeholder cells (unsupported
- * widget type, hidden insight) carry `card: null` and placeholder copy.
+ * per chart (each its own card, per design); map widgets render one cell
+ * with `map` set; placeholder cells (unsupported widget type, hidden
+ * insight, malformed map config) carry `card: null` and placeholder copy.
  */
 interface GridCell {
   key: string;
   widget: DashboardWidget;
   card: InsightWidget | null;
+  map: MapWidgetLayer | null;
   placeholder: string | null;
   chartCount: number;
 }
@@ -38,12 +45,26 @@ function cellsForWidget(
   widget: DashboardWidget,
   areaName: string | undefined
 ): GridCell[] {
+  if (widget.widget_type === "map") {
+    const map = mapWidgetLayer(widget.config);
+    return [
+      {
+        key: widget.id,
+        widget,
+        card: null,
+        map,
+        placeholder: map ? null : "This map widget can't be displayed.",
+        chartCount: 0,
+      },
+    ];
+  }
   if (widget.widget_type !== "insight") {
     return [
       {
         key: widget.id,
         widget,
         card: null,
+        map: null,
         placeholder: `This ${widget.widget_type} widget isn't supported here yet.`,
         chartCount: 0,
       },
@@ -56,6 +77,7 @@ function cellsForWidget(
         key: widget.id,
         widget,
         card: null,
+        map: null,
         placeholder: "This analysis is not available.",
         chartCount: 0,
       },
@@ -65,6 +87,7 @@ function cellsForWidget(
     key: `${widget.id}:${card.id}`,
     widget,
     card,
+    map: null,
     placeholder: null,
     chartCount: cards.length,
   }));
@@ -101,7 +124,8 @@ export default function DashboardWidgetsGrid({
     () => [...dashboard.widgets].sort((a, b) => a.position - b.position),
     [dashboard.widgets]
   );
-  const areaName = dashboard.aois[0]?.name;
+  const areaAoi = dashboard.aois[0];
+  const areaName = areaAoi?.name;
   const cells = useMemo(
     () => widgets.flatMap((widget) => cellsForWidget(widget, areaName)),
     [widgets, areaName]
@@ -141,6 +165,7 @@ export default function DashboardWidgetsGrid({
           : widgetSize(widget.config);
         const title =
           card?.title ??
+          cell.map?.title ??
           (typeof widget.config.title === "string" ? widget.config.title : "");
         return (
           <GridItem
@@ -167,6 +192,11 @@ export default function DashboardWidgetsGrid({
             <DashboardWidgetCard
               title={title}
               card={card}
+              map={cell.map}
+              aoi={areaAoi}
+              viewportBbox={
+                cell.map ? mapWidgetViewportBbox(widget.config) : null
+              }
               placeholder={cell.placeholder}
               chartCount={cell.chartCount}
               isOwner={isOwner}

--- a/src/features/dashboards/ui/DashboardWidgetsGrid.tsx
+++ b/src/features/dashboards/ui/DashboardWidgetsGrid.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { Grid, GridItem } from "@chakra-ui/react";
+
+import useAuthStore from "@/app/store/authStore";
+import type { Dashboard } from "../api/schemas";
+import { computeReorder, widgetSize, withSize } from "../lib/widgets";
+import {
+  useDeleteWidget,
+  useReorderWidgets,
+  useUpdateWidget,
+} from "./dashboardQueries";
+import DashboardWidgetCard from "./DashboardWidgetCard";
+
+/**
+ * The dashboard's widget grid. Reordering is native HTML5 drag-and-drop,
+ * armed only while the card's drag handle is pressed (so text selection and
+ * chart interactions inside the card keep working); the drop target gets the
+ * design's dashed outline. Position and column span persist via the widget
+ * PATCH endpoint (optimistically, in dashboardQueries).
+ */
+export default function DashboardWidgetsGrid({
+  dashboard,
+}: {
+  dashboard: Dashboard;
+}) {
+  const userId = useAuthStore((s) => s.userId);
+  const isOwner = !!userId && userId === dashboard.user_id;
+
+  const updateWidget = useUpdateWidget(dashboard.id);
+  const deleteWidget = useDeleteWidget(dashboard.id);
+  const reorderWidgets = useReorderWidgets(dashboard.id);
+
+  // grabbedId arms draggable on one grid item; dragIndex/overIndex track the
+  // HTML5 drag in flight.
+  const [grabbedId, setGrabbedId] = useState<string | null>(null);
+  const [dragIndex, setDragIndex] = useState<number | null>(null);
+  const [overIndex, setOverIndex] = useState<number | null>(null);
+
+  const widgets = useMemo(
+    () => [...dashboard.widgets].sort((a, b) => a.position - b.position),
+    [dashboard.widgets]
+  );
+
+  const endDrag = () => {
+    setGrabbedId(null);
+    setDragIndex(null);
+    setOverIndex(null);
+  };
+
+  const dropOn = (targetIndex: number) => {
+    if (dragIndex !== null && dragIndex !== targetIndex) {
+      const { patches } = computeReorder(widgets, dragIndex, targetIndex);
+      if (patches.length > 0) reorderWidgets.mutate(patches);
+    }
+    endDrag();
+  };
+
+  return (
+    <Grid templateColumns={{ base: "1fr", lg: "repeat(2, 1fr)" }} gap={4}>
+      {widgets.map((widget, i) => (
+        <GridItem
+          key={widget.id}
+          colSpan={{
+            base: 1,
+            lg: widgetSize(widget.config) === "double" ? 2 : 1,
+          }}
+          draggable={isOwner && grabbedId === widget.id}
+          onDragStart={() => setDragIndex(i)}
+          onDragEnd={endDrag}
+          onDragOver={(e) => {
+            if (dragIndex === null) return;
+            e.preventDefault();
+            setOverIndex(i);
+          }}
+          onDrop={() => dropOn(i)}
+          opacity={dragIndex === i ? 0.4 : 1}
+          outline={
+            overIndex === i && dragIndex !== null && dragIndex !== i
+              ? "2px dashed"
+              : undefined
+          }
+          outlineColor="primary.solid"
+          borderRadius="sm"
+        >
+          <DashboardWidgetCard
+            widget={widget}
+            isOwner={isOwner}
+            onArmDrag={() => setGrabbedId(widget.id)}
+            onDisarmDrag={() => setGrabbedId(null)}
+            onToggleSize={() =>
+              updateWidget.mutate({
+                widgetId: widget.id,
+                patch: {
+                  config: withSize(
+                    widget.config,
+                    widgetSize(widget.config) === "double" ? "single" : "double"
+                  ),
+                },
+              })
+            }
+            onRemove={() => deleteWidget.mutate(widget.id)}
+          />
+        </GridItem>
+      ))}
+    </Grid>
+  );
+}

--- a/src/features/dashboards/ui/DashboardWidgetsGrid.tsx
+++ b/src/features/dashboards/ui/DashboardWidgetsGrid.tsx
@@ -147,7 +147,12 @@ export default function DashboardWidgetsGrid({
             key={cell.key}
             colSpan={{ base: 1, lg: size === "double" ? 2 : 1 }}
             draggable={isOwner && grabbedKey === cell.key}
-            onDragStart={() => setDragIndex(i)}
+            onDragStart={(e) => {
+              // Required for Firefox to initiate drag-and-drop.
+              e.dataTransfer.setData("text/plain", cell.key);
+              e.dataTransfer.effectAllowed = "move";
+              setDragIndex(i);
+            }}
             onDragEnd={endDrag}
             onDragOver={(e) => {
               if (dragIndex === null) return;

--- a/src/features/dashboards/ui/DashboardWidgetsGrid.tsx
+++ b/src/features/dashboards/ui/DashboardWidgetsGrid.tsx
@@ -114,20 +114,22 @@ export default function DashboardWidgetsGrid({
   };
 
   // Cards of the same widget share a position — dropping on a sibling is a no-op.
-  const isDropTarget = (index: number) =>
-    dragIndex !== null &&
-    cells[dragIndex]?.widget.id !== cells[index]?.widget.id;
+  const isDropTarget = (index: number) => {
+    const dragged = dragIndex !== null ? cells[dragIndex] : undefined;
+    const target = cells[index];
+    return !!dragged && !!target && dragged.widget.id !== target.widget.id;
+  };
 
   const dropOn = (targetIndex: number) => {
-    if (dragIndex !== null && isDropTarget(targetIndex)) {
-      const fromIndex = widgets.findIndex(
-        (w) => w.id === cells[dragIndex].widget.id
-      );
-      const toIndex = widgets.findIndex(
-        (w) => w.id === cells[targetIndex].widget.id
-      );
-      const { patches } = computeReorder(widgets, fromIndex, toIndex);
-      if (patches.length > 0) reorderWidgets.mutate(patches);
+    const draggedCell = dragIndex !== null ? cells[dragIndex] : undefined;
+    const targetCell = cells[targetIndex];
+    if (draggedCell && targetCell && draggedCell.widget.id !== targetCell.widget.id) {
+      const fromIndex = widgets.findIndex((w) => w.id === draggedCell.widget.id);
+      const toIndex = widgets.findIndex((w) => w.id === targetCell.widget.id);
+      if (fromIndex >= 0 && toIndex >= 0) {
+        const { patches } = computeReorder(widgets, fromIndex, toIndex);
+        if (patches.length > 0) reorderWidgets.mutate(patches);
+      }
     }
     endDrag();
   };

--- a/src/features/dashboards/ui/DashboardsPage.tsx
+++ b/src/features/dashboards/ui/DashboardsPage.tsx
@@ -67,7 +67,7 @@ export default function DashboardsPage() {
               </Box>
             ) : (
               // Fixed 261px cards per the Figma; as many as fit per row.
-              <Grid templateColumns="repeat(auto-fill, 261px)" gap={4}>
+              <Grid templateColumns={{ base: "1fr", sm: "repeat(auto-fill, 261px)" }} gap={4}>
                 {dashboards.map((dashboard) => (
                   <DashboardCard key={dashboard.id} dashboard={dashboard} />
                 ))}

--- a/src/features/dashboards/ui/DashboardsPage.tsx
+++ b/src/features/dashboards/ui/DashboardsPage.tsx
@@ -66,14 +66,8 @@ export default function DashboardsPage() {
                 </Text>
               </Box>
             ) : (
-              <Grid
-                templateColumns={{
-                  base: "1fr",
-                  md: "repeat(2, minmax(0, 1fr))",
-                  lg: "repeat(3, minmax(0, 1fr))",
-                }}
-                gap={4}
-              >
+              // Fixed 261px cards per the Figma; as many as fit per row.
+              <Grid templateColumns="repeat(auto-fill, 261px)" gap={4}>
                 {dashboards.map((dashboard) => (
                   <DashboardCard key={dashboard.id} dashboard={dashboard} />
                 ))}

--- a/src/features/dashboards/ui/__tests__/DashboardChatNudges.test.tsx
+++ b/src/features/dashboards/ui/__tests__/DashboardChatNudges.test.tsx
@@ -1,0 +1,140 @@
+// @vitest-environment happy-dom
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen } from "@testing-library/react";
+import type { ReactElement } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// The chatStore import chain reaches the Chakra toaster (.tsx) — stub it so the
+// test environment can parse the module boundary.
+vi.mock("@/app/components/ui/toaster", () => ({
+  toaster: { create: vi.fn() },
+  Toaster: () => null,
+}));
+
+// Keep the unseeded-cache path off the network: the query mounts and calls
+// getDashboard, which must hang (pending) rather than hit the API host.
+vi.mock("../../api/dashboards", async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  getDashboard: vi.fn(() => new Promise(() => {})),
+}));
+
+import DashboardChatNudges from "../DashboardChatNudges";
+import { dashboardKeys } from "../dashboardQueries";
+import type { Dashboard } from "../../api/schemas";
+import useChatStore from "@/app/store/chatStore";
+import useViewContextStore from "@/app/store/viewContextStore";
+
+const emptyDashboard: Dashboard = {
+  id: "d1",
+  user_id: "u1",
+  name: "Pará forest watch",
+  description: null,
+  is_public: false,
+  created_at: "2026-07-01T00:00:00Z",
+  updated_at: "2026-07-01T00:00:00Z",
+  aois: [],
+  widgets: [],
+};
+
+const populatedDashboard: Dashboard = {
+  ...emptyDashboard,
+  widgets: [
+    {
+      id: "w1",
+      position: 0,
+      widget_type: "insight",
+      insight_id: "i1",
+      config: {},
+      created_at: "2026-07-01T00:00:00Z",
+      insight: null,
+    },
+  ],
+};
+
+const sendSpy = vi.fn().mockResolvedValue({ isNew: true, id: "t1" });
+
+const renderWithDashboard = (ui: ReactElement, dashboard: Dashboard | null) => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  if (dashboard) {
+    queryClient.setQueryData(dashboardKeys.detail(dashboard.id), dashboard);
+  }
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <ChakraProvider value={defaultSystem}>{ui}</ChakraProvider>
+    </QueryClientProvider>
+  );
+};
+
+describe("DashboardChatNudges", () => {
+  beforeEach(() => {
+    sendSpy.mockClear();
+    useChatStore.setState({ sendMessage: sendSpy });
+    useViewContextStore
+      .getState()
+      .setViewContext({ page: "dashboard", dashboard_id: "d1" });
+  });
+
+  it("shows the build variant for an empty dashboard", () => {
+    renderWithDashboard(<DashboardChatNudges showChips />, emptyDashboard);
+
+    expect(screen.getByText("Start building this dashboard")).toBeTruthy();
+    expect(screen.getByText("You might want to:")).toBeTruthy();
+    expect(
+      screen.getByRole("button", {
+        name: /Add a satellite imagery map of this area/i,
+      })
+    ).toBeTruthy();
+  });
+
+  it("shows the refine variant once the dashboard has widgets", () => {
+    renderWithDashboard(<DashboardChatNudges showChips />, populatedDashboard);
+
+    expect(screen.getByText("Refine this dashboard")).toBeTruthy();
+    expect(
+      screen.getByRole("button", {
+        name: /Summarize what this dashboard shows/i,
+      })
+    ).toBeTruthy();
+  });
+
+  it("sends the chip text as a chat message on click", () => {
+    renderWithDashboard(<DashboardChatNudges showChips />, emptyDashboard);
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: /Add a satellite imagery map of this area/i,
+      })
+    );
+
+    expect(sendSpy).toHaveBeenCalledWith(
+      "Add a satellite imagery map of this area"
+    );
+  });
+
+  it("keeps the greeting but hides the chips once a prompt was sent", () => {
+    renderWithDashboard(
+      <DashboardChatNudges showChips={false} />,
+      emptyDashboard
+    );
+
+    expect(screen.getByText("Start building this dashboard")).toBeTruthy();
+    expect(screen.queryByText("You might want to:")).toBeNull();
+    expect(screen.queryByRole("button")).toBeNull();
+  });
+
+  it("renders nothing until the dashboard resolves", () => {
+    useViewContextStore
+      .getState()
+      .setViewContext({ page: "dashboard", dashboard_id: "d-missing" });
+
+    const { container } = renderWithDashboard(
+      <DashboardChatNudges showChips />,
+      null
+    );
+
+    expect(container.textContent).toBe("");
+  });
+});

--- a/src/features/dashboards/ui/dashboardQueries.ts
+++ b/src/features/dashboards/ui/dashboardQueries.ts
@@ -9,10 +9,14 @@ import { searchAois } from "../api/aois";
 import {
   createDashboard,
   createDashboardPayloadFromAoi,
+  deleteWidget,
   getDashboard,
   listDashboards,
+  updateWidget,
+  type WidgetUpdate,
 } from "../api/dashboards";
-import type { AoiSearchResult } from "../api/schemas";
+import type { AoiSearchResult, Dashboard } from "../api/schemas";
+import type { WidgetPositionPatch } from "../lib/widgets";
 
 export const dashboardKeys = {
   all: ["dashboards"] as const,
@@ -67,4 +71,79 @@ export function useCreateDashboardFromAoi() {
       queryClient.setQueryData(dashboardKeys.detail(dashboard.id), dashboard);
     },
   });
+}
+
+// Shared optimistic-update plumbing for the widget mutations: snapshot the
+// cached dashboard, apply `apply` to its widgets, roll back on error and
+// refetch on settle (the server is the position/config authority).
+function useOptimisticWidgetMutation<TVars>(
+  dashboardId: string,
+  mutationFn: (vars: TVars) => Promise<unknown>,
+  apply: (widgets: Dashboard["widgets"], vars: TVars) => Dashboard["widgets"]
+) {
+  const queryClient = useQueryClient();
+  const key = dashboardKeys.detail(dashboardId);
+
+  return useMutation({
+    mutationFn,
+    onMutate: async (vars: TVars) => {
+      await queryClient.cancelQueries({ queryKey: key });
+      const previous = queryClient.getQueryData<Dashboard>(key);
+      if (previous) {
+        queryClient.setQueryData<Dashboard>(key, {
+          ...previous,
+          widgets: apply(previous.widgets, vars),
+        });
+      }
+      return { previous };
+    },
+    onError: (_err, _vars, context) => {
+      if (context?.previous) queryClient.setQueryData(key, context.previous);
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: key });
+    },
+  });
+}
+
+export function useUpdateWidget(dashboardId: string) {
+  return useOptimisticWidgetMutation(
+    dashboardId,
+    ({ widgetId, patch }: { widgetId: string; patch: WidgetUpdate }) =>
+      updateWidget(dashboardId, widgetId, patch),
+    (widgets, { widgetId, patch }) =>
+      widgets.map((w) =>
+        w.id === widgetId
+          ? {
+              ...w,
+              ...(patch.position !== undefined
+                ? { position: patch.position }
+                : {}),
+              ...(patch.config ? { config: patch.config } : {}),
+            }
+          : w
+      )
+  );
+}
+
+export function useDeleteWidget(dashboardId: string) {
+  return useOptimisticWidgetMutation(
+    dashboardId,
+    (widgetId: string) => deleteWidget(dashboardId, widgetId),
+    (widgets, widgetId) => widgets.filter((w) => w.id !== widgetId)
+  );
+}
+
+export function useReorderWidgets(dashboardId: string) {
+  return useOptimisticWidgetMutation(
+    dashboardId,
+    (patches: WidgetPositionPatch[]) =>
+      Promise.all(patches.map((p) => updateWidget(dashboardId, p.id, p))),
+    (widgets, patches) => {
+      const positions = new Map(patches.map((p) => [p.id, p.position]));
+      return widgets.map((w) =>
+        positions.has(w.id) ? { ...w, position: positions.get(w.id)! } : w
+      );
+    }
+  );
 }

--- a/src/features/dashboards/ui/dashboardQueries.ts
+++ b/src/features/dashboards/ui/dashboardQueries.ts
@@ -12,6 +12,7 @@ import {
   deleteWidget,
   getDashboard,
   listDashboards,
+  renameDashboard,
   updateWidget,
   type WidgetUpdate,
 } from "../api/dashboards";
@@ -69,6 +70,33 @@ export function useCreateDashboardFromAoi() {
     onSuccess: (dashboard) => {
       queryClient.invalidateQueries({ queryKey: dashboardKeys.all });
       queryClient.setQueryData(dashboardKeys.detail(dashboard.id), dashboard);
+    },
+  });
+}
+
+export function useRenameDashboard(dashboardId: string) {
+  const queryClient = useQueryClient();
+  const key = dashboardKeys.detail(dashboardId);
+
+  return useMutation({
+    mutationFn: (name: string) => renameDashboard(dashboardId, name),
+    // Optimistic: the PATCH response lacks insight expansion, so the new name
+    // is applied to the cached dashboard and the server copy refetched on
+    // settle rather than written from the response.
+    onMutate: async (name: string) => {
+      await queryClient.cancelQueries({ queryKey: key });
+      const previous = queryClient.getQueryData<Dashboard>(key);
+      if (previous) {
+        queryClient.setQueryData<Dashboard>(key, { ...previous, name });
+      }
+      return { previous };
+    },
+    onError: (_err, _name, context) => {
+      if (context?.previous) queryClient.setQueryData(key, context.previous);
+    },
+    onSettled: () => {
+      // Prefix-matches the detail key and the list (dashboard switcher).
+      queryClient.invalidateQueries({ queryKey: dashboardKeys.all });
     },
   });
 }

--- a/src/features/dashboards/ui/dashboardQueries.ts
+++ b/src/features/dashboards/ui/dashboardQueries.ts
@@ -7,6 +7,7 @@ import {
 
 import { searchAois } from "../api/aois";
 import {
+  addInsightWidget,
   createDashboard,
   createDashboardPayloadFromAoi,
   deleteWidget,
@@ -152,6 +153,22 @@ export function useUpdateWidget(dashboardId: string) {
           : w
       )
   );
+}
+
+// Chat-side "Add to dashboard" toggle-on. Not optimistic: the server assigns
+// the widget id/position and the POST response lacks insight expansion, so
+// the detail is refetched to render the new card.
+export function useAddInsightWidget(dashboardId: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (insightId: string) => addInsightWidget(dashboardId, insightId),
+    onSettled: () => {
+      queryClient.invalidateQueries({
+        queryKey: dashboardKeys.detail(dashboardId),
+      });
+    },
+  });
 }
 
 export function useDeleteWidget(dashboardId: string) {

--- a/src/features/dashboards/ui/dashboardQueries.ts
+++ b/src/features/dashboards/ui/dashboardQueries.ts
@@ -10,6 +10,7 @@ import {
   addInsightWidget,
   createDashboard,
   createDashboardPayloadFromAoi,
+  deleteDashboard,
   deleteWidget,
   getDashboard,
   listDashboards,
@@ -97,6 +98,38 @@ export function useRenameDashboard(dashboardId: string) {
     },
     onSettled: () => {
       // Prefix-matches the detail key and the list (dashboard switcher).
+      queryClient.invalidateQueries({ queryKey: dashboardKeys.all });
+    },
+  });
+}
+
+export function useDeleteDashboard() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (dashboardId: string) => deleteDashboard(dashboardId),
+    // Optimistic: the card disappears from the list immediately; the
+    // snapshot is restored if the DELETE fails.
+    onMutate: async (dashboardId: string) => {
+      await queryClient.cancelQueries({ queryKey: dashboardKeys.all });
+      const previous = queryClient.getQueryData<Dashboard[]>(dashboardKeys.all);
+      if (previous) {
+        queryClient.setQueryData<Dashboard[]>(
+          dashboardKeys.all,
+          previous.filter((d) => d.id !== dashboardId)
+        );
+      }
+      return { previous };
+    },
+    onError: (_err, _id, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(dashboardKeys.all, context.previous);
+      }
+    },
+    onSettled: (_data, _err, dashboardId) => {
+      queryClient.removeQueries({
+        queryKey: dashboardKeys.detail(dashboardId),
+      });
       queryClient.invalidateQueries({ queryKey: dashboardKeys.all });
     },
   });

--- a/src/features/dashboards/ui/heroGrid.ts
+++ b/src/features/dashboards/ui/heroGrid.ts
@@ -1,0 +1,10 @@
+// Graph-paper hero per the Figma page shell (node 1317-3730): minor 1px
+// #FCFCFC lines every 7px with a stronger #F9F9FA line every 70px, on white.
+// Major lines listed first so they paint over coincident minor lines.
+// Shared by the dashboard detail hero band and the dashboard list cards.
+export const HERO_GRID_IMAGE = [
+  "repeating-linear-gradient(to right, #F9F9FA 0 1px, transparent 1px 70px)",
+  "repeating-linear-gradient(to bottom, #F9F9FA 0 1px, transparent 1px 70px)",
+  "repeating-linear-gradient(to right, #FCFCFC 0 1px, transparent 1px 7px)",
+  "repeating-linear-gradient(to bottom, #FCFCFC 0 1px, transparent 1px 7px)",
+].join(",");


### PR DESCRIPTION
## Dashboards MVP — chat-connected dashboard pages

NOTE: hardcodes the `experimental` agent profile in API requests.

<img width="1920" height="993" alt="Screenshot 2026-07-10 at 17 46 51" src="https://github.com/user-attachments/assets/458b1741-6369-44d8-98f9-aef76be33009" />

Adds the dashboards surface behind the `?ff=dashboard` feature flag: a
dashboards list, a dashboard detail page rendering persisted insight widgets,
and the AI chat mounted on the dashboard so the agent can create dashboards
and add insights to them ("add this to my dashboard"). Frontend counterpart
of `wri/project-zeno` `feat/dashboards-mvp` (see `docs/dashboards-frontend-handoff.md`).

### Pages & shell
- `/dashboards` (list) and `/dashboards/[id]` (detail), auth-guarded and
  gated by `DashboardFeatureGate` (`?ff=dashboard`).
- Detail page shell matches the Figma "Dashboard default" frame: breadcrumb,
  1200px card with 8px radius and 2px primary top edge, 30px title,
  mono "Updated…" label.
- **Editable title** (owner only): pencil → inline input, Enter/blur saves via
  `PATCH /api/dashboards/:id` with optimistic cache update; the PATCH response
  lacks insight expansion so it is never written into the cache (refetch on settle).
- **Export / Share are false doors** ("coming soon" toasts) — PDF export is an
  explicit MVP scope cut; Share has a ready backend (publish + cascade) and is
  a follow-up.

### Widgets
- Zod-validated API layer (`src/features/dashboards/api/`) — deliberately
  lenient parsing so unknown backend fields never break the page; hidden
  insights degrade to a "not available" placeholder per the API contract.
- **One card per chart**: a widget whose insight has several charts renders as
  individual containers (per design). Cells map 1:1 to charts while
  position/config/remove stay widget-level: dragging any card moves the whole
  analysis, per-chart column spans persist under `config.sizes[chartId]`
  (legacy `size` fallback), and the remove dialog says when it removes siblings.
- Card = Figma "Analysis" container: light-blue shell, header (drag handle ·
  title · add-to-conversation/resize/remove), "Show params" row with an AREA
  chip (the dashboard's single AOI — the API carries no other params), and the
  existing `WidgetMessage` chart card inside (chart/table toggle, fullscreen,
  CSV/PNG download, provenance drawer come free).
- Reorder is native HTML5 drag-and-drop armed from the drag handle only, with
  optimistic PATCHes and rollback on error.

### Chat integration
- ChatPanel mounts on the dashboard detail page as a fixed overlay; opening it
  full-width shifts the dashboard content right so they never overlap (panel
  size state moved into `sidebarStore` — single source of truth across surfaces).
- Every chat request reports `view_context` (`page: "dashboard"` +
  `dashboard_id`/`name`) so "add this to my dashboard" needs no naming.
- On a dashboard surface the request defaults to the **experimental agent
  profile** for flag-eligible user types — the backend's dashboard tools only
  exist in that profile; previously this silently depended on a persisted
  `?agent_profile=` visit.
- `dashboard_updated` write signals now survive multi-message stream updates
  and error-classified tool messages (parser scans every message; refetch is
  hoisted above the message-type branching).
- Map-only chat affordances (Layer/Area pickers, catalog panel offsets) are
  suppressed off `/app` routes.

### Test plan
- [ ] `pnpm test` — 456 passing (2 pre-existing `ViewAnalysisNudge` copy
      failures, unrelated); new coverage for the widget adapter, per-chart
      size helpers, reorder mapping, stream write-signal parsing, layout geometry.
- [ ] `format:check` / `lint` / `typecheck` / `build` green.
- [ ] Manual: open a dashboard → widgets render one card per chart; rename via
      pencil persists; drag/resize/remove persist and roll back on API error;
      "add this to my dashboard" in chat (admin/superuser account) adds a
      widget and the page refetches without reload; chat full-width doesn't
      cover content.

### Known gaps / follow-ups
- **Map widgets** (`widget_type: "map"`) render a placeholder — the design's
  full-bleed map + MAP LAYERS legend is the next big rock (last in the
  handoff's build order).
- **Text/annotation widgets** ("Key Insights" card) need a backend
  `widget_type` first; **params beyond AREA** (DATA/MONTH chips) need the
  backend to persist analysis params on insights.
- **Dashboard-aware chat content** — "Refine this dashboard" welcome,
  dashboard-specific suggestions, Datasets/Analyses prompt buttons.
- **Real Share flow** — backend publish endpoint + cascade confirmation
  (`publicized_insight_ids`) exists; currently a false door. Export PDF stays
  a false door by scope.
- **Chat-side "add to dashboard" toggle** on insight cards (direct
  `POST /widgets`, no agent round-trip).
- Mobile: dashboard chat is desktop-only for now (bottom-sheet slice deferred).
- Non-admin users can't use dashboard chat tools until the backend moves them
  out of the experimental profile.