### PR TITLE
Dashboard chat nudges

### DIFF
--- a/app/app/(chat)/layout.tsx
+++ b/app/app/(chat)/layout.tsx
@@ -11,6 +11,7 @@ import {
 import { useEffect, useState } from "react";
 
 import ChatPanel from "@/app/ChatPanel";
+import ConversationHistoryDrawer from "@/app/components/ConversationHistoryDrawer";
 import UploadAreaDialog from "@/app/components/UploadAreaDialog";
 import Map from "@/app/components/Map";
 import CatalogPanel from "@/app/components/CatalogPanel";
@@ -40,7 +41,7 @@ export default function DashboardLayout({
 }) {
   const isReady = useAuthGuard();
   const [sheetHeight, setSheetHeight] = useState(400);
-  const { toggleSidebar, sideBarVisible } = useSidebarStore();
+  const { toggleSidebar } = useSidebarStore();
   const isMobile = useBreakpointValue({ base: true, md: false });
   const [mobileHeight, setMobileHeight] = useState("0");
 
@@ -111,22 +112,7 @@ export default function DashboardLayout({
           <ChatPanel />
         </Box>
       </Box>
-      <Drawer.Root
-        placement="start"
-        open={sideBarVisible}
-        onOpenChange={(e) => {
-          if (!e.open && sideBarVisible) toggleSidebar();
-        }}
-      >
-        <Portal>
-          <Drawer.Backdrop backdropFilter="blur(2px)" />
-          <Drawer.Positioner>
-            <Drawer.Content maxW="428px" w="428px">
-              <Sidebar />
-            </Drawer.Content>
-          </Drawer.Positioner>
-        </Portal>
-      </Drawer.Root>
+      <ConversationHistoryDrawer />
     </Box>
   );
 

--- a/app/components/ChatMessages.tsx
+++ b/app/components/ChatMessages.tsx
@@ -2,7 +2,9 @@
 import { Fragment, useEffect, useRef } from "react";
 import { Box, BoxProps } from "@chakra-ui/react";
 import useChatStore from "@/app/store/chatStore";
+import useViewContextStore from "@/app/store/viewContextStore";
 import { usePinnedPrompt } from "@/app/hooks/usePinnedPrompt";
+import DashboardChatNudges from "@/src/features/dashboards/ui/DashboardChatNudges";
 import MessageBubble from "./MessageBubble";
 import PinnedPrompt from "./PinnedPrompt";
 import Reasoning from "./Reasoning";
@@ -23,6 +25,11 @@ function ChatMessages({ pt }: ChatMessagesProps) {
   const lastUserMessageRef = useRef<HTMLDivElement>(null);
   const spacerRef = useRef<HTMLDivElement>(null);
   const { messages, isLoading, toolSteps: currentToolSteps } = useChatStore();
+  // The greeting and first-message prompts are surface-specific: on a
+  // dashboard the seeded map welcome is swapped for the dashboard nudges.
+  const onDashboard = useViewContextStore(
+    (s) => s.viewContext?.page === "dashboard"
+  );
   const shouldAutoScroll = useRef(true);
   const { pinnedMessage, registerPromptNode, jumpToPinnedPrompt } =
     usePinnedPrompt(containerRef, messages);
@@ -115,20 +122,25 @@ function ChatMessages({ pt }: ChatMessagesProps) {
         const isLast = index === messages.length - 1;
         const isLastUserMessage =
           index === lastUserMessageIndex && message.type === "user";
+        const isSeededGreeting = isFirst && message.type === "system";
         return (
           <Fragment key={message.id}>
             {isLastUserMessage && <Box ref={lastUserMessageRef} />}
-            <MessageBubble
-              bubbleRef={
-                message.type === "user"
-                  ? registerPromptNode(message.id)
-                  : undefined
-              }
-              message={message}
-              isConsecutive={isConsecutive}
-              isFirst={isFirst}
-              isLast={isLast}
-            />
+            {isSeededGreeting && onDashboard ? (
+              <DashboardChatNudges showChips={messages.length < 2} />
+            ) : (
+              <MessageBubble
+                bubbleRef={
+                  message.type === "user"
+                    ? registerPromptNode(message.id)
+                    : undefined
+                }
+                message={message}
+                isConsecutive={isConsecutive}
+                isFirst={isFirst}
+                isLast={isLast}
+              />
+            )}
             {message.type === "user" && (
               <>
                 {/* Show reasoning for current loading query (last user message) */}
@@ -146,8 +158,9 @@ function ChatMessages({ pt }: ChatMessagesProps) {
               </>
             )}
 
-            {/* Prompt options for first message, removed when sent */}
-            {messages.length < 2 && <SamplePrompts />}
+            {/* Prompt options for first message, removed when sent. On the
+                dashboard surface DashboardChatNudges renders its own chips. */}
+            {messages.length < 2 && !onDashboard && <SamplePrompts />}
           </Fragment>
         );
       })}

--- a/app/components/ConversationHistoryDrawer.tsx
+++ b/app/components/ConversationHistoryDrawer.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { Drawer, Portal } from "@chakra-ui/react";
+
+import { Sidebar } from "@/app/sidebar";
+import useSidebarStore from "@/app/store/sidebarStore";
+
+/**
+ * The conversation-history sidebar in a left drawer, driven by
+ * `sidebarStore.sideBarVisible` (the PageHeader clock icon toggles it).
+ * The header renders that button on every surface, so every surface must
+ * mount this drawer — otherwise the click silently flips an invisible flag.
+ * Extracted from the map layout so the dashboard pages can mount it too.
+ */
+export default function ConversationHistoryDrawer() {
+  const { sideBarVisible, toggleSidebar } = useSidebarStore();
+  return (
+    <Drawer.Root
+      placement="start"
+      open={sideBarVisible}
+      onOpenChange={(e) => {
+        if (!e.open && sideBarVisible) toggleSidebar();
+      }}
+    >
+      <Portal>
+        <Drawer.Backdrop backdropFilter="blur(2px)" />
+        <Drawer.Positioner>
+          <Drawer.Content maxW="428px" w="428px">
+            <Sidebar />
+          </Drawer.Content>
+        </Drawer.Positioner>
+      </Portal>
+    </Drawer.Root>
+  );
+}

--- a/app/components/PageHeader.tsx
+++ b/app/components/PageHeader.tsx
@@ -39,7 +39,11 @@ import { usePathname } from "next/navigation";
 import { useLogout } from "@/app/hooks/useLogout";
 import { useThreadsInfinite } from "@/app/hooks/useThreadsInfinite";
 import { useFeatureFlag } from "@/src/shared/lib/feature-flags";
-import { mapTabHref } from "@/app/utils/threadNavigation";
+import {
+  mapTabHref,
+  newConversationTarget,
+} from "@/app/utils/threadNavigation";
+import useMapStore from "../store/mapStore";
 
 const isPrototype = process.env.NEXT_PUBLIC_PROTOTYPE_MODE === "true";
 const DISCLAIMER_STORAGE_KEY = "gnw_disclaimer_dismissed_v2";
@@ -56,6 +60,15 @@ function PageHeader() {
   const onMap = pathname.startsWith("/app");
   const onDashboards = pathname.startsWith("/dashboards");
   const dashboardFeatureEnabled = useFeatureFlag("dashboard");
+
+  const newConvo = newConversationTarget(pathname, dashboardFeatureEnabled);
+  // Mirrors the /app NewThread mount reset. In place because the dashboard
+  // page hosts its own chat panel and its URL doesn't carry the conversation
+  // (ADR-003) — navigating would leave the page the user is working on.
+  const startNewConversationInPlace = () => {
+    useChatStore.getState().reset();
+    useMapStore.getState().reset();
+  };
 
   const currentThread = currentThreadId
     ? threads.find((t) => t.id === currentThreadId)
@@ -261,18 +274,32 @@ function PageHeader() {
             </Text>
           )}
           <Tooltip content="New conversation" showArrow>
-            <IconButton
-              asChild
-              size="xs"
-              variant="ghost"
-              color={inverseColor}
-              _hover={{ bg: inverseHoverBg }}
-              _focusVisible={focusRing}
-            >
-              <Link href="/app" aria-label="New conversation">
+            {newConvo.kind === "reset-in-place" ? (
+              <IconButton
+                size="xs"
+                variant="ghost"
+                color={inverseColor}
+                _hover={{ bg: inverseHoverBg }}
+                _focusVisible={focusRing}
+                aria-label="New conversation"
+                onClick={startNewConversationInPlace}
+              >
                 <PlusIcon size={16} />
-              </Link>
-            </IconButton>
+              </IconButton>
+            ) : (
+              <IconButton
+                asChild
+                size="xs"
+                variant="ghost"
+                color={inverseColor}
+                _hover={{ bg: inverseHoverBg }}
+                _focusVisible={focusRing}
+              >
+                <Link href={newConvo.href} aria-label="New conversation">
+                  <PlusIcon size={16} />
+                </Link>
+              </IconButton>
+            )}
           </Tooltip>
         </Flex>
       </Flex>

--- a/app/dashboards/[id]/page.tsx
+++ b/app/dashboards/[id]/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import ConversationHistoryDrawer from "@/app/components/ConversationHistoryDrawer";
 import PageHeader from "@/app/components/PageHeader";
 import { useAuthGuard } from "@/app/hooks/useAuthGuard";
 import {
@@ -14,6 +15,7 @@ export default function DashboardDetailRoute() {
   return (
     <DashboardFeatureGate>
       <PageHeader />
+      <ConversationHistoryDrawer />
       <DashboardDetailPage />
     </DashboardFeatureGate>
   );

--- a/app/dashboards/page.tsx
+++ b/app/dashboards/page.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import ConversationHistoryDrawer from "@/app/components/ConversationHistoryDrawer";
 import PageHeader from "@/app/components/PageHeader";
 import { useAuthGuard } from "@/app/hooks/useAuthGuard";
 import {
@@ -14,6 +15,7 @@ export default function DashboardsRoute() {
   return (
     <DashboardFeatureGate>
       <PageHeader />
+      <ConversationHistoryDrawer />
       <DashboardsPage />
     </DashboardFeatureGate>
   );

--- a/app/sidebar.tsx
+++ b/app/sidebar.tsx
@@ -1,4 +1,5 @@
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { usePathname } from "next/navigation";
 import {
   Button,
   Flex,
@@ -28,13 +29,32 @@ import {
 import useSidebarStore from "./store/sidebarStore";
 import useAuthStore from "./store/authStore";
 import useChatStore from "./store/chatStore";
+import useMapStore from "./store/mapStore";
 import { useLogout } from "./hooks/useLogout";
 import ThreadActionsMenu from "./components/ThreadActionsMenu";
 import LclLogo from "./components/LclLogo";
 import { useThreadsInfinite } from "./hooks/useThreadsInfinite";
 import { useIntersectionObserver } from "./hooks/useIntersectionObserver";
+import { useFeatureFlag } from "@/src/shared/lib/feature-flags";
+import {
+  newConversationTarget,
+  threadClickTarget,
+} from "./utils/threadNavigation";
 
-function ThreadLink(props: LinkProps & { isActive?: boolean; href: string }) {
+/**
+ * The current `location.search`, captured once on mount (mirroring
+ * `useFeatureFlag`): the URL only exists client-side, and the first-message
+ * thread rewrite can drop query params mid-session — the mount-time value is
+ * the trustworthy one.
+ */
+function useMountSearch(): string | null {
+  const [search] = useState(() =>
+    typeof window === "undefined" ? null : window.location.search
+  );
+  return search;
+}
+
+function ThreadLink(props: LinkProps & { isActive?: boolean; href?: string }) {
   const { href, children, isActive, ...rest } = props;
   return (
     <ChLink
@@ -47,6 +67,7 @@ function ThreadLink(props: LinkProps & { isActive?: boolean; href: string }) {
       display="block"
       flex="1"
       outline="none"
+      cursor="pointer"
       {...(isActive
         ? {
             color: "primary.fg",
@@ -55,9 +76,18 @@ function ThreadLink(props: LinkProps & { isActive?: boolean; href: string }) {
       {...rest}
       asChild
     >
-      <Link href={href} style={{ display: "block", width: "100%" }}>
-        {children}
-      </Link>
+      {href ? (
+        <Link href={href} style={{ display: "block", width: "100%" }}>
+          {children}
+        </Link>
+      ) : (
+        <button
+          type="button"
+          style={{ display: "block", width: "100%", textAlign: "left" }}
+        >
+          {children}
+        </button>
+      )}
     </ChLink>
   );
 }
@@ -81,6 +111,22 @@ function ThreadSection({
   footer?: React.ReactNode;
 }) {
   const { toggleSidebar } = useSidebarStore();
+  const pathname = usePathname();
+  const search = useMountSearch();
+
+  // On a dashboard detail page the conversation isn't in the URL (ADR-003),
+  // so resuming one loads it into the global chat store in place — the same
+  // reset the map's thread page performs on navigation, minus the navigation.
+  const openThreadInPlace = (threadId: string) => {
+    const chat = useChatStore.getState();
+    if (chat.currentThreadId !== threadId) {
+      chat.reset();
+      useMapStore.getState().reset();
+      chat.fetchThread(threadId);
+    }
+    toggleSidebar();
+  };
+
   if (!threads.length && !footer) return null;
   return (
     <Accordion.Item value={value} border="none">
@@ -100,6 +146,7 @@ function ThreadSection({
         <Stack gap="1" mt="1">
           {threads.map((thread) => {
             const isActive = currentThreadId === thread.id;
+            const target = threadClickTarget(pathname, thread.id, search);
             return (
               <Flex
                 key={thread.id}
@@ -121,14 +168,24 @@ function ThreadSection({
                 }}
                 {...(isActive ? { bg: "bg", color: "blue.fg" } : {})}
               >
-                <ThreadLink
-                  href={`/app/threads/${thread.id}`}
-                  isActive={isActive}
-                  _hover={{ textDecor: "none" }}
-                  onClick={toggleSidebar}
-                >
-                  {thread.name}
-                </ThreadLink>
+                {target.kind === "navigate" ? (
+                  <ThreadLink
+                    href={target.href}
+                    isActive={isActive}
+                    _hover={{ textDecor: "none" }}
+                    onClick={toggleSidebar}
+                  >
+                    {thread.name}
+                  </ThreadLink>
+                ) : (
+                  <ThreadLink
+                    isActive={isActive}
+                    _hover={{ textDecor: "none" }}
+                    onClick={() => openThreadInPlace(thread.id)}
+                  >
+                    {thread.name}
+                  </ThreadLink>
+                )}
                 <div onClick={(e) => e.stopPropagation()}>
                   <ThreadActionsMenu thread={thread} />
                 </div>
@@ -166,6 +223,17 @@ export function Sidebar() {
   }, [fetchApiStatus]);
 
   const { logout, isLoggingOut } = useLogout();
+
+  const pathname = usePathname();
+  const dashboardFeatureEnabled = useFeatureFlag("dashboard");
+  const newConvo = newConversationTarget(pathname, dashboardFeatureEnabled);
+  // Mirrors PageHeader's in-place reset: a dashboard detail page hosts its
+  // own chat panel, so starting a new conversation must not navigate away.
+  const startNewConversationInPlace = () => {
+    useChatStore.getState().reset();
+    useMapStore.getState().reset();
+    toggleSidebar();
+  };
 
   const hasTodayThreads = threadGroups.today.length > 0;
   const hasPreviousWeekThreads = threadGroups.previousWeek.length > 0;
@@ -230,19 +298,33 @@ export function Sidebar() {
         bg="bg.subtle"
         boxShadow="xs"
       >
-        <Button
-          asChild
-          variant="outline"
-          colorPalette="primary"
-          size="sm"
-          w={{ base: "full", md: "auto" }}
-          onClick={toggleSidebar}
-        >
-          <Link href="/app" aria-label="New conversation">
+        {newConvo.kind === "reset-in-place" ? (
+          <Button
+            variant="outline"
+            colorPalette="primary"
+            size="sm"
+            w={{ base: "full", md: "auto" }}
+            aria-label="New conversation"
+            onClick={startNewConversationInPlace}
+          >
             New Conversation
             <NotePencilIcon />
-          </Link>
-        </Button>
+          </Button>
+        ) : (
+          <Button
+            asChild
+            variant="outline"
+            colorPalette="primary"
+            size="sm"
+            w={{ base: "full", md: "auto" }}
+            onClick={toggleSidebar}
+          >
+            <Link href={newConvo.href} aria-label="New conversation">
+              New Conversation
+              <NotePencilIcon />
+            </Link>
+          </Button>
+        )}
         <Tooltip
           content="Close sidebar"
           positioning={{ placement: "right" }}

--- a/app/utils/__tests__/threadNavigation.test.ts
+++ b/app/utils/__tests__/threadNavigation.test.ts
@@ -4,6 +4,7 @@ import {
   firstMessageRedirectPath,
   isAppRoute,
   mapTabHref,
+  newConversationTarget,
 } from "../threadNavigation";
 
 describe("isAppRoute", () => {
@@ -64,6 +65,39 @@ describe("firstMessageRedirectPath", () => {
 
   it("stays put when the pathname is unknown", () => {
     expect(firstMessageRedirectPath(null, "t-1")).toBeNull();
+  });
+});
+
+describe("newConversationTarget", () => {
+  it("resets in place on a dashboard detail page", () => {
+    expect(newConversationTarget("/dashboards/abc", true)).toEqual({
+      kind: "reset-in-place",
+    });
+  });
+
+  it("navigates from the dashboards list (no chat panel there)", () => {
+    expect(newConversationTarget("/dashboards", true)).toEqual({
+      kind: "navigate",
+      href: "/app?ff=dashboard",
+    });
+  });
+
+  it("keeps the dashboards feature gate open when navigating", () => {
+    expect(newConversationTarget("/app/threads/t-1", true)).toEqual({
+      kind: "navigate",
+      href: "/app?ff=dashboard",
+    });
+  });
+
+  it("navigates plainly when the feature gate is closed", () => {
+    expect(newConversationTarget("/app", false)).toEqual({
+      kind: "navigate",
+      href: "/app",
+    });
+    expect(newConversationTarget(null, false)).toEqual({
+      kind: "navigate",
+      href: "/app",
+    });
   });
 });
 

--- a/app/utils/__tests__/threadNavigation.test.ts
+++ b/app/utils/__tests__/threadNavigation.test.ts
@@ -5,6 +5,7 @@ import {
   isAppRoute,
   mapTabHref,
   newConversationTarget,
+  threadClickTarget,
 } from "../threadNavigation";
 
 describe("isAppRoute", () => {
@@ -97,6 +98,48 @@ describe("newConversationTarget", () => {
     expect(newConversationTarget(null, false)).toEqual({
       kind: "navigate",
       href: "/app",
+    });
+  });
+});
+
+describe("threadClickTarget", () => {
+  it("loads in place on a dashboard detail page", () => {
+    expect(
+      threadClickTarget("/dashboards/abc", "t-1", "?ff=dashboard")
+    ).toEqual({
+      kind: "load-in-place",
+    });
+  });
+
+  it("navigates from the dashboards list, keeping the feature gate open", () => {
+    expect(threadClickTarget("/dashboards", "t-1", "?ff=dashboard")).toEqual({
+      kind: "navigate",
+      href: "/app/threads/t-1?ff=dashboard",
+    });
+  });
+
+  it("navigates on the map surface, carrying the current ff flags", () => {
+    expect(threadClickTarget("/app", "t-1", "?ff=dashboard,analysis")).toEqual({
+      kind: "navigate",
+      href: "/app/threads/t-1?ff=dashboard%2Canalysis",
+    });
+  });
+
+  it("navigates plainly without flags or a known pathname", () => {
+    expect(threadClickTarget("/app", "t-1")).toEqual({
+      kind: "navigate",
+      href: "/app/threads/t-1",
+    });
+    expect(threadClickTarget(null, "t-1", null)).toEqual({
+      kind: "navigate",
+      href: "/app/threads/t-1",
+    });
+  });
+
+  it("does not carry unrelated params into the thread link", () => {
+    expect(threadClickTarget("/app", "t-1", "?prompt=hello")).toEqual({
+      kind: "navigate",
+      href: "/app/threads/t-1",
     });
   });
 });

--- a/app/utils/threadNavigation.ts
+++ b/app/utils/threadNavigation.ts
@@ -9,6 +9,20 @@ export function isAppRoute(pathname: string | null): boolean {
 }
 
 /**
+ * The canonical map URL for a thread, carrying the hidden-feature flags
+ * (?ff=…) from the given `location.search` — dropping them closes the
+ * dashboards feature gate on the next navigation or refresh. Other params
+ * are deliberately not carried over (e.g. a landing ?prompt= must not ride
+ * along).
+ */
+export function threadHref(threadId: string, search?: string | null): string {
+  const ff = search ? new URLSearchParams(search).get("ff") : null;
+  return ff
+    ? `/app/threads/${threadId}?${new URLSearchParams({ ff })}`
+    : `/app/threads/${threadId}`;
+}
+
+/**
  * Where to send the browser after the first message of a new thread.
  *
  * Only the map surface rewrites its URL to the canonical thread route.
@@ -16,11 +30,6 @@ export function isAppRoute(pathname: string | null): boolean {
  * chat store and the user stays where they are — returning to the map via
  * the header's thread-aware Map tab lands on the thread URL with state
  * intact. Returns null when no navigation should happen.
- *
- * Pass the current `location.search` so the hidden-feature flags (?ff=…)
- * survive the rewrite — dropping them closes the dashboards feature gate on
- * the next navigation or refresh. Other params are deliberately not carried
- * over (e.g. a landing ?prompt= must not ride along).
  */
 export function firstMessageRedirectPath(
   pathname: string | null,
@@ -28,10 +37,28 @@ export function firstMessageRedirectPath(
   search?: string | null
 ): string | null {
   if (!isAppRoute(pathname)) return null;
-  const ff = search ? new URLSearchParams(search).get("ff") : null;
-  return ff
-    ? `/app/threads/${threadId}?${new URLSearchParams({ ff })}`
-    : `/app/threads/${threadId}`;
+  return threadHref(threadId, search);
+}
+
+/**
+ * What clicking a conversation in the history sidebar should do.
+ *
+ * A dashboard detail page hosts its own chat panel, and its URL doesn't
+ * encode the conversation (ADR-003) — so resuming a past conversation there
+ * loads the thread into the global chat store in place, keeping the user on
+ * the dashboard. Everywhere else (map, dashboards list — which has no chat
+ * panel) the click navigates to the thread's canonical map URL, carrying
+ * `?ff=…` so hidden feature gates stay open.
+ */
+export function threadClickTarget(
+  pathname: string | null,
+  threadId: string,
+  search?: string | null
+): { kind: "load-in-place" } | { kind: "navigate"; href: string } {
+  if (/^\/dashboards\/./.test(pathname ?? "")) {
+    return { kind: "load-in-place" };
+  }
+  return { kind: "navigate", href: threadHref(threadId, search) };
 }
 
 /**

--- a/app/utils/threadNavigation.ts
+++ b/app/utils/threadNavigation.ts
@@ -35,6 +35,29 @@ export function firstMessageRedirectPath(
 }
 
 /**
+ * What the header's "New conversation" (+) control should do.
+ *
+ * A dashboard detail page hosts its own chat panel, so starting a new
+ * conversation there must not navigate away — the conversation is global
+ * session state that dashboard URLs don't encode (see ADR-003), so the
+ * caller resets the stores in place instead. Everywhere else the button
+ * navigates to the map's new-thread route, carrying `?ff=dashboard` when the
+ * feature gate is open so the navigation doesn't close it.
+ */
+export function newConversationTarget(
+  pathname: string | null,
+  dashboardFeatureEnabled: boolean
+): { kind: "reset-in-place" } | { kind: "navigate"; href: string } {
+  if (/^\/dashboards\/./.test(pathname ?? "")) {
+    return { kind: "reset-in-place" };
+  }
+  return {
+    kind: "navigate",
+    href: dashboardFeatureEnabled ? "/app?ff=dashboard" : "/app",
+  };
+}
+
+/**
  * The header Map tab's destination. `/app` mounts the new-thread page, which
  * resets the chat and map stores — correct when nothing is under way, but it
  * would wipe a live conversation when returning from a dashboard. With an

--- a/src/features/dashboards/ui/DashboardChatNudges.tsx
+++ b/src/features/dashboards/ui/DashboardChatNudges.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import { Box, Flex, Heading, Text } from "@chakra-ui/react";
+
+import useChatStore from "@/app/store/chatStore";
+import useViewContextStore from "@/app/store/viewContextStore";
+import { useDashboard } from "./dashboardQueries";
+
+/**
+ * The dashboard surface's chat greeting (Figma node 1317-4279), rendered in
+ * place of the map welcome message. Copy is deliberately generic — no
+ * dataset/AOI templating yet — and every chip maps to an action the
+ * experimental agent profile can actually take (generate_insights +
+ * add_to_dashboard, show_imagery + add_map_widget, inspect_view_context,
+ * search_blogs). The variant flips on widget count: an empty dashboard gets
+ * "start building" framing, a populated one "refine".
+ */
+const NUDGE_VARIANTS = {
+  build: {
+    heading: "Start building this dashboard",
+    body: "I can help you add analyses, maps, and context to this dashboard.",
+    chips: [
+      "Analyse recent tree cover loss in this area and add it to the dashboard",
+      "Add a satellite imagery map of this area",
+      "What's driving recent forest loss in this area?",
+    ],
+  },
+  refine: {
+    heading: "Refine this dashboard",
+    body: "I can help you add new analyses, maps, or context to make this dashboard more useful.",
+    chips: [
+      "Summarize what this dashboard shows",
+      "Analyse land cover change in this area and add it to the dashboard",
+      "Add a satellite imagery map of this area",
+    ],
+  },
+} as const;
+
+interface DashboardChatNudgesProps {
+  /**
+   * Chips belong to the naked (pre-first-prompt) state only; the greeting
+   * itself persists as the conversation's first block, like the map welcome.
+   */
+  showChips: boolean;
+}
+
+export default function DashboardChatNudges({
+  showChips,
+}: DashboardChatNudgesProps) {
+  const viewContext = useViewContextStore((s) => s.viewContext);
+  const dashboardId =
+    viewContext?.page === "dashboard" ? viewContext.dashboard_id : "";
+  const { data: dashboard } = useDashboard(dashboardId);
+  const sendMessage = useChatStore((s) => s.sendMessage);
+
+  // The detail page's own useDashboard call keeps this cache warm; until it
+  // resolves neither variant is right, so render nothing rather than flash.
+  if (!dashboard) return null;
+
+  const variant =
+    dashboard.widgets.length === 0
+      ? NUDGE_VARIANTS.build
+      : NUDGE_VARIANTS.refine;
+
+  return (
+    <Flex direction="column" gap={4} mt={2} mb={2}>
+      <Box>
+        {/* blue/blue-70 per the Figma page shell, as elsewhere in the feature */}
+        <Heading
+          as="h2"
+          fontSize="md"
+          fontWeight="medium"
+          color="#0049AA"
+          mb={2}
+        >
+          {variant.heading}
+        </Heading>
+        <Text fontSize="xs">{variant.body}</Text>
+      </Box>
+      {showChips && (
+        <Flex direction="column" gap={3}>
+          <Text fontSize="xs" color="fg.muted">
+            You might want to:
+          </Text>
+          <Flex direction="column" gap={2}>
+            {variant.chips.map((chip) => (
+              <Box
+                as="button"
+                key={chip}
+                px={3}
+                py={2}
+                rounded="lg"
+                border="1px solid"
+                borderColor="border.emphasized"
+                fontSize="xs"
+                textAlign="left"
+                bg="bg"
+                transition="all 0.24s ease"
+                _hover={{
+                  cursor: "pointer",
+                  bg: "bg.subtle",
+                  borderColor: "primary.solid",
+                }}
+                onClick={() => sendMessage(chip)}
+              >
+                {chip}
+              </Box>
+            ))}
+          </Flex>
+        </Flex>
+      )}
+    </Flex>
+  );
+}

--- a/src/features/dashboards/ui/DashboardChatNudges.tsx
+++ b/src/features/dashboards/ui/DashboardChatNudges.tsx
@@ -100,9 +100,7 @@ export default function DashboardChatNudges({
                   cursor: "pointer",
                   bg: "bg.subtle",
                   borderColor: "primary.solid",
-                }}
-                onClick={() => sendMessage(chip)}
-              >
+                onClick={() => void sendMessage(chip)}
                 {chip}
               </Box>
             ))}

--- a/src/features/dashboards/ui/DashboardChatNudges.tsx
+++ b/src/features/dashboards/ui/DashboardChatNudges.tsx
@@ -100,7 +100,9 @@ export default function DashboardChatNudges({
                   cursor: "pointer",
                   bg: "bg.subtle",
                   borderColor: "primary.solid",
+                }}
                 onClick={() => void sendMessage(chip)}
+              >
                 {chip}
               </Box>
             ))}

--- a/src/features/dashboards/ui/__tests__/DashboardChatNudges.test.tsx
+++ b/src/features/dashboards/ui/__tests__/DashboardChatNudges.test.tsx
@@ -1,0 +1,140 @@
+// @vitest-environment happy-dom
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen } from "@testing-library/react";
+import type { ReactElement } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// The chatStore import chain reaches the Chakra toaster (.tsx) — stub it so the
+// test environment can parse the module boundary.
+vi.mock("@/app/components/ui/toaster", () => ({
+  toaster: { create: vi.fn() },
+  Toaster: () => null,
+}));
+
+// Keep the unseeded-cache path off the network: the query mounts and calls
+// getDashboard, which must hang (pending) rather than hit the API host.
+vi.mock("../../api/dashboards", async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  getDashboard: vi.fn(() => new Promise(() => {})),
+}));
+
+import DashboardChatNudges from "../DashboardChatNudges";
+import { dashboardKeys } from "../dashboardQueries";
+import type { Dashboard } from "../../api/schemas";
+import useChatStore from "@/app/store/chatStore";
+import useViewContextStore from "@/app/store/viewContextStore";
+
+const emptyDashboard: Dashboard = {
+  id: "d1",
+  user_id: "u1",
+  name: "Pará forest watch",
+  description: null,
+  is_public: false,
+  created_at: "2026-07-01T00:00:00Z",
+  updated_at: "2026-07-01T00:00:00Z",
+  aois: [],
+  widgets: [],
+};
+
+const populatedDashboard: Dashboard = {
+  ...emptyDashboard,
+  widgets: [
+    {
+      id: "w1",
+      position: 0,
+      widget_type: "insight",
+      insight_id: "i1",
+      config: {},
+      created_at: "2026-07-01T00:00:00Z",
+      insight: null,
+    },
+  ],
+};
+
+const sendSpy = vi.fn().mockResolvedValue({ isNew: true, id: "t1" });
+
+const renderWithDashboard = (ui: ReactElement, dashboard: Dashboard | null) => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  if (dashboard) {
+    queryClient.setQueryData(dashboardKeys.detail(dashboard.id), dashboard);
+  }
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <ChakraProvider value={defaultSystem}>{ui}</ChakraProvider>
+    </QueryClientProvider>
+  );
+};
+
+describe("DashboardChatNudges", () => {
+  beforeEach(() => {
+    sendSpy.mockClear();
+    useChatStore.setState({ sendMessage: sendSpy });
+    useViewContextStore
+      .getState()
+      .setViewContext({ page: "dashboard", dashboard_id: "d1" });
+  });
+
+  it("shows the build variant for an empty dashboard", () => {
+    renderWithDashboard(<DashboardChatNudges showChips />, emptyDashboard);
+
+    expect(screen.getByText("Start building this dashboard")).toBeTruthy();
+    expect(screen.getByText("You might want to:")).toBeTruthy();
+    expect(
+      screen.getByRole("button", {
+        name: /Add a satellite imagery map of this area/i,
+      })
+    ).toBeTruthy();
+  });
+
+  it("shows the refine variant once the dashboard has widgets", () => {
+    renderWithDashboard(<DashboardChatNudges showChips />, populatedDashboard);
+
+    expect(screen.getByText("Refine this dashboard")).toBeTruthy();
+    expect(
+      screen.getByRole("button", {
+        name: /Summarize what this dashboard shows/i,
+      })
+    ).toBeTruthy();
+  });
+
+  it("sends the chip text as a chat message on click", () => {
+    renderWithDashboard(<DashboardChatNudges showChips />, emptyDashboard);
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: /Add a satellite imagery map of this area/i,
+      })
+    );
+
+    expect(sendSpy).toHaveBeenCalledWith(
+      "Add a satellite imagery map of this area"
+    );
+  });
+
+  it("keeps the greeting but hides the chips once a prompt was sent", () => {
+    renderWithDashboard(
+      <DashboardChatNudges showChips={false} />,
+      emptyDashboard
+    );
+
+    expect(screen.getByText("Start building this dashboard")).toBeTruthy();
+    expect(screen.queryByText("You might want to:")).toBeNull();
+    expect(screen.queryByRole("button")).toBeNull();
+  });
+
+  it("renders nothing until the dashboard resolves", () => {
+    useViewContextStore
+      .getState()
+      .setViewContext({ page: "dashboard", dashboard_id: "d-missing" });
+
+    const { container } = renderWithDashboard(
+      <DashboardChatNudges showChips />,
+      null
+    );
+
+    expect(container.textContent).toBe("");
+  });
+});


### PR DESCRIPTION
Adds an initial state to new conversations in Dashboards, including nudges that surface dashboard capabilities.


TODO
- [x] Start new convo from dashboards
- [x] Open old conversations from dashboards
- [x] define behaviour when moving between map <> dashboard

NOTE: we may need to make a decision on routing: how do we carry conversation thread_ids in the url across app and dashboard pages.

1. We should probably rename existing routes:
  a. `/app` --> `/map`
  b. `/dashboard` --> `/setting` (or profile or similar)
2. Decide on convention for conversation thread_id:
  a. Page `/map/threads/conversation_id` and `/dashboards/dashboard_id/threads/conversation_id`
  b. Arg `/map?thread=conversation_id` and `/dashboards/dashboard_id?thread=conversation_id`
  
For now, this branch defers this decision.