### PR TITLE
Dashboard map widgets

### DIFF
--- a/app/components/legend/LayerEntry.tsx
+++ b/app/components/legend/LayerEntry.tsx
@@ -36,6 +36,8 @@ export function LayerEntry(
     onLayerAction: LayerActionHandler;
     expanded?: boolean;
     onToggleExpand?: () => void;
+    /** Tighter type and spacing for small hosts (dashboard map widgets). */
+    compact?: boolean;
   }
 ) {
   const {
@@ -52,6 +54,7 @@ export function LayerEntry(
     info,
     expanded = false,
     onToggleExpand,
+    compact,
   } = props;
 
   return (
@@ -88,7 +91,7 @@ export function LayerEntry(
           >
             <CaretDownIcon size={12} />
           </IconButton>
-          <Heading as="h3" size="sm" m={0} truncate>
+          <Heading as="h3" size={compact ? "xs" : "sm"} m={0} truncate>
             {title}
           </Heading>
         </Flex>
@@ -99,8 +102,8 @@ export function LayerEntry(
           flexShrink={0}
           css={{
             "& button": {
-              h: 6,
-              minW: 6,
+              h: compact ? 5 : 6,
+              minW: compact ? 5 : 6,
             },
           }}
         >
@@ -156,7 +159,12 @@ export function LayerEntry(
       {/* Collapsible body — symbology → params → within → notes */}
       <Collapsible.Root open={expanded}>
         <Collapsible.Content css={{ transition: "height 0.15s ease" }}>
-          <Flex flexDir="column" gap={2} pt={2} pr={4}>
+          <Flex
+            flexDir="column"
+            gap={compact ? 1.5 : 2}
+            pt={compact ? 1.5 : 2}
+            pr={compact ? 2 : 4}
+          >
             {symbology}
             {params && params.length > 0 && (
               <Flex gap={1} flexWrap="wrap" alignItems="center">

--- a/app/components/legend/Legend.tsx
+++ b/app/components/legend/Legend.tsx
@@ -31,6 +31,8 @@ interface LegendProps {
   onLayerAction?: LayerActionHandler;
   aois?: LegendAoi[];
   onRemoveAoi?: (layerId: string) => void;
+  /** Tighter type and spacing for small hosts (dashboard map widgets). */
+  compact?: boolean;
 }
 
 /**
@@ -40,7 +42,7 @@ interface LegendProps {
  * @param props.layers - Array of LegendLayer objects to display.
  */
 export function Legend(props: LegendProps) {
-  const { layers, onLayerAction, aois, onRemoveAoi } = props;
+  const { layers, onLayerAction, aois, onRemoveAoi, compact } = props;
 
   // Controls whether the whole legend body is collapsed to just the header.
   const [isCollapsed, setIsCollapsed] = useState(false);
@@ -114,7 +116,7 @@ export function Legend(props: LegendProps) {
       {/* Always-visible header — 28px section header per Figma */}
       <Flex
         h="28px"
-        px="16px"
+        px={compact ? "12px" : "16px"}
         py="6px"
         gap="8px"
         alignItems="center"
@@ -173,12 +175,13 @@ export function Legend(props: LegendProps) {
               m={0}
               w="100%"
               overflowY="auto"
-              maxH="200px"
+              maxH={compact ? "160px" : "200px"}
             >
               {layers.map((item) => (
                 <Item
                   key={item.id}
                   item={item}
+                  compact={compact}
                   expanded={expandedIds.has(item.id)}
                   onToggleExpand={() =>
                     setExpandedIds((prev) => {
@@ -239,8 +242,9 @@ function Item(props: {
   expanded: boolean;
   onToggleExpand: () => void;
   onLayerAction: LayerActionHandler;
+  compact?: boolean;
 }) {
-  const { item, expanded, onToggleExpand, onLayerAction } = props;
+  const { item, expanded, onToggleExpand, onLayerAction, compact } = props;
   const dragControls = useDragControls();
 
   return (
@@ -249,7 +253,7 @@ function Item(props: {
       id={item}
       dragListener={false}
       dragControls={dragControls}
-      p={2}
+      p={compact ? 1.5 : 2}
       pl={1}
       display="flex"
       gap={1}
@@ -272,6 +276,7 @@ function Item(props: {
       </IconButton>
       <LayerEntry
         {...item}
+        compact={compact}
         expanded={expanded}
         onToggleExpand={onToggleExpand}
         onLayerAction={onLayerAction}

--- a/app/components/legend/useLegendHook.tsx
+++ b/app/components/legend/useLegendHook.tsx
@@ -35,8 +35,10 @@ const PARAMETER_FORMATTERS: Record<string, (v: unknown) => string> = {
 /**
  * Converts a layer's raw parameters object into structured LegendParam chips.
  * Each entry becomes a { label, value } pair rendered as a badge in the card.
+ * Exported for the dashboard map-widget legend, which builds its entries from
+ * widget configs instead of mapStore layers.
  */
-function buildParams(
+export function buildParams(
   params: Record<string, unknown>,
   yearParam?: YearParam
 ): LegendParam[] {
@@ -56,7 +58,7 @@ function buildParams(
   return result;
 }
 
-function renderLegendSymbology(legend: DatasetLegendConfig) {
+export function renderLegendSymbology(legend: DatasetLegendConfig) {
   const { type, items, color, unit } = legend;
 
   return type === "categorical" && items ? (

--- a/app/components/map/layers/GeoJsonLayers.tsx
+++ b/app/components/map/layers/GeoJsonLayers.tsx
@@ -12,7 +12,12 @@ import {
 import { BasemapTheme } from "../BasemapSelector";
 import bbox from "@turf/bbox";
 import { createBboxPolygon, unionAoiBboxes } from "@/app/utils/bboxUtils";
-import { aoiBoundaryColors, aoiCasingPaint, aoiLinePaint } from "./aoiStyle";
+import {
+  aoiBboxLinePaint,
+  aoiBoundaryColors,
+  aoiCasingPaint,
+  aoiLinePaint,
+} from "./aoiStyle";
 
 // Compute the combined bbox of a list of features
 function computeCombinedBbox(
@@ -223,11 +228,7 @@ function GeoJsonLayerGroup({
           <MapLayer
             id={`bbox-line-${groupId}-solid`}
             type="line"
-            paint={{
-              "line-color": mainLineColor,
-              "line-width": 1.5,
-              "line-opacity": 0.75 * lineOpacity,
-            }}
+            paint={aoiBboxLinePaint(mainLineColor, lineOpacity)}
           />
         </Source>
       )}

--- a/app/components/map/layers/GeoJsonLayers.tsx
+++ b/app/components/map/layers/GeoJsonLayers.tsx
@@ -12,6 +12,7 @@ import {
 import { BasemapTheme } from "../BasemapSelector";
 import bbox from "@turf/bbox";
 import { createBboxPolygon, unionAoiBboxes } from "@/app/utils/bboxUtils";
+import { aoiBoundaryColors, aoiCasingPaint, aoiLinePaint } from "./aoiStyle";
 
 // Compute the combined bbox of a list of features
 function computeCombinedBbox(
@@ -129,11 +130,10 @@ function GeoJsonLayerGroup({
 
   const isMultiArea = !!layer.selectionName;
 
-  // On dark basemaps (dark, satellite) boundaries use white lines + blue casing
-  // to maximise contrast. On light basemaps the colours are inverted.
-  const casingColor = basemapTheme === "dark" ? "#172B7A" : "#FFFFFF";
-  const mainLineColor =
-    basemapTheme === "dark" ? "#FFFFFF" : isMultiArea ? "#8EA4E8" : "#172B7A";
+  const { casingColor, mainLineColor } = aoiBoundaryColors(
+    basemapTheme,
+    isMultiArea
+  );
 
   const handleRemove = () => removeLayer(layer.id);
   // Prefer backend-provided bbox (handles antimeridian); fall back to turf.
@@ -180,21 +180,7 @@ function GeoJsonLayerGroup({
             <MapLayer
               id={casingLayerId}
               type="line"
-              paint={{
-                "line-color": casingColor,
-                "line-width": [
-                  "interpolate",
-                  ["linear"],
-                  ["zoom"],
-                  3,
-                  3.5,
-                  6,
-                  7,
-                  10,
-                  11,
-                ],
-                "line-opacity": lineOpacity,
-              }}
+              paint={aoiCasingPaint(casingColor, lineOpacity)}
               filter={[
                 "any",
                 ["==", ["geometry-type"], "Polygon"],
@@ -204,21 +190,7 @@ function GeoJsonLayerGroup({
             <MapLayer
               id={lineLayerId}
               type="line"
-              paint={{
-                "line-color": mainLineColor,
-                "line-width": [
-                  "interpolate",
-                  ["linear"],
-                  ["zoom"],
-                  3,
-                  1,
-                  6,
-                  1.5,
-                  10,
-                  2,
-                ],
-                "line-opacity": lineOpacity,
-              }}
+              paint={aoiLinePaint(mainLineColor, lineOpacity)}
               filter={[
                 "any",
                 ["==", ["geometry-type"], "Polygon"],

--- a/app/components/map/layers/aoiStyle.ts
+++ b/app/components/map/layers/aoiStyle.ts
@@ -1,0 +1,39 @@
+import type { LineLayerSpecification } from "maplibre-gl";
+
+import type { BasemapTheme } from "../BasemapSelector";
+
+type LinePaint = NonNullable<LineLayerSpecification["paint"]>;
+
+/**
+ * AOI boundary styling shared by the explorer map (GeoJsonLayers) and the
+ * dashboard map widgets: a wide contrasting casing rendered beneath the main
+ * line, both with zoom-interpolated widths.
+ */
+
+// On dark basemaps (dark, satellite) boundaries use white lines + blue casing
+// to maximise contrast. On light basemaps the colours are inverted.
+export function aoiBoundaryColors(
+  basemapTheme: BasemapTheme,
+  isMultiArea = false
+) {
+  const casingColor = basemapTheme === "dark" ? "#172B7A" : "#FFFFFF";
+  const mainLineColor =
+    basemapTheme === "dark" ? "#FFFFFF" : isMultiArea ? "#8EA4E8" : "#172B7A";
+  return { casingColor, mainLineColor };
+}
+
+export function aoiCasingPaint(color: string, opacity = 1): LinePaint {
+  return {
+    "line-color": color,
+    "line-width": ["interpolate", ["linear"], ["zoom"], 3, 3.5, 6, 7, 10, 11],
+    "line-opacity": opacity,
+  };
+}
+
+export function aoiLinePaint(color: string, opacity = 1): LinePaint {
+  return {
+    "line-color": color,
+    "line-width": ["interpolate", ["linear"], ["zoom"], 3, 1, 6, 1.5, 10, 2],
+    "line-opacity": opacity,
+  };
+}

--- a/app/components/map/layers/aoiStyle.ts
+++ b/app/components/map/layers/aoiStyle.ts
@@ -37,3 +37,12 @@ export function aoiLinePaint(color: string, opacity = 1): LinePaint {
     "line-opacity": opacity,
   };
 }
+
+/** The solid rectangle drawn around an AOI's bounding box. */
+export function aoiBboxLinePaint(color: string, opacity = 1): LinePaint {
+  return {
+    "line-color": color,
+    "line-width": 1.5,
+    "line-opacity": 0.75 * opacity,
+  };
+}

--- a/src/features/dashboards/lib/__tests__/mapWidgets.test.ts
+++ b/src/features/dashboards/lib/__tests__/mapWidgets.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it } from "vitest";
+
+import { mapWidgetLayer, mapWidgetViewportBbox } from "../mapWidgets";
+
+const datasetConfig = (overrides: Record<string, unknown> = {}) => ({
+  default_view: "map",
+  dataset: {
+    dataset_id: 4,
+    dataset_name: "Tree cover loss",
+    tile_url: "https://tiles.example.org/tcl/{z}/{x}/{y}.png?tcd=30",
+    context_layer: null,
+    context_layers: [],
+    ...overrides,
+  },
+});
+
+describe("mapWidgetLayer — dataset configs", () => {
+  it("parses a dataset config into a renderable layer", () => {
+    const layer = mapWidgetLayer(datasetConfig());
+    expect(layer).toEqual({
+      kind: "dataset",
+      title: "Tree cover loss",
+      tileUrl: "https://tiles.example.org/tcl/{z}/{x}/{y}.png?tcd=30",
+    });
+  });
+
+  it("prefers the config.title override for the card header", () => {
+    const layer = mapWidgetLayer({
+      ...datasetConfig(),
+      title: "Loss over Paraná",
+    });
+    expect(layer?.title).toBe("Loss over Paraná");
+  });
+
+  it("resolves the active context layer's tiles by name", () => {
+    const layer = mapWidgetLayer(
+      datasetConfig({
+        context_layer: "driver",
+        context_layers: [
+          { name: "other", tile_url: "https://tiles.example.org/other" },
+          { name: "driver", tile_url: "https://tiles.example.org/driver" },
+        ],
+      })
+    );
+    expect(layer?.contextTileUrl).toBe("https://tiles.example.org/driver");
+  });
+
+  it("omits the context layer when the active name has no entry", () => {
+    const layer = mapWidgetLayer(
+      datasetConfig({ context_layer: "driver", context_layers: [] })
+    );
+    expect(layer?.contextTileUrl).toBeUndefined();
+  });
+
+  it("routes primary-forest tiles through the pf:// protocol", () => {
+    const layer = mapWidgetLayer(
+      datasetConfig({
+        tile_url:
+          "https://tiles.example.org/umd_regional_primary_forest/{z}/{x}/{y}.png",
+      })
+    );
+    expect(layer?.tileUrl).toMatch(/^pf:\/\//);
+  });
+
+  it("returns null when the dataset has no tile_url", () => {
+    expect(mapWidgetLayer(datasetConfig({ tile_url: "" }))).toBeNull();
+  });
+});
+
+describe("mapWidgetLayer — imagery configs", () => {
+  it("parses an imagery config with a date-stamped fallback title", () => {
+    const layer = mapWidgetLayer({
+      imagery: {
+        tile_url: "https://tiles.example.org/mosaic/{z}/{x}/{y}.png?url=abc",
+        target_date: "2024-06-01",
+      },
+    });
+    expect(layer).toEqual({
+      kind: "imagery",
+      title: "Sentinel-2 imagery, 2024-06-01",
+      tileUrl: "https://tiles.example.org/mosaic/{z}/{x}/{y}.png?url=abc",
+    });
+  });
+
+  it("falls back to a generic title without a target_date", () => {
+    const layer = mapWidgetLayer({
+      imagery: { tile_url: "https://tiles.example.org/mosaic" },
+    });
+    expect(layer?.title).toBe("Sentinel-2 imagery");
+  });
+
+  it("returns null when neither dataset nor imagery is present", () => {
+    expect(mapWidgetLayer({ default_view: "map" })).toBeNull();
+  });
+});
+
+describe("mapWidgetViewportBbox", () => {
+  it("returns the override bbox when well-formed", () => {
+    expect(
+      mapWidgetViewportBbox({ viewport: { bbox: [-54, -27, -48, -22] } })
+    ).toEqual([-54, -27, -48, -22]);
+  });
+
+  it("returns null for absent or malformed viewports", () => {
+    expect(mapWidgetViewportBbox({})).toBeNull();
+    expect(mapWidgetViewportBbox({ viewport: { zoom: 4 } })).toBeNull();
+    expect(
+      mapWidgetViewportBbox({ viewport: { bbox: [-54, -27, -48] } })
+    ).toBeNull();
+    expect(
+      mapWidgetViewportBbox({ viewport: { bbox: [-54, -27, -48, "x"] } })
+    ).toBeNull();
+  });
+});

--- a/src/features/dashboards/lib/__tests__/mapWidgets.test.ts
+++ b/src/features/dashboards/lib/__tests__/mapWidgets.test.ts
@@ -21,6 +21,7 @@ describe("mapWidgetLayer — dataset configs", () => {
       kind: "dataset",
       title: "Tree cover loss",
       tileUrl: "https://tiles.example.org/tcl/{z}/{x}/{y}.png?tcd=30",
+      datasetId: 4,
     });
   });
 
@@ -43,6 +44,7 @@ describe("mapWidgetLayer — dataset configs", () => {
       })
     );
     expect(layer?.contextTileUrl).toBe("https://tiles.example.org/driver");
+    expect(layer?.contextLayerName).toBe("driver");
   });
 
   it("omits the context layer when the active name has no entry", () => {
@@ -50,6 +52,39 @@ describe("mapWidgetLayer — dataset configs", () => {
       datasetConfig({ context_layer: "driver", context_layers: [] })
     );
     expect(layer?.contextTileUrl).toBeUndefined();
+    expect(layer?.contextLayerName).toBeUndefined();
+  });
+
+  it("reduces config parameters to a first-value record for the legend", () => {
+    const layer = mapWidgetLayer(
+      datasetConfig({
+        parameters: [
+          { name: "canopy_cover", values: [30] },
+          { name: "empty", values: [] },
+          { name: 42, values: [1] },
+          "junk",
+        ],
+      })
+    );
+    expect(layer?.parameters).toEqual({ canopy_cover: 30 });
+  });
+
+  it("omits parameters when the config has none worth showing", () => {
+    expect(mapWidgetLayer(datasetConfig())?.parameters).toBeUndefined();
+    expect(
+      mapWidgetLayer(datasetConfig({ parameters: [] }))?.parameters
+    ).toBeUndefined();
+    expect(
+      mapWidgetLayer(datasetConfig({ parameters: null }))?.parameters
+    ).toBeUndefined();
+  });
+
+  it("carries the config's date range for the legend chip", () => {
+    const layer = mapWidgetLayer(
+      datasetConfig({ start_date: "2024-01-01", end_date: "2024-12-31" })
+    );
+    expect(layer?.startDate).toBe("2024-01-01");
+    expect(layer?.endDate).toBe("2024-12-31");
   });
 
   it("routes primary-forest tiles through the pf:// protocol", () => {

--- a/src/features/dashboards/lib/mapWidgets.ts
+++ b/src/features/dashboards/lib/mapWidgets.ts
@@ -13,10 +13,38 @@ export interface MapWidgetLayer {
   tileUrl: string;
   /** The active context sub-layer's tiles, rendered beneath the main layer. */
   contextTileUrl?: string;
+  /** The active context sub-layer's name — set only with `contextTileUrl`. */
+  contextLayerName?: string;
+  // Dataset-kind fields that drive the widget's legend (DashboardMapLegend).
+  datasetId?: number;
+  /** Display parameters as a record, e.g. `{ canopy_cover: 30 }`. */
+  parameters?: Record<string, unknown>;
+  startDate?: string;
+  endDate?: string;
 }
 
 const str = (value: unknown): string | undefined =>
   typeof value === "string" && value.trim() ? value : undefined;
+
+// Config parameters are `[{ name, values }]` (per the handoff); the legend
+// wants a `{ name: firstValue }` record — same reduction the explorer's
+// getDatasetLayerContextProps applies to DatasetInfo.parameters.
+function parametersRecord(
+  parameters: unknown
+): Record<string, unknown> | undefined {
+  if (!Array.isArray(parameters)) return undefined;
+  const entries = parameters
+    .filter(
+      (p): p is { name: string; values: unknown[] } =>
+        !!p &&
+        typeof p === "object" &&
+        typeof (p as { name?: unknown }).name === "string" &&
+        Array.isArray((p as { values?: unknown }).values) &&
+        (p as { values: unknown[] }).values.length > 0
+    )
+    .map((p) => [p.name, p.values[0]] as const);
+  return entries.length > 0 ? Object.fromEntries(entries) : undefined;
+}
 
 // Primary forest tiles ship black-background PNGs; the pf:// protocol
 // rewrites black to alpha (same patch the explorer applies).
@@ -46,6 +74,7 @@ export function mapWidgetLayer(
     // Resolve the active context layer by name. Raster-only: vector (MVT)
     // context layers need a source_layer the persisted config doesn't carry.
     let contextTileUrl: string | undefined;
+    let contextLayerName: string | undefined;
     const activeName = str(d.context_layer);
     if (activeName && Array.isArray(d.context_layers)) {
       const entry = d.context_layers.find(
@@ -55,14 +84,25 @@ export function mapWidgetLayer(
           (l as { name?: unknown }).name === activeName
       );
       const entryUrl = str(entry?.tile_url);
-      if (entryUrl) contextTileUrl = patchPrimaryForest(entryUrl);
+      if (entryUrl) {
+        contextTileUrl = patchPrimaryForest(entryUrl);
+        contextLayerName = activeName;
+      }
     }
+
+    const parameters = parametersRecord(d.parameters);
+    const startDate = str(d.start_date);
+    const endDate = str(d.end_date);
 
     return {
       kind: "dataset",
       title: titleOverride ?? str(d.dataset_name) ?? "Map layer",
       tileUrl: patchPrimaryForest(tileUrl),
-      ...(contextTileUrl ? { contextTileUrl } : {}),
+      ...(contextTileUrl ? { contextTileUrl, contextLayerName } : {}),
+      ...(typeof d.dataset_id === "number" ? { datasetId: d.dataset_id } : {}),
+      ...(parameters ? { parameters } : {}),
+      ...(startDate ? { startDate } : {}),
+      ...(endDate ? { endDate } : {}),
     };
   }
 

--- a/src/features/dashboards/lib/mapWidgets.ts
+++ b/src/features/dashboards/lib/mapWidgets.ts
@@ -1,0 +1,108 @@
+import { wrapPrimaryForestTileUrl } from "@/app/utils/primaryForestTileProtocol";
+
+/**
+ * A renderable map-widget layer parsed from a `widget_type: "map"` config
+ * (dashboards-map-widgets-handoff.md). Configs are self-contained snapshots:
+ * exactly one of `config.dataset` / `config.imagery`, each carrying a fully
+ * resolved `tile_url` to render directly — no catalog lookup.
+ */
+export interface MapWidgetLayer {
+  kind: "dataset" | "imagery";
+  /** Card header: `config.title` override, else a kind-specific fallback. */
+  title: string;
+  tileUrl: string;
+  /** The active context sub-layer's tiles, rendered beneath the main layer. */
+  contextTileUrl?: string;
+}
+
+const str = (value: unknown): string | undefined =>
+  typeof value === "string" && value.trim() ? value : undefined;
+
+// Primary forest tiles ship black-background PNGs; the pf:// protocol
+// rewrites black to alpha (same patch the explorer applies).
+function patchPrimaryForest(url: string): string {
+  return url.includes("umd_regional_primary_forest")
+    ? wrapPrimaryForestTileUrl(url)
+    : url;
+}
+
+/**
+ * Parses a map widget's config into a renderable layer, or null when there is
+ * nothing to render (no dataset/imagery sub-object, or no tile_url — the
+ * caller shows a placeholder). The backend validates these on create, so null
+ * here means a malformed or future config shape.
+ */
+export function mapWidgetLayer(
+  config: Record<string, unknown>
+): MapWidgetLayer | null {
+  const titleOverride = str(config.title);
+
+  const dataset = config.dataset;
+  if (dataset && typeof dataset === "object") {
+    const d = dataset as Record<string, unknown>;
+    const tileUrl = str(d.tile_url);
+    if (!tileUrl) return null;
+
+    // Resolve the active context layer by name. Raster-only: vector (MVT)
+    // context layers need a source_layer the persisted config doesn't carry.
+    let contextTileUrl: string | undefined;
+    const activeName = str(d.context_layer);
+    if (activeName && Array.isArray(d.context_layers)) {
+      const entry = d.context_layers.find(
+        (l): l is Record<string, unknown> =>
+          !!l &&
+          typeof l === "object" &&
+          (l as { name?: unknown }).name === activeName
+      );
+      const entryUrl = str(entry?.tile_url);
+      if (entryUrl) contextTileUrl = patchPrimaryForest(entryUrl);
+    }
+
+    return {
+      kind: "dataset",
+      title: titleOverride ?? str(d.dataset_name) ?? "Map layer",
+      tileUrl: patchPrimaryForest(tileUrl),
+      ...(contextTileUrl ? { contextTileUrl } : {}),
+    };
+  }
+
+  const imagery = config.imagery;
+  if (imagery && typeof imagery === "object") {
+    const im = imagery as Record<string, unknown>;
+    const tileUrl = str(im.tile_url);
+    if (!tileUrl) return null;
+    const targetDate = str(im.target_date);
+    return {
+      kind: "imagery",
+      title:
+        titleOverride ??
+        (targetDate
+          ? `Sentinel-2 imagery, ${targetDate}`
+          : "Sentinel-2 imagery"),
+      tileUrl,
+    };
+  }
+
+  return null;
+}
+
+/**
+ * The reserved `config.viewport` manual override — the backend never writes
+ * it, but per the handoff it wins over the AOI fit when present. Only a
+ * `bbox: [west, south, east, north]` shape is honoured.
+ */
+export function mapWidgetViewportBbox(
+  config: Record<string, unknown>
+): [number, number, number, number] | null {
+  const viewport = config.viewport;
+  if (!viewport || typeof viewport !== "object") return null;
+  const bbox = (viewport as { bbox?: unknown }).bbox;
+  if (
+    Array.isArray(bbox) &&
+    bbox.length === 4 &&
+    bbox.every((n) => typeof n === "number" && Number.isFinite(n))
+  ) {
+    return bbox as [number, number, number, number];
+  }
+  return null;
+}

--- a/src/features/dashboards/ui/DashboardMapLegend.tsx
+++ b/src/features/dashboards/ui/DashboardMapLegend.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { Text } from "@chakra-ui/react";
+
+import { Legend } from "@/app/components/legend/Legend";
+import type {
+  LegendContextLayer,
+  LegendLayer,
+} from "@/app/components/legend/types";
+import {
+  buildParams,
+  renderLegendSymbology,
+} from "@/app/components/legend/useLegendHook";
+import {
+  CONTEXT_LAYER_METADATA,
+  DATASET_CARDS,
+} from "@/app/constants/datasets";
+import { buildYearParam } from "@/app/utils/formatYearRange";
+import type { MapWidgetLayer } from "../lib/mapWidgets";
+
+/** Per-sub-layer legend opacity, 0–100 (main dataset · context sub-layer). */
+export interface MapWidgetOpacity {
+  main: number;
+  context: number;
+}
+
+/**
+ * The explorer's Legend reused inside a dashboard map widget, built from the
+ * widget's config snapshot instead of mapStore layers. Dataset widgets only —
+ * imagery has no DATASET_CARDS entry — and no AOI chips (the dashboard's area
+ * is fixed, not removable). The layer itself isn't removable either (the
+ * card's ✕ removes the whole widget), so only opacity is actionable.
+ */
+export default function DashboardMapLegend({
+  layer,
+  opacity,
+  onOpacityChange,
+}: {
+  layer: MapWidgetLayer;
+  opacity: MapWidgetOpacity;
+  onOpacityChange: (target: keyof MapWidgetOpacity, value: number) => void;
+}) {
+  const card =
+    layer.datasetId != null
+      ? DATASET_CARDS.find((d) => d.dataset_id === layer.datasetId)
+      : undefined;
+  if (!card?.legend) return null;
+  const legend = card.legend;
+
+  // Same fallback the explorer applies (getDatasetLayerContextProps): configs
+  // without explicit parameters rendered with the card's default threshold.
+  const parameters =
+    layer.parameters ??
+    (typeof card.threshold === "number"
+      ? { canopy_cover: card.threshold }
+      : {});
+  const params = buildParams(
+    parameters,
+    buildYearParam(layer.startDate, layer.endDate)
+  );
+
+  let contextLayer: LegendContextLayer | undefined;
+  if (layer.contextTileUrl && layer.contextLayerName) {
+    const ctxLegend = CONTEXT_LAYER_METADATA[layer.contextLayerName]?.legend;
+    contextLayer = {
+      id: "context",
+      title: ctxLegend?.title ?? layer.contextLayerName,
+      color: ctxLegend?.items?.[0]?.color ?? ctxLegend?.color ?? "#888",
+      opacity: opacity.context,
+      info: ctxLegend?.info,
+    };
+  }
+
+  const entry: LegendLayer = {
+    id: "main",
+    title: legend.title,
+    opacity: opacity.main,
+    info: legend.info,
+    params: params.length > 0 ? params : undefined,
+    contextLayer,
+    symbology: renderLegendSymbology(legend),
+    children: legend.note ? (
+      <Text fontSize="xs">{legend.note}</Text>
+    ) : undefined,
+    hideRemoveControl: true,
+  };
+
+  return (
+    <Legend
+      layers={[entry]}
+      onLayerAction={({ action, payload }) => {
+        if (action === "opacity") {
+          onOpacityChange(
+            payload.id === "context" ? "context" : "main",
+            payload.opacity
+          );
+        }
+      }}
+    />
+  );
+}

--- a/src/features/dashboards/ui/DashboardMapLegend.tsx
+++ b/src/features/dashboards/ui/DashboardMapLegend.tsx
@@ -88,6 +88,7 @@ export default function DashboardMapLegend({
   return (
     <Legend
       layers={[entry]}
+      compact
       onLayerAction={({ action, payload }) => {
         if (action === "opacity") {
           onOpacityChange(

--- a/src/features/dashboards/ui/DashboardMapWidget.tsx
+++ b/src/features/dashboards/ui/DashboardMapWidget.tsx
@@ -10,6 +10,7 @@ import MapGl, {
   AttributionControl,
   Layer,
   Marker,
+  NavigationControl,
   Source,
   type MapRef,
 } from "react-map-gl/maplibre";
@@ -96,7 +97,11 @@ export default function DashboardMapWidget({
         [bounds[0], bounds[1]],
         [bounds[2], bounds[3]],
       ],
-      { padding: 24, duration: 0 }
+      {
+        // Extra top headroom: the area label chip hangs above the bbox corner.
+        padding: { top: 56, right: 32, bottom: 32, left: 32 },
+        duration: 0,
+      }
     );
   };
 
@@ -104,8 +109,27 @@ export default function DashboardMapWidget({
   // completes last (the effect covers late bounds, onLoad covers late maps).
   useEffect(fitToBounds, [bounds]);
 
+  // Re-centre the area whenever the card resizes (size toggle, grid reflow,
+  // window resize). The observer only sees the container; the latest fit
+  // callback rides in a ref so we never re-observe.
+  const containerRef = useRef<HTMLDivElement>(null);
+  const fitRef = useRef(fitToBounds);
+  fitRef.current = fitToBounds;
+
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+    const observer = new ResizeObserver(() => {
+      // Next frame, so MapLibre's own resize handling runs first.
+      requestAnimationFrame(() => fitRef.current());
+    });
+    observer.observe(container);
+    return () => observer.disconnect();
+  }, []);
+
   return (
     <Box
+      ref={containerRef}
       h={{ base: "280px", md: tall ? "520px" : "360px" }}
       rounded="md"
       overflow="hidden"
@@ -123,7 +147,9 @@ export default function DashboardMapWidget({
         dragRotate={false}
         attributionControl={false}
       >
-        {/* Bottom-left so the legend can occupy the design's bottom-right slot. */}
+        {/* Bottom-left so the legend can occupy the design's bottom-right
+            slot; the attribution stacks beneath the zoom buttons. */}
+        <NavigationControl position="bottom-left" showCompass={false} />
         <AttributionControl compact position="bottom-left" />
         <Source
           id="widget-basemap"

--- a/src/features/dashboards/ui/DashboardMapWidget.tsx
+++ b/src/features/dashboards/ui/DashboardMapWidget.tsx
@@ -12,6 +12,11 @@ import MapGl, {
   type MapRef,
 } from "react-map-gl/maplibre";
 
+import {
+  aoiBoundaryColors,
+  aoiCasingPaint,
+  aoiLinePaint,
+} from "@/app/components/map/layers/aoiStyle";
 import { buildBasemapTileUrl } from "@/app/utils/basemapTileUrl";
 import { fetchGeometry } from "@/app/utils/geometryClient";
 import { registerPrimaryForestProtocol } from "@/app/utils/primaryForestTileProtocol";
@@ -23,8 +28,8 @@ import DashboardMapLegend, {
 const MAPBOX_ACCESS_TOKEN = process.env.NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN;
 // The explorer's default light basemap style.
 const BASEMAP_STYLE = "devseed/cmazl5ws500bz01scaa27dqi4";
-// Boundary colour on light basemaps (matches the explorer's area layers).
-const OUTLINE_COLOR = "#172B7A";
+// The widget basemap is always light, and dashboards are single-area.
+const AOI_COLORS = aoiBoundaryColors("light");
 
 /**
  * The map body of a `widget_type: "map"` dashboard card. Self-contained per
@@ -157,10 +162,17 @@ export default function DashboardMapWidget({
         </Source>
         {geometry?.geometry && (
           <Source id="widget-aoi" type="geojson" data={geometry.geometry}>
+            {/* The explorer's boundary treatment: contrasting casing under
+                the main line (shared paints, zoom-interpolated widths). */}
+            <Layer
+              id="widget-aoi-casing"
+              type="line"
+              paint={aoiCasingPaint(AOI_COLORS.casingColor)}
+            />
             <Layer
               id="widget-aoi-line"
               type="line"
-              paint={{ "line-color": OUTLINE_COLOR, "line-width": 1.5 }}
+              paint={aoiLinePaint(AOI_COLORS.mainLineColor)}
             />
           </Source>
         )}

--- a/src/features/dashboards/ui/DashboardMapWidget.tsx
+++ b/src/features/dashboards/ui/DashboardMapWidget.tsx
@@ -1,0 +1,159 @@
+"use client";
+
+import "maplibre-gl/dist/maplibre-gl.css";
+import { useEffect, useMemo, useRef } from "react";
+import { Box } from "@chakra-ui/react";
+import { useQuery } from "@tanstack/react-query";
+import turfBbox from "@turf/bbox";
+import MapGl, {
+  AttributionControl,
+  Layer,
+  Source,
+  type MapRef,
+} from "react-map-gl/maplibre";
+
+import { buildBasemapTileUrl } from "@/app/utils/basemapTileUrl";
+import { fetchGeometry } from "@/app/utils/geometryClient";
+import { registerPrimaryForestProtocol } from "@/app/utils/primaryForestTileProtocol";
+import type { MapWidgetLayer } from "../lib/mapWidgets";
+
+const MAPBOX_ACCESS_TOKEN = process.env.NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN;
+// The explorer's default light basemap style.
+const BASEMAP_STYLE = "devseed/cmazl5ws500bz01scaa27dqi4";
+// Boundary colour on light basemaps (matches the explorer's area layers).
+const OUTLINE_COLOR = "#172B7A";
+
+/**
+ * The map body of a `widget_type: "map"` dashboard card. Self-contained per
+ * the handoff: renders the config's resolved `tile_url` directly (context
+ * sub-layer beneath it), outlines the dashboard's area, and fits the
+ * viewport to that area — or to the reserved `config.viewport` bbox
+ * override, which wins when present.
+ */
+export default function DashboardMapWidget({
+  layer,
+  aoi,
+  bboxOverride,
+  tall,
+}: {
+  layer: MapWidgetLayer;
+  /** The dashboard's (single) area — outline + default viewport fit. */
+  aoi: { source: string; src_id: string } | undefined;
+  bboxOverride: [number, number, number, number] | null;
+  /** Full-width cards get a taller map. */
+  tall?: boolean;
+}) {
+  const mapRef = useRef<MapRef>(null);
+
+  useEffect(() => {
+    // Idempotent; needed here because the dashboard page never mounts the
+    // main explorer map, which is the usual registration point.
+    registerPrimaryForestProtocol();
+  }, []);
+
+  // The area geometry — shared across the dashboard's map widgets via the
+  // query cache; geometries are immutable, so never refetch.
+  const { data: geometry } = useQuery({
+    queryKey: ["aoi-geometry", aoi?.source, aoi?.src_id],
+    queryFn: () => fetchGeometry(aoi!.source, aoi!.src_id),
+    enabled: !!aoi,
+    staleTime: Infinity,
+  });
+
+  const bounds = useMemo<[number, number, number, number] | null>(() => {
+    if (bboxOverride) return bboxOverride;
+    if (!geometry?.geometry) return null;
+    // Naive bbox — antimeridian-crossing areas get a wide box. Acceptable
+    // here: dashboard AOIs don't carry a backend bbox to prefer.
+    const [west, south, east, north] = turfBbox(geometry.geometry);
+    return [west, south, east, north];
+  }, [bboxOverride, geometry]);
+
+  const fitToBounds = () => {
+    if (!bounds || !mapRef.current) return;
+    mapRef.current.fitBounds(
+      [
+        [bounds[0], bounds[1]],
+        [bounds[2], bounds[3]],
+      ],
+      { padding: 24, duration: 0 }
+    );
+  };
+
+  // The map and the geometry load in either order — fit on whichever
+  // completes last (the effect covers late bounds, onLoad covers late maps).
+  useEffect(fitToBounds, [bounds]);
+
+  return (
+    <Box
+      h={{ base: "280px", md: tall ? "520px" : "360px" }}
+      rounded="md"
+      overflow="hidden"
+      borderWidth="1px"
+      borderColor="#DDE2F5"
+    >
+      <MapGl
+        ref={mapRef}
+        style={{ width: "100%", height: "100%" }}
+        initialViewState={{ longitude: 0, latitude: 0, zoom: 1 }}
+        onLoad={fitToBounds}
+        // No scroll-zoom: the widget sits in a scrolling page and must not
+        // trap the wheel. Pan/double-click zoom remain available.
+        scrollZoom={false}
+        dragRotate={false}
+        attributionControl={false}
+      >
+        <AttributionControl compact position="bottom-right" />
+        <Source
+          id="widget-basemap"
+          type="raster"
+          tiles={[
+            buildBasemapTileUrl(
+              BASEMAP_STYLE,
+              MAPBOX_ACCESS_TOKEN,
+              typeof window === "undefined" ? 1 : window.devicePixelRatio
+            ),
+          ]}
+        >
+          <Layer id="widget-basemap" type="raster" />
+        </Source>
+        {/* Declaration order is stacking order: context under main, outline on top. */}
+        {layer.contextTileUrl && (
+          <Source
+            id="widget-context"
+            type="raster"
+            tiles={[layer.contextTileUrl]}
+            tileSize={256}
+          >
+            <Layer
+              id="widget-context"
+              type="raster"
+              paint={{ "raster-opacity": 0.8 }}
+            />
+          </Source>
+        )}
+        <Source
+          id="widget-tiles"
+          type="raster"
+          tiles={[layer.tileUrl]}
+          tileSize={256}
+        >
+          <Layer
+            id="widget-tiles"
+            type="raster"
+            paint={{ "raster-opacity": 0.8 }}
+          />
+        </Source>
+        {geometry?.geometry && (
+          <Source id="widget-aoi" type="geojson" data={geometry.geometry}>
+            <Layer
+              id="widget-aoi-line"
+              type="line"
+              paint={{ "line-color": OUTLINE_COLOR, "line-width": 1.5 }}
+            />
+          </Source>
+        )}
+      </MapGl>
+    </Box>
+  );
+}

--- a/src/features/dashboards/ui/DashboardMapWidget.tsx
+++ b/src/features/dashboards/ui/DashboardMapWidget.tsx
@@ -2,22 +2,26 @@
 
 import "maplibre-gl/dist/maplibre-gl.css";
 import { useEffect, useMemo, useRef, useState } from "react";
-import { Box } from "@chakra-ui/react";
+import { Box, Tag } from "@chakra-ui/react";
+import { PolygonIcon } from "@phosphor-icons/react";
 import { useQuery } from "@tanstack/react-query";
 import turfBbox from "@turf/bbox";
 import MapGl, {
   AttributionControl,
   Layer,
+  Marker,
   Source,
   type MapRef,
 } from "react-map-gl/maplibre";
 
 import {
+  aoiBboxLinePaint,
   aoiBoundaryColors,
   aoiCasingPaint,
   aoiLinePaint,
 } from "@/app/components/map/layers/aoiStyle";
 import { buildBasemapTileUrl } from "@/app/utils/basemapTileUrl";
+import { createBboxPolygon } from "@/app/utils/bboxUtils";
 import { fetchGeometry } from "@/app/utils/geometryClient";
 import { registerPrimaryForestProtocol } from "@/app/utils/primaryForestTileProtocol";
 import type { MapWidgetLayer } from "../lib/mapWidgets";
@@ -45,8 +49,8 @@ export default function DashboardMapWidget({
   tall,
 }: {
   layer: MapWidgetLayer;
-  /** The dashboard's (single) area — outline + default viewport fit. */
-  aoi: { source: string; src_id: string } | undefined;
+  /** The dashboard's (single) area — outline, label + default viewport fit. */
+  aoi: { source: string; src_id: string; name: string } | undefined;
   bboxOverride: [number, number, number, number] | null;
   /** Full-width cards get a taller map. */
   tall?: boolean;
@@ -75,14 +79,15 @@ export default function DashboardMapWidget({
     staleTime: Infinity,
   });
 
-  const bounds = useMemo<[number, number, number, number] | null>(() => {
-    if (bboxOverride) return bboxOverride;
+  const aoiBbox = useMemo<[number, number, number, number] | null>(() => {
     if (!geometry?.geometry) return null;
     // Naive bbox — antimeridian-crossing areas get a wide box. Acceptable
     // here: dashboard AOIs don't carry a backend bbox to prefer.
     const [west, south, east, north] = turfBbox(geometry.geometry);
     return [west, south, east, north];
-  }, [bboxOverride, geometry]);
+  }, [geometry]);
+
+  const bounds = bboxOverride ?? aoiBbox;
 
   const fitToBounds = () => {
     if (!bounds || !mapRef.current) return;
@@ -175,6 +180,42 @@ export default function DashboardMapWidget({
               paint={aoiLinePaint(AOI_COLORS.mainLineColor)}
             />
           </Source>
+        )}
+        {aoiBbox && (
+          <Source
+            id="widget-aoi-bbox"
+            type="geojson"
+            data={createBboxPolygon(aoiBbox)}
+          >
+            <Layer
+              id="widget-aoi-bbox-line"
+              type="line"
+              paint={aoiBboxLinePaint(AOI_COLORS.mainLineColor)}
+            />
+          </Source>
+        )}
+        {/* Area label pinned to the bbox corner, as on the explorer map —
+            minus the close trigger: a dashboard's area is fixed. */}
+        {aoiBbox && aoi?.name && (
+          <Marker
+            longitude={aoiBbox[0]}
+            latitude={aoiBbox[3]}
+            anchor="bottom-left"
+          >
+            <Tag.Root
+              colorPalette="primary"
+              px={2}
+              py={1}
+              size="md"
+              variant="solid"
+              roundedBottom="none"
+            >
+              <Tag.StartElement>
+                <PolygonIcon />
+              </Tag.StartElement>
+              <Tag.Label fontWeight="medium">{aoi.name}</Tag.Label>
+            </Tag.Root>
+          </Marker>
         )}
         {/* Non-map children render as DOM overlays inside the map container
             (same pattern as the explorer's Map.tsx). */}

--- a/src/features/dashboards/ui/DashboardMapWidget.tsx
+++ b/src/features/dashboards/ui/DashboardMapWidget.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import "maplibre-gl/dist/maplibre-gl.css";
-import { useEffect, useMemo, useRef } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { Box } from "@chakra-ui/react";
 import { useQuery } from "@tanstack/react-query";
 import turfBbox from "@turf/bbox";
@@ -16,6 +16,9 @@ import { buildBasemapTileUrl } from "@/app/utils/basemapTileUrl";
 import { fetchGeometry } from "@/app/utils/geometryClient";
 import { registerPrimaryForestProtocol } from "@/app/utils/primaryForestTileProtocol";
 import type { MapWidgetLayer } from "../lib/mapWidgets";
+import DashboardMapLegend, {
+  type MapWidgetOpacity,
+} from "./DashboardMapLegend";
 
 const MAPBOX_ACCESS_TOKEN = process.env.NEXT_PUBLIC_MAPBOX_ACCESS_TOKEN;
 // The explorer's default light basemap style.
@@ -44,6 +47,13 @@ export default function DashboardMapWidget({
   tall?: boolean;
 }) {
   const mapRef = useRef<MapRef>(null);
+
+  // Legend-controlled raster opacity (0–100). 80 matches the explorer's
+  // default dataset opacity and the legend's default display value.
+  const [opacity, setOpacity] = useState<MapWidgetOpacity>({
+    main: 80,
+    context: 80,
+  });
 
   useEffect(() => {
     // Idempotent; needed here because the dashboard page never mounts the
@@ -103,7 +113,8 @@ export default function DashboardMapWidget({
         dragRotate={false}
         attributionControl={false}
       >
-        <AttributionControl compact position="bottom-right" />
+        {/* Bottom-left so the legend can occupy the design's bottom-right slot. */}
+        <AttributionControl compact position="bottom-left" />
         <Source
           id="widget-basemap"
           type="raster"
@@ -128,7 +139,7 @@ export default function DashboardMapWidget({
             <Layer
               id="widget-context"
               type="raster"
-              paint={{ "raster-opacity": 0.8 }}
+              paint={{ "raster-opacity": opacity.context / 100 }}
             />
           </Source>
         )}
@@ -141,7 +152,7 @@ export default function DashboardMapWidget({
           <Layer
             id="widget-tiles"
             type="raster"
-            paint={{ "raster-opacity": 0.8 }}
+            paint={{ "raster-opacity": opacity.main / 100 }}
           />
         </Source>
         {geometry?.geometry && (
@@ -153,6 +164,24 @@ export default function DashboardMapWidget({
             />
           </Source>
         )}
+        {/* Non-map children render as DOM overlays inside the map container
+            (same pattern as the explorer's Map.tsx). */}
+        <Box
+          position="absolute"
+          bottom="8px"
+          right="8px"
+          zIndex={1}
+          w="400px"
+          maxW="calc(100% - 16px)"
+        >
+          <DashboardMapLegend
+            layer={layer}
+            opacity={opacity}
+            onOpacityChange={(target, value) =>
+              setOpacity((prev) => ({ ...prev, [target]: value }))
+            }
+          />
+        </Box>
       </MapGl>
     </Box>
   );

--- a/src/features/dashboards/ui/DashboardMapWidget.tsx
+++ b/src/features/dashboards/ui/DashboardMapWidget.tsx
@@ -224,7 +224,7 @@ export default function DashboardMapWidget({
           bottom="8px"
           right="8px"
           zIndex={1}
-          w="400px"
+          w="300px"
           maxW="calc(100% - 16px)"
         >
           <DashboardMapLegend

--- a/src/features/dashboards/ui/DashboardWidgetCard.tsx
+++ b/src/features/dashboards/ui/DashboardWidgetCard.tsx
@@ -26,11 +26,14 @@ import AnalysisParametersToggle, {
 import { buildChips } from "@/app/components/widgets/analysis-params-utils";
 import { toaster } from "@/app/components/ui/toaster";
 import type { InsightWidget } from "@/app/types/chat";
+import type { MapWidgetLayer } from "../lib/mapWidgets";
+import DashboardMapWidget from "./DashboardMapWidget";
 
 /**
  * One dashboard card — the Figma "Analysis" container: a light-blue shell
  * with a header row (drag handle · insight title · owner actions), a
- * "Show params" row, and the white chart card (`WidgetMessage`) inside.
+ * "Show params" row, and the white chart card (`WidgetMessage`) — or the
+ * map body (`DashboardMapWidget`) for map widgets — inside.
  * A widget whose insight has several charts renders one of these per chart,
  * so `card` is a single insight card, not a list. Header actions still act
  * on the underlying widget (per the API: position/config/DELETE are
@@ -39,6 +42,9 @@ import type { InsightWidget } from "@/app/types/chat";
 export default function DashboardWidgetCard({
   title,
   card,
+  map,
+  aoi,
+  viewportBbox,
   placeholder,
   chartCount,
   isOwner,
@@ -49,8 +55,14 @@ export default function DashboardWidgetCard({
   onRemove,
 }: {
   title: string;
-  /** The insight card to render, or null for a placeholder cell. */
+  /** The insight card to render, or null for a map/placeholder cell. */
   card: InsightWidget | null;
+  /** The map layer to render for `widget_type: "map"` cells. */
+  map?: MapWidgetLayer | null;
+  /** The dashboard's area — outline + viewport fit for map cells. */
+  aoi?: { source: string; src_id: string };
+  /** Reserved `config.viewport` bbox override for map cells. */
+  viewportBbox?: [number, number, number, number] | null;
   /** Placeholder copy when `card` is null (unsupported type / hidden insight). */
   placeholder: string | null;
   /** How many cards the underlying widget renders in total (its chart count). */
@@ -189,6 +201,15 @@ export default function DashboardWidgetCard({
           <ChartBarIcon size={24} />
           <Text fontSize="sm">{placeholder}</Text>
         </Flex>
+      ) : map ? (
+        <Box px="8px" pb="8px" flex="1" minW={0}>
+          <DashboardMapWidget
+            layer={map}
+            aoi={aoi}
+            bboxOverride={viewportBbox ?? null}
+            tall={isDouble}
+          />
+        </Box>
       ) : (
         card && (
           <Box px="8px" pb="8px" flex="1" minW={0}>

--- a/src/features/dashboards/ui/DashboardWidgetCard.tsx
+++ b/src/features/dashboards/ui/DashboardWidgetCard.tsx
@@ -59,8 +59,8 @@ export default function DashboardWidgetCard({
   card: InsightWidget | null;
   /** The map layer to render for `widget_type: "map"` cells. */
   map?: MapWidgetLayer | null;
-  /** The dashboard's area — outline + viewport fit for map cells. */
-  aoi?: { source: string; src_id: string };
+  /** The dashboard's area — outline, label + viewport fit for map cells. */
+  aoi?: { source: string; src_id: string; name: string };
   /** Reserved `config.viewport` bbox override for map cells. */
   viewportBbox?: [number, number, number, number] | null;
   /** Placeholder copy when `card` is null (unsupported type / hidden insight). */

--- a/src/features/dashboards/ui/DashboardWidgetsGrid.tsx
+++ b/src/features/dashboards/ui/DashboardWidgetsGrid.tsx
@@ -15,6 +15,11 @@ import {
   withSize,
 } from "../lib/widgets";
 import {
+  mapWidgetLayer,
+  mapWidgetViewportBbox,
+  type MapWidgetLayer,
+} from "../lib/mapWidgets";
+import {
   useDeleteWidget,
   useReorderWidgets,
   useUpdateWidget,
@@ -23,13 +28,15 @@ import DashboardWidgetCard from "./DashboardWidgetCard";
 
 /**
  * One grid cell. A widget whose insight has several charts renders one cell
- * per chart (each its own card, per design); placeholder cells (unsupported
- * widget type, hidden insight) carry `card: null` and placeholder copy.
+ * per chart (each its own card, per design); map widgets render one cell
+ * with `map` set; placeholder cells (unsupported widget type, hidden
+ * insight, malformed map config) carry `card: null` and placeholder copy.
  */
 interface GridCell {
   key: string;
   widget: DashboardWidget;
   card: InsightWidget | null;
+  map: MapWidgetLayer | null;
   placeholder: string | null;
   chartCount: number;
 }
@@ -38,12 +45,26 @@ function cellsForWidget(
   widget: DashboardWidget,
   areaName: string | undefined
 ): GridCell[] {
+  if (widget.widget_type === "map") {
+    const map = mapWidgetLayer(widget.config);
+    return [
+      {
+        key: widget.id,
+        widget,
+        card: null,
+        map,
+        placeholder: map ? null : "This map widget can't be displayed.",
+        chartCount: 0,
+      },
+    ];
+  }
   if (widget.widget_type !== "insight") {
     return [
       {
         key: widget.id,
         widget,
         card: null,
+        map: null,
         placeholder: `This ${widget.widget_type} widget isn't supported here yet.`,
         chartCount: 0,
       },
@@ -56,6 +77,7 @@ function cellsForWidget(
         key: widget.id,
         widget,
         card: null,
+        map: null,
         placeholder: "This analysis is not available.",
         chartCount: 0,
       },
@@ -65,6 +87,7 @@ function cellsForWidget(
     key: `${widget.id}:${card.id}`,
     widget,
     card,
+    map: null,
     placeholder: null,
     chartCount: cards.length,
   }));
@@ -101,7 +124,8 @@ export default function DashboardWidgetsGrid({
     () => [...dashboard.widgets].sort((a, b) => a.position - b.position),
     [dashboard.widgets]
   );
-  const areaName = dashboard.aois[0]?.name;
+  const areaAoi = dashboard.aois[0];
+  const areaName = areaAoi?.name;
   const cells = useMemo(
     () => widgets.flatMap((widget) => cellsForWidget(widget, areaName)),
     [widgets, areaName]
@@ -141,6 +165,7 @@ export default function DashboardWidgetsGrid({
           : widgetSize(widget.config);
         const title =
           card?.title ??
+          cell.map?.title ??
           (typeof widget.config.title === "string" ? widget.config.title : "");
         return (
           <GridItem
@@ -167,6 +192,11 @@ export default function DashboardWidgetsGrid({
             <DashboardWidgetCard
               title={title}
               card={card}
+              map={cell.map}
+              aoi={areaAoi}
+              viewportBbox={
+                cell.map ? mapWidgetViewportBbox(widget.config) : null
+              }
               placeholder={cell.placeholder}
               chartCount={cell.chartCount}
               isOwner={isOwner}


### PR DESCRIPTION
Adds map widget(s) to dashboards. Covers both datasets and satellite imagery.
Changes the size of the legend component in this view and also tries to render the AOI within the viewport on resize

<img width="547" height="432" alt="Screenshot 2026-07-13 at 12 02 42" src="https://github.com/user-attachments/assets/013ce07b-35a5-4372-ae19-9dd6813b933e" />

TODO
- [x] Maps need legend
- [x] Maps need zoom controls
- [x] Use same AOI border styles as map page
