### PR TITLE
Dashboard cards: Figma restyle with rename/delete actions menu

### DIFF
--- a/src/features/dashboards/api/dashboards.ts
+++ b/src/features/dashboards/api/dashboards.ts
@@ -57,6 +57,18 @@ export async function renameDashboard(
   });
 }
 
+export async function deleteDashboard(dashboardId: string): Promise<void> {
+  // 204 No Content — bypass readJson, which would choke on the empty body.
+  const res = await apiFetch(`/api/dashboards/${dashboardId}`, {
+    method: "DELETE",
+  });
+  if (!res.ok) {
+    const error = new Error(`Failed to delete dashboard: ${res.statusText}`);
+    (error as Error & { status?: number }).status = res.status;
+    throw error;
+  }
+}
+
 export interface WidgetUpdate {
   position?: number;
   // Replaced whole by the backend (not merged) — always send the full config.

--- a/src/features/dashboards/ui/DashboardActionsMenu.tsx
+++ b/src/features/dashboards/ui/DashboardActionsMenu.tsx
@@ -93,18 +93,22 @@ export default function DashboardActionsMenu({
           </Menu.Content>
         </Menu.Positioner>
       </Menu.Root>
-      <DashboardRenameDialog
-        name={dashboard.name}
-        isOpen={renameOpen}
-        onOpenChange={setRenameOpen}
-        onRename={onRename}
-      />
-      <DashboardDeleteDialog
-        dashboardName={dashboard.name}
-        isOpen={deleteOpen}
-        onOpenChange={setDeleteOpen}
-        onConfirm={onDelete}
-      />
+      {renameOpen && (
+        <DashboardRenameDialog
+          name={dashboard.name}
+          isOpen={renameOpen}
+          onOpenChange={setRenameOpen}
+          onRename={onRename}
+        />
+      )}
+      {deleteOpen && (
+        <DashboardDeleteDialog
+          dashboardName={dashboard.name}
+          isOpen={deleteOpen}
+          onOpenChange={setDeleteOpen}
+          onConfirm={onDelete}
+        />
+      )}
     </>
   );
 }

--- a/src/features/dashboards/ui/DashboardActionsMenu.tsx
+++ b/src/features/dashboards/ui/DashboardActionsMenu.tsx
@@ -1,0 +1,229 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import {
+  Button,
+  Dialog,
+  IconButton,
+  Input,
+  Menu,
+  Portal,
+} from "@chakra-ui/react";
+import {
+  DotsThreeVerticalIcon,
+  PencilSimpleIcon,
+  TrashIcon,
+} from "@phosphor-icons/react";
+
+import { toaster } from "@/app/components/ui/toaster";
+import type { Dashboard } from "../api/schemas";
+import { useDeleteDashboard, useRenameDashboard } from "./dashboardQueries";
+
+export default function DashboardActionsMenu({
+  dashboard,
+}: {
+  dashboard: Dashboard;
+}) {
+  const [renameOpen, setRenameOpen] = useState(false);
+  const [deleteOpen, setDeleteOpen] = useState(false);
+  const renameDashboard = useRenameDashboard(dashboard.id);
+  const deleteDashboard = useDeleteDashboard();
+
+  const onRename = (name: string) => {
+    if (!name || name === dashboard.name) return;
+    renameDashboard.mutate(name, {
+      onError: () =>
+        toaster.create({
+          title: "Rename failed",
+          description:
+            "The dashboard name couldn't be saved. Please try again.",
+          type: "error",
+          duration: 4000,
+        }),
+    });
+  };
+
+  const onDelete = () => {
+    deleteDashboard.mutate(dashboard.id, {
+      onError: () =>
+        toaster.create({
+          title: "Delete failed",
+          description: "The dashboard couldn't be deleted. Please try again.",
+          type: "error",
+          duration: 4000,
+        }),
+    });
+  };
+
+  return (
+    <>
+      <Menu.Root positioning={{ strategy: "fixed", hideWhenDetached: true }}>
+        <Menu.Trigger asChild>
+          <IconButton
+            aria-label={`Dashboard actions for ${dashboard.name}`}
+            variant="ghost"
+            size="xs"
+            rounded="sm"
+            color="fg.muted"
+            bg="whiteAlpha.500"
+            _hover={{ bg: "blackAlpha.50" }}
+          >
+            <DotsThreeVerticalIcon size={16} weight="bold" />
+          </IconButton>
+        </Menu.Trigger>
+        <Menu.Positioner>
+          <Menu.Content>
+            <Menu.Item
+              value="rename dashboard"
+              color="fg.muted"
+              onSelect={() => setRenameOpen(true)}
+            >
+              <PencilSimpleIcon />
+              Rename
+            </Menu.Item>
+            <Menu.Item
+              value="delete dashboard"
+              color="fg.error"
+              _hover={{ bg: "bg.error", color: "fg.error" }}
+              onSelect={() => setDeleteOpen(true)}
+            >
+              <TrashIcon />
+              Delete
+            </Menu.Item>
+          </Menu.Content>
+        </Menu.Positioner>
+      </Menu.Root>
+      <DashboardRenameDialog
+        name={dashboard.name}
+        isOpen={renameOpen}
+        onOpenChange={setRenameOpen}
+        onRename={onRename}
+      />
+      <DashboardDeleteDialog
+        dashboardName={dashboard.name}
+        isOpen={deleteOpen}
+        onOpenChange={setDeleteOpen}
+        onConfirm={onDelete}
+      />
+    </>
+  );
+}
+
+function DashboardRenameDialog({
+  name,
+  isOpen,
+  onOpenChange,
+  onRename,
+}: {
+  name: string;
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+  onRename: (newName: string) => void;
+}) {
+  const ref = useRef<HTMLInputElement>(null);
+  const [draft, setDraft] = useState("");
+
+  useEffect(() => {
+    setDraft(name);
+  }, [name, isOpen]);
+
+  return (
+    <Dialog.Root
+      initialFocusEl={() => ref.current}
+      open={isOpen}
+      onOpenChange={({ open }) => onOpenChange(open)}
+    >
+      <Portal>
+        <Dialog.Backdrop />
+        <Dialog.Positioner>
+          <Dialog.Content
+            as="form"
+            onSubmit={(e) => {
+              e.preventDefault();
+              if (!draft.trim()) return;
+              onRename(draft.trim());
+              onOpenChange(false);
+            }}
+          >
+            <Dialog.Header>
+              <Dialog.Title>Rename dashboard</Dialog.Title>
+            </Dialog.Header>
+            <Dialog.Body pb="4">
+              <Input
+                ref={ref}
+                value={draft}
+                onChange={(e) => setDraft(e.target.value)}
+              />
+            </Dialog.Body>
+            <Dialog.Footer>
+              <Dialog.ActionTrigger asChild>
+                <Button variant="outline">Cancel</Button>
+              </Dialog.ActionTrigger>
+              <Button
+                colorPalette="blue"
+                disabled={!draft.trim()}
+                type="submit"
+              >
+                Save
+              </Button>
+            </Dialog.Footer>
+          </Dialog.Content>
+        </Dialog.Positioner>
+      </Portal>
+    </Dialog.Root>
+  );
+}
+
+function DashboardDeleteDialog({
+  dashboardName,
+  isOpen,
+  onOpenChange,
+  onConfirm,
+}: {
+  dashboardName: string;
+  isOpen: boolean;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: () => void;
+}) {
+  return (
+    <Dialog.Root
+      role="alertdialog"
+      open={isOpen}
+      onOpenChange={({ open }) => onOpenChange(open)}
+    >
+      <Portal>
+        <Dialog.Backdrop />
+        <Dialog.Positioner>
+          <Dialog.Content>
+            <Dialog.Header>
+              <Dialog.Title>Are you sure?</Dialog.Title>
+            </Dialog.Header>
+            <Dialog.Body>
+              <p>
+                This action cannot be undone. This will permanently delete the
+                dashboard <strong>{dashboardName}</strong> and its widgets.
+                Insights referenced by the dashboard are kept.
+              </p>
+            </Dialog.Body>
+            <Dialog.Footer>
+              <Dialog.ActionTrigger asChild>
+                <Button variant="outline">Cancel</Button>
+              </Dialog.ActionTrigger>
+              <Dialog.ActionTrigger asChild>
+                <Button
+                  colorPalette="red"
+                  onClick={() => {
+                    onOpenChange(false);
+                    onConfirm();
+                  }}
+                >
+                  Delete
+                </Button>
+              </Dialog.ActionTrigger>
+            </Dialog.Footer>
+          </Dialog.Content>
+        </Dialog.Positioner>
+      </Portal>
+    </Dialog.Root>
+  );
+}

--- a/src/features/dashboards/ui/DashboardActionsMenu.tsx
+++ b/src/features/dashboards/ui/DashboardActionsMenu.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useRef, useState } from "react";
 import {
   Button,
   Dialog,
@@ -121,11 +121,14 @@ function DashboardRenameDialog({
   onRename: (newName: string) => void;
 }) {
   const ref = useRef<HTMLInputElement>(null);
-  const [draft, setDraft] = useState("");
-
-  useEffect(() => {
-    setDraft(name);
-  }, [name, isOpen]);
+  const [draft, setDraft] = useState(name);
+  // Re-seed the draft from the current name each time the dialog opens
+  // (render-time derived state, not an effect, to avoid a cascading render).
+  const [prevOpen, setPrevOpen] = useState(isOpen);
+  if (prevOpen !== isOpen) {
+    setPrevOpen(isOpen);
+    if (isOpen) setDraft(name);
+  }
 
   return (
     <Dialog.Root

--- a/src/features/dashboards/ui/DashboardCard.tsx
+++ b/src/features/dashboards/ui/DashboardCard.tsx
@@ -2,72 +2,78 @@
 
 import Link from "next/link";
 import { Box, Flex, Heading, Link as ChakraLink, Text } from "@chakra-ui/react";
-import { MapPinIcon } from "@phosphor-icons/react";
+import { LockIcon, PolygonIcon } from "@phosphor-icons/react";
 
 import type { Dashboard } from "../api/schemas";
-import { sourceLabel } from "../lib/aoi";
 import { updatedLabel } from "../lib/dates";
+import DashboardActionsMenu from "./DashboardActionsMenu";
 
 export default function DashboardCard({ dashboard }: { dashboard: Dashboard }) {
   const primaryAoi = dashboard.aois[0];
-  const widgetCount = dashboard.widgets.length;
 
   return (
-    <ChakraLink
-      asChild
-      display="flex"
-      flexDir="column"
-      minH="180px"
-      bg="white"
-      borderWidth="1px"
-      borderColor="border"
-      borderTopWidth="2px"
-      borderTopColor="primary.solid"
-      borderRadius="sm"
-      overflow="hidden"
-      transition="border-color 0.16s ease, box-shadow 0.16s ease"
-      _hover={{
-        borderColor: "primary.solid",
-        boxShadow: "sm",
-        textDecor: "none",
-      }}
-      _focusVisible={{
-        outline: "2px solid",
-        outlineColor: "primary.focusRing",
-        outlineOffset: "2px",
-      }}
-    >
-      <Link href={`/dashboards/${dashboard.id}?ff=dashboard`}>
-        <Flex
-          flex="1"
-          direction="column"
-          justify="flex-end"
-          gap={3}
-          p={4}
-          pt={12}
-        >
-          {primaryAoi && (
-            <Flex align="center" gap={1.5} color="primary.solid" fontSize="xs">
-              <MapPinIcon size={14} />
-              <Text lineClamp={1}>{primaryAoi.name}</Text>
-            </Flex>
-          )}
-          <Box>
-            <Heading as="h2" size="sm" fontWeight="medium" lineClamp={2}>
+    <Box position="relative" display="flex" flexDir="column">
+      <ChakraLink
+        asChild
+        display="flex"
+        flexDir="column"
+        flex="1"
+        minH="308px"
+        bg="white"
+        borderWidth="1px"
+        borderColor="border"
+        borderTopWidth="2px"
+        borderTopColor="primary.solid"
+        borderRadius="sm"
+        overflow="hidden"
+        transition="border-color 0.16s ease, box-shadow 0.16s ease"
+        _hover={{
+          borderColor: "primary.solid",
+          boxShadow: "sm",
+          textDecor: "none",
+        }}
+        _focusVisible={{
+          outline: "2px solid",
+          outlineColor: "primary.focusRing",
+          outlineOffset: "2px",
+        }}
+      >
+        <Link href={`/dashboards/${dashboard.id}?ff=dashboard`}>
+          <Flex
+            flex="1"
+            direction="column"
+            justify="flex-end"
+            gap={2}
+            p={5}
+            pt={16}
+          >
+            {primaryAoi && (
+              <Flex align="center" gap={2} color="primary.solid" fontSize="xs">
+                <PolygonIcon size={16} />
+                <Text lineClamp={1}>{primaryAoi.name}</Text>
+              </Flex>
+            )}
+            <Heading
+              as="h2"
+              fontSize="lg"
+              fontWeight="normal"
+              lineHeight="1.4"
+              lineClamp={3}
+            >
               {dashboard.name}
             </Heading>
-            {primaryAoi && (
-              <Text color="fg.muted" fontSize="xs" mt={1} lineClamp={1}>
-                {sourceLabel(primaryAoi.source)}
-              </Text>
-            )}
-          </Box>
-          <Text color="fg.muted" fontSize="xs">
-            {updatedLabel(dashboard.updated_at)}
-            {widgetCount > 0 ? ` · ${widgetCount} widgets` : ""}
-          </Text>
-        </Flex>
-      </Link>
-    </ChakraLink>
+            <Flex align="center" gap={2} color="fg.muted" fontSize="xs">
+              {!dashboard.is_public && <LockIcon size={16} />}
+              <Text>{updatedLabel(dashboard.updated_at)}</Text>
+            </Flex>
+          </Flex>
+        </Link>
+      </ChakraLink>
+      {/* Sibling of the link, not a child — a button inside an anchor would
+          trigger navigation on menu clicks. */}
+      <Box position="absolute" top={5} right={5}>
+        <DashboardActionsMenu dashboard={dashboard} />
+      </Box>
+    </Box>
   );
 }

--- a/src/features/dashboards/ui/DashboardCard.tsx
+++ b/src/features/dashboards/ui/DashboardCard.tsx
@@ -7,6 +7,7 @@ import { LockIcon, PolygonIcon } from "@phosphor-icons/react";
 import type { Dashboard } from "../api/schemas";
 import { updatedLabel } from "../lib/dates";
 import DashboardActionsMenu from "./DashboardActionsMenu";
+import { HERO_GRID_IMAGE } from "./heroGrid";
 
 export default function DashboardCard({ dashboard }: { dashboard: Dashboard }) {
   const primaryAoi = dashboard.aois[0];
@@ -17,9 +18,14 @@ export default function DashboardCard({ dashboard }: { dashboard: Dashboard }) {
         asChild
         display="flex"
         flexDir="column"
+        // Chakra's Link defaults to align-items: center, which would centre
+        // the column content; the design is left-justified.
+        alignItems="stretch"
+        textAlign="left"
         flex="1"
         minH="308px"
         bg="white"
+        backgroundImage={HERO_GRID_IMAGE}
         borderWidth="1px"
         borderColor="border"
         borderTopWidth="2px"

--- a/src/features/dashboards/ui/DashboardDetailPage.tsx
+++ b/src/features/dashboards/ui/DashboardDetailPage.tsx
@@ -23,16 +23,7 @@ import useViewContextStore from "@/app/store/viewContextStore";
 import { useDashboard } from "./dashboardQueries";
 import DashboardHeader from "./DashboardHeader";
 import DashboardWidgetsGrid from "./DashboardWidgetsGrid";
-
-// Graph-paper hero per the Figma page shell (node 1317-3730): minor 1px
-// #FCFCFC lines every 7px with a stronger #F9F9FA line every 70px, on white.
-// Major lines listed first so they paint over coincident minor lines.
-const HERO_GRID_IMAGE = [
-  "repeating-linear-gradient(to right, #F9F9FA 0 1px, transparent 1px 70px)",
-  "repeating-linear-gradient(to bottom, #F9F9FA 0 1px, transparent 1px 70px)",
-  "repeating-linear-gradient(to right, #FCFCFC 0 1px, transparent 1px 7px)",
-  "repeating-linear-gradient(to bottom, #FCFCFC 0 1px, transparent 1px 7px)",
-].join(",");
+import { HERO_GRID_IMAGE } from "./heroGrid";
 
 export default function DashboardDetailPage() {
   const params = useParams<{ id: string }>();

--- a/src/features/dashboards/ui/DashboardsPage.tsx
+++ b/src/features/dashboards/ui/DashboardsPage.tsx
@@ -67,7 +67,7 @@ export default function DashboardsPage() {
               </Box>
             ) : (
               // Fixed 261px cards per the Figma; as many as fit per row.
-              <Grid templateColumns="repeat(auto-fill, 261px)" gap={4}>
+              <Grid templateColumns={{ base: "1fr", sm: "repeat(auto-fill, 261px)" }} gap={4}>
                 {dashboards.map((dashboard) => (
                   <DashboardCard key={dashboard.id} dashboard={dashboard} />
                 ))}

--- a/src/features/dashboards/ui/DashboardsPage.tsx
+++ b/src/features/dashboards/ui/DashboardsPage.tsx
@@ -66,14 +66,8 @@ export default function DashboardsPage() {
                 </Text>
               </Box>
             ) : (
-              <Grid
-                templateColumns={{
-                  base: "1fr",
-                  md: "repeat(2, minmax(0, 1fr))",
-                  lg: "repeat(3, minmax(0, 1fr))",
-                }}
-                gap={4}
-              >
+              // Fixed 261px cards per the Figma; as many as fit per row.
+              <Grid templateColumns="repeat(auto-fill, 261px)" gap={4}>
                 {dashboards.map((dashboard) => (
                   <DashboardCard key={dashboard.id} dashboard={dashboard} />
                 ))}

--- a/src/features/dashboards/ui/dashboardQueries.ts
+++ b/src/features/dashboards/ui/dashboardQueries.ts
@@ -10,6 +10,7 @@ import {
   addInsightWidget,
   createDashboard,
   createDashboardPayloadFromAoi,
+  deleteDashboard,
   deleteWidget,
   getDashboard,
   listDashboards,
@@ -97,6 +98,38 @@ export function useRenameDashboard(dashboardId: string) {
     },
     onSettled: () => {
       // Prefix-matches the detail key and the list (dashboard switcher).
+      queryClient.invalidateQueries({ queryKey: dashboardKeys.all });
+    },
+  });
+}
+
+export function useDeleteDashboard() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (dashboardId: string) => deleteDashboard(dashboardId),
+    // Optimistic: the card disappears from the list immediately; the
+    // snapshot is restored if the DELETE fails.
+    onMutate: async (dashboardId: string) => {
+      await queryClient.cancelQueries({ queryKey: dashboardKeys.all });
+      const previous = queryClient.getQueryData<Dashboard[]>(dashboardKeys.all);
+      if (previous) {
+        queryClient.setQueryData<Dashboard[]>(
+          dashboardKeys.all,
+          previous.filter((d) => d.id !== dashboardId)
+        );
+      }
+      return { previous };
+    },
+    onError: (_err, _id, context) => {
+      if (context?.previous) {
+        queryClient.setQueryData(dashboardKeys.all, context.previous);
+      }
+    },
+    onSettled: (_data, _err, dashboardId) => {
+      queryClient.removeQueries({
+        queryKey: dashboardKeys.detail(dashboardId),
+      });
       queryClient.invalidateQueries({ queryKey: dashboardKeys.all });
     },
   });

--- a/src/features/dashboards/ui/heroGrid.ts
+++ b/src/features/dashboards/ui/heroGrid.ts
@@ -1,0 +1,10 @@
+// Graph-paper hero per the Figma page shell (node 1317-3730): minor 1px
+// #FCFCFC lines every 7px with a stronger #F9F9FA line every 70px, on white.
+// Major lines listed first so they paint over coincident minor lines.
+// Shared by the dashboard detail hero band and the dashboard list cards.
+export const HERO_GRID_IMAGE = [
+  "repeating-linear-gradient(to right, #F9F9FA 0 1px, transparent 1px 70px)",
+  "repeating-linear-gradient(to bottom, #F9F9FA 0 1px, transparent 1px 70px)",
+  "repeating-linear-gradient(to right, #FCFCFC 0 1px, transparent 1px 7px)",
+  "repeating-linear-gradient(to bottom, #FCFCFC 0 1px, transparent 1px 7px)",
+].join(",");


### PR DESCRIPTION
## Summary

Updates the `/dashboards` listing cards to the Figma design ([node 2357-9427](https://www.figma.com/design/fUyMHyhGck5FmGEg0HlNHa/-Global-Nature-Watch--Playground?node-id=2357-9427)) and adds a ⋯ actions menu with **Rename** and **Delete**.

<img width="1141" height="721" alt="Screenshot 2026-07-13 at 12 35 56" src="https://github.com/user-attachments/assets/90d2792d-2f33-408b-99f4-a2d47474153c" />

- **Card restyle:** fixed 261×308px cards that auto-fill each row, graph-paper background (shared with the detail-page hero via a new `heroGrid.ts` module), polygon AOI icon, 18px title, lock icon + "Updated…" row, left-aligned content.
- **Actions menu:** ⋯ button top-right of each card (a sibling of the link, so menu clicks don't navigate), modeled on `ThreadActionsMenu`. Rename opens a name dialog (reuses the existing `useRenameDashboard` optimistic mutation); Delete opens a confirm dialog.
- **New API plumbing:** `deleteDashboard` client call for the existing `DELETE /api/dashboards/{id}` backend endpoint, plus a `useDeleteDashboard` mutation that optimistically removes the card from the list cache and rolls back on error.

## Test plan

- [x] `pnpm test` (465 passed), `pnpm test:arch`, `pnpm typecheck`, `pnpm lint` (no new warnings), `pnpm build`
- [ ] Visual QA on `/dashboards?ff=dashboard`: card layout matches Figma; rename updates the card after refetch; delete removes the card and confirms first

🤖 Generated with [Claude Code](https://claude.com/claude-code)