### PR TITLE
feat(dashboards): legend and opacity control for imagery map widgets

### DIFF
--- a/app/components/legend/LayerEntry.tsx
+++ b/app/components/legend/LayerEntry.tsx
@@ -174,6 +174,9 @@ export function LayerEntry(
                     label={p.label}
                     value={p.value}
                     colorScheme="purple"
+                    {...(p.maxValueWidth
+                      ? { maxValueWidth: p.maxValueWidth }
+                      : {})}
                   />
                 ))}
               </Flex>

--- a/app/components/legend/__tests__/imageryLegend.test.ts
+++ b/app/components/legend/__tests__/imageryLegend.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  imageryLayerTitle,
+  imageryLegendCloudNote,
+  imageryLegendInfo,
+  imageryLegendParams,
+  type ImageryLegendMeta,
+} from "../imageryLegend";
+
+// A freshly built mosaic: every metadata field the backend can emit.
+const fullMeta: ImageryLegendMeta = {
+  item_count: 4,
+  date_start: "2024-05-28",
+  date_end: "2024-06-03",
+  target_date: "2024-06-01",
+  window_days: 7,
+  max_cloud_cover: 20,
+  aoi_names: ["Ucayali", "Loreto"],
+};
+
+describe("imageryLegendParams", () => {
+  it("builds DATES, WINDOW, CLOUD and AREA chips from full metadata", () => {
+    expect(imageryLegendParams(fullMeta)).toEqual([
+      { label: "DATES", value: "May 28 – Jun 3, 2024", maxValueWidth: "26ch" },
+      { label: "WINDOW", value: "±7 days" },
+      { label: "CLOUD", value: "< 20%" },
+      { label: "AREA", value: "Ucayali, Loreto" },
+    ]);
+  });
+
+  it("omits the DATES chip on cache hits (no acquired date range)", () => {
+    const params = imageryLegendParams({
+      ...fullMeta,
+      date_start: undefined,
+      date_end: undefined,
+    });
+    expect(params.map((p) => p.label)).toEqual(["WINDOW", "CLOUD", "AREA"]);
+  });
+
+  it("omits constraint chips absent from pre-fields payloads", () => {
+    const params = imageryLegendParams({
+      ...fullMeta,
+      window_days: undefined,
+      max_cloud_cover: undefined,
+    });
+    expect(params.map((p) => p.label)).toEqual(["DATES", "AREA"]);
+  });
+
+  it("omits the AREA chip without any area names", () => {
+    expect(
+      imageryLegendParams({ ...fullMeta, aoi_names: [] }).map((p) => p.label)
+    ).toEqual(["DATES", "WINDOW", "CLOUD"]);
+    expect(
+      imageryLegendParams({ ...fullMeta, aoi_names: undefined }).map(
+        (p) => p.label
+      )
+    ).toEqual(["DATES", "WINDOW", "CLOUD"]);
+  });
+
+  it("returns no chips for an empty payload", () => {
+    expect(imageryLegendParams({})).toEqual([]);
+  });
+
+  it("keeps both years on a range crossing a year boundary", () => {
+    const params = imageryLegendParams({
+      date_start: "2023-12-28",
+      date_end: "2024-01-04",
+    });
+    expect(params[0].value).toBe("Dec 28, 2023 – Jan 4, 2024");
+  });
+
+  it("falls back to the raw string for unparseable dates", () => {
+    const params = imageryLegendParams({
+      date_start: "not-a-date",
+      date_end: "2024-06-03",
+    });
+    expect(params[0].value).toBe("not-a-date – Jun 3, 2024");
+  });
+});
+
+describe("imageryLegendInfo", () => {
+  it("describes the mosaic with scene count and target date", () => {
+    expect(imageryLegendInfo(fullMeta)).toBe(
+      "Sentinel-2 true-colour mosaic built from 4 scenes closest to " +
+        "Jun 1, 2024. Contains modified Copernicus Sentinel data."
+    );
+  });
+
+  it("uses the singular for a one-scene mosaic", () => {
+    expect(imageryLegendInfo({ ...fullMeta, item_count: 1 })).toContain(
+      "built from 1 scene closest to"
+    );
+  });
+
+  it("drops the scene count on cache hits", () => {
+    expect(imageryLegendInfo({ ...fullMeta, item_count: undefined })).toBe(
+      "Sentinel-2 true-colour mosaic closest to Jun 1, 2024. " +
+        "Contains modified Copernicus Sentinel data."
+    );
+  });
+
+  it("still describes the layer with no metadata at all", () => {
+    expect(imageryLegendInfo({})).toBe(
+      "Sentinel-2 true-colour mosaic. Contains modified Copernicus Sentinel data."
+    );
+  });
+});
+
+describe("imageryLegendCloudNote", () => {
+  it("returns a note when the search loosened the cloud-cover limit", () => {
+    expect(imageryLegendCloudNote({ max_cloud_cover: 60 })).toBe(
+      "Searched with a loosened cloud-cover limit (60%) — imagery may contain clouds."
+    );
+  });
+
+  it("returns nothing at or below the default limit", () => {
+    expect(imageryLegendCloudNote({ max_cloud_cover: 20 })).toBeUndefined();
+    expect(imageryLegendCloudNote({ max_cloud_cover: 5 })).toBeUndefined();
+    expect(imageryLegendCloudNote({})).toBeUndefined();
+  });
+});
+
+describe("imageryLayerTitle", () => {
+  it("stamps the target date into the title", () => {
+    expect(imageryLayerTitle("2024-06-01")).toBe(
+      "Satellite imagery (Jun 1, 2024)"
+    );
+  });
+
+  it("falls back to the bare name without (or with a bad) date", () => {
+    expect(imageryLayerTitle(undefined)).toBe("Satellite imagery");
+    expect(imageryLayerTitle("not-a-date")).toBe("Satellite imagery");
+  });
+});

--- a/app/components/legend/imageryLegend.ts
+++ b/app/components/legend/imageryLegend.ts
@@ -1,0 +1,122 @@
+import { format, parseISO } from "date-fns";
+
+import type { LegendParam } from "./types";
+
+/**
+ * Sentinel-2 mosaic metadata that drives an imagery legend entry — the
+ * ImageryState payload the show_imagery tool writes to agent state, whether
+ * carried on an explorer map layer or snapshotted into a dashboard map
+ * widget's config. Field names follow the wire format (snake_case) so both
+ * consumers can pass their payloads through unmapped.
+ *
+ * Everything is optional: item_count / date_start / date_end are only known
+ * when the mosaic is built (absent on a cache hit), and payloads created
+ * before a field existed simply lack it. Builders below omit whatever is
+ * missing rather than failing.
+ */
+export interface ImageryLegendMeta {
+  item_count?: number;
+  date_start?: string;
+  date_end?: string;
+  target_date?: string;
+  window_days?: number;
+  max_cloud_cover?: number;
+  aoi_names?: string[];
+}
+
+export const IMAGERY_LAYER_NAME = "Satellite imagery";
+
+// Backend default for show_imagery's max_cloud_cover; anything above it
+// means the agent loosened the search and clouds are expected.
+export const IMAGERY_DEFAULT_MAX_CLOUD_COVER = 20;
+
+function formatImageryDate(isoDate: string): string {
+  try {
+    return format(parseISO(isoDate), "MMM d, yyyy");
+  } catch {
+    return isoDate;
+  }
+}
+
+// Compact acquired-date range, e.g. "May 28 – Jun 3, 2024": the start date's
+// year is elided within a single year so the chip survives the dashboard
+// legend's 300px width without truncating away the end date.
+function formatImageryDateRange(startIso: string, endIso: string): string {
+  try {
+    const start = parseISO(startIso);
+    const end = parseISO(endIso);
+    const startLabel =
+      format(start, "yyyy") === format(end, "yyyy")
+        ? format(start, "MMM d")
+        : format(start, "MMM d, yyyy");
+    return `${startLabel} – ${format(end, "MMM d, yyyy")}`;
+  } catch {
+    return `${formatImageryDate(startIso)} – ${formatImageryDate(endIso)}`;
+  }
+}
+
+/** Legend/layer title, e.g. "Satellite imagery (Jun 1, 2024)". */
+export function imageryLayerTitle(targetDate?: string): string {
+  if (!targetDate) return IMAGERY_LAYER_NAME;
+  try {
+    return `${IMAGERY_LAYER_NAME} (${format(parseISO(targetDate), "MMM d, yyyy")})`;
+  } catch {
+    return IMAGERY_LAYER_NAME;
+  }
+}
+
+/**
+ * The read-only chips under an imagery legend title. Each chip is omitted
+ * when its metadata is missing (cache hits, pre-fields payloads).
+ */
+export function imageryLegendParams(meta: ImageryLegendMeta): LegendParam[] {
+  const params: LegendParam[] = [];
+  if (meta.date_start && meta.date_end) {
+    params.push({
+      label: "DATES",
+      value: formatImageryDateRange(meta.date_start, meta.date_end),
+      // Wide enough for a cross-year range ("Dec 28, 2023 – Jan 4, 2024");
+      // the default 15ch would hide the end date behind an ellipsis.
+      maxValueWidth: "26ch",
+    });
+  }
+  if (meta.window_days !== undefined) {
+    params.push({ label: "WINDOW", value: `±${meta.window_days} days` });
+  }
+  if (meta.max_cloud_cover !== undefined) {
+    params.push({ label: "CLOUD", value: `< ${meta.max_cloud_cover}%` });
+  }
+  if (meta.aoi_names && meta.aoi_names.length > 0) {
+    params.push({ label: "AREA", value: meta.aoi_names.join(", ") });
+  }
+  return params;
+}
+
+/** The info-popover sentence for an imagery legend entry. */
+export function imageryLegendInfo(meta: ImageryLegendMeta): string {
+  const scenes =
+    meta.item_count !== undefined
+      ? ` built from ${meta.item_count} scene${meta.item_count === 1 ? "" : "s"}`
+      : "";
+  const closest = meta.target_date
+    ? ` closest to ${formatImageryDate(meta.target_date)}`
+    : "";
+  return `Sentinel-2 true-colour mosaic${scenes}${closest}. Contains modified Copernicus Sentinel data.`;
+}
+
+/**
+ * A cautionary note shown when the search ran above the default cloud-cover
+ * limit — partly obscured imagery is then expected and shouldn't read as a
+ * rendering bug. Undefined when the default (or a stricter) limit applied.
+ */
+export function imageryLegendCloudNote(
+  meta: ImageryLegendMeta
+): string | undefined {
+  if (
+    meta.max_cloud_cover === undefined ||
+    meta.max_cloud_cover <= IMAGERY_DEFAULT_MAX_CLOUD_COVER
+  ) {
+    return undefined;
+  }
+  return `Searched with a loosened cloud-cover limit (${meta.max_cloud_cover}%) — imagery may contain clouds.`;
+}

--- a/app/components/legend/types.ts
+++ b/app/components/legend/types.ts
@@ -7,6 +7,11 @@ import { ReactNode } from "react";
 export interface LegendParam {
   label: string;
   value: string;
+  /**
+   * Overrides ParamChip's default 15ch value truncation width. Set on chips
+   * whose value must stay fully visible (e.g. imagery acquired-date ranges).
+   */
+  maxValueWidth?: string;
 }
 
 /**

--- a/src/features/dashboards/lib/__tests__/mapWidgets.test.ts
+++ b/src/features/dashboards/lib/__tests__/mapWidgets.test.ts
@@ -114,6 +114,9 @@ describe("mapWidgetLayer — imagery configs", () => {
       kind: "imagery",
       title: "Sentinel-2 imagery, 2024-06-01",
       tileUrl: "https://tiles.example.org/mosaic/{z}/{x}/{y}.png?url=abc",
+      minzoom: 8,
+      maxzoom: 14,
+      imagery: { target_date: "2024-06-01" },
     });
   });
 
@@ -122,6 +125,44 @@ describe("mapWidgetLayer — imagery configs", () => {
       imagery: { tile_url: "https://tiles.example.org/mosaic" },
     });
     expect(layer?.title).toBe("Sentinel-2 imagery");
+  });
+
+  it("carries the mosaic's legend metadata", () => {
+    const layer = mapWidgetLayer({
+      imagery: {
+        tile_url: "https://tiles.example.org/mosaic",
+        mosaic_id: "abc",
+        item_count: 4,
+        date_start: "2024-05-28",
+        date_end: "2024-06-03",
+        target_date: "2024-06-01",
+        window_days: 7,
+        max_cloud_cover: 20,
+        aoi_names: ["Ucayali", "Loreto"],
+      },
+    });
+    expect(layer?.imagery).toEqual({
+      item_count: 4,
+      date_start: "2024-05-28",
+      date_end: "2024-06-03",
+      target_date: "2024-06-01",
+      window_days: 7,
+      max_cloud_cover: 20,
+      aoi_names: ["Ucayali", "Loreto"],
+    });
+  });
+
+  it("drops malformed metadata fields instead of the whole layer", () => {
+    const layer = mapWidgetLayer({
+      imagery: {
+        tile_url: "https://tiles.example.org/mosaic",
+        item_count: "four",
+        date_start: 20240528,
+        window_days: Infinity,
+        aoi_names: ["Ucayali", 42, "  "],
+      },
+    });
+    expect(layer?.imagery).toEqual({ aoi_names: ["Ucayali"] });
   });
 
   it("returns null when neither dataset nor imagery is present", () => {

--- a/src/features/dashboards/lib/mapWidgets.ts
+++ b/src/features/dashboards/lib/mapWidgets.ts
@@ -1,4 +1,12 @@
+import type { ImageryLegendMeta } from "@/app/components/legend/imageryLegend";
 import { wrapPrimaryForestTileUrl } from "@/app/utils/primaryForestTileProtocol";
+
+// The backend builds Sentinel-2 mosaics for z8–14 (create_sentinel2_mosaic);
+// tile requests outside that range 404. minzoom stops the pointless requests,
+// maxzoom makes MapLibre overscale z14 tiles instead of going blank when the
+// user zooms in further.
+const IMAGERY_MIN_ZOOM = 8;
+const IMAGERY_MAX_ZOOM = 14;
 
 /**
  * A renderable map-widget layer parsed from a `widget_type: "map"` config
@@ -21,10 +29,19 @@ export interface MapWidgetLayer {
   parameters?: Record<string, unknown>;
   startDate?: string;
   endDate?: string;
+  // Imagery-kind fields.
+  /** Raster source zoom bounds — mosaics only exist for z8–14. */
+  minzoom?: number;
+  maxzoom?: number;
+  /** Mosaic metadata driving the widget's legend (DashboardMapLegend). */
+  imagery?: ImageryLegendMeta;
 }
 
 const str = (value: unknown): string | undefined =>
   typeof value === "string" && value.trim() ? value : undefined;
+
+const num = (value: unknown): number | undefined =>
+  typeof value === "number" && Number.isFinite(value) ? value : undefined;
 
 // Config parameters are `[{ name, values }]` (per the handoff); the legend
 // wants a `{ name: firstValue }` record — same reduction the explorer's
@@ -44,6 +61,32 @@ function parametersRecord(
     )
     .map((p) => [p.name, p.values[0]] as const);
   return entries.length > 0 ? Object.fromEntries(entries) : undefined;
+}
+
+// Legend metadata snapshotted from the show_imagery tool's ImageryState.
+// Per-field validation: a malformed field is dropped (its legend chip is
+// simply omitted) rather than discarding the rest of the metadata.
+function imageryMeta(im: Record<string, unknown>): ImageryLegendMeta {
+  const itemCount = num(im.item_count);
+  const dateStart = str(im.date_start);
+  const dateEnd = str(im.date_end);
+  const targetDate = str(im.target_date);
+  const windowDays = num(im.window_days);
+  const maxCloudCover = num(im.max_cloud_cover);
+  const aoiNames = Array.isArray(im.aoi_names)
+    ? im.aoi_names.filter(
+        (name): name is string => typeof name === "string" && !!name.trim()
+      )
+    : [];
+  return {
+    ...(itemCount !== undefined ? { item_count: itemCount } : {}),
+    ...(dateStart ? { date_start: dateStart } : {}),
+    ...(dateEnd ? { date_end: dateEnd } : {}),
+    ...(targetDate ? { target_date: targetDate } : {}),
+    ...(windowDays !== undefined ? { window_days: windowDays } : {}),
+    ...(maxCloudCover !== undefined ? { max_cloud_cover: maxCloudCover } : {}),
+    ...(aoiNames.length > 0 ? { aoi_names: aoiNames } : {}),
+  };
 }
 
 // Primary forest tiles ship black-background PNGs; the pf:// protocol
@@ -111,15 +154,18 @@ export function mapWidgetLayer(
     const im = imagery as Record<string, unknown>;
     const tileUrl = str(im.tile_url);
     if (!tileUrl) return null;
-    const targetDate = str(im.target_date);
+    const meta = imageryMeta(im);
     return {
       kind: "imagery",
       title:
         titleOverride ??
-        (targetDate
-          ? `Sentinel-2 imagery, ${targetDate}`
+        (meta.target_date
+          ? `Sentinel-2 imagery, ${meta.target_date}`
           : "Sentinel-2 imagery"),
       tileUrl,
+      minzoom: IMAGERY_MIN_ZOOM,
+      maxzoom: IMAGERY_MAX_ZOOM,
+      imagery: meta,
     };
   }
 

--- a/src/features/dashboards/ui/DashboardMapLegend.tsx
+++ b/src/features/dashboards/ui/DashboardMapLegend.tsx
@@ -2,6 +2,12 @@
 
 import { Text } from "@chakra-ui/react";
 
+import {
+  imageryLayerTitle,
+  imageryLegendCloudNote,
+  imageryLegendInfo,
+  imageryLegendParams,
+} from "@/app/components/legend/imageryLegend";
 import { Legend } from "@/app/components/legend/Legend";
 import type {
   LegendContextLayer,
@@ -26,10 +32,12 @@ export interface MapWidgetOpacity {
 
 /**
  * The explorer's Legend reused inside a dashboard map widget, built from the
- * widget's config snapshot instead of mapStore layers. Dataset widgets only —
- * imagery has no DATASET_CARDS entry — and no AOI chips (the dashboard's area
- * is fixed, not removable). The layer itself isn't removable either (the
- * card's ✕ removes the whole widget), so only opacity is actionable.
+ * widget's config snapshot instead of mapStore layers. Dataset entries come
+ * from the DATASET_CARDS catalog; imagery entries from the mosaic metadata
+ * snapshotted into the config (shared imageryLegend builders). No AOI chips
+ * (the dashboard's area is fixed, not removable), and the layer itself isn't
+ * removable either (the card's ✕ removes the whole widget), so only opacity
+ * is actionable.
  */
 export default function DashboardMapLegend({
   layer,
@@ -40,6 +48,32 @@ export default function DashboardMapLegend({
   opacity: MapWidgetOpacity;
   onOpacityChange: (target: keyof MapWidgetOpacity, value: number) => void;
 }) {
+  const entry =
+    layer.kind === "imagery"
+      ? imageryEntry(layer, opacity.main)
+      : datasetEntry(layer, opacity);
+  if (!entry) return null;
+
+  return (
+    <Legend
+      layers={[entry]}
+      compact
+      onLayerAction={({ action, payload }) => {
+        if (action === "opacity") {
+          onOpacityChange(
+            payload.id === "context" ? "context" : "main",
+            payload.opacity
+          );
+        }
+      }}
+    />
+  );
+}
+
+function datasetEntry(
+  layer: MapWidgetLayer,
+  opacity: MapWidgetOpacity
+): LegendLayer | null {
   const card =
     layer.datasetId != null
       ? DATASET_CARDS.find((d) => d.dataset_id === layer.datasetId)
@@ -71,7 +105,7 @@ export default function DashboardMapLegend({
     };
   }
 
-  const entry: LegendLayer = {
+  return {
     id: "main",
     title: legend.title,
     opacity: opacity.main,
@@ -84,19 +118,21 @@ export default function DashboardMapLegend({
     ) : undefined,
     hideRemoveControl: true,
   };
+}
 
-  return (
-    <Legend
-      layers={[entry]}
-      compact
-      onLayerAction={({ action, payload }) => {
-        if (action === "opacity") {
-          onOpacityChange(
-            payload.id === "context" ? "context" : "main",
-            payload.opacity
-          );
-        }
-      }}
-    />
-  );
+function imageryEntry(layer: MapWidgetLayer, opacity: number): LegendLayer {
+  const meta = layer.imagery ?? {};
+  const params = imageryLegendParams(meta);
+  const note = imageryLegendCloudNote(meta);
+
+  return {
+    id: "main",
+    title: imageryLayerTitle(meta.target_date),
+    opacity,
+    info: imageryLegendInfo(meta),
+    params: params.length > 0 ? params : undefined,
+    symbology: null,
+    children: note ? <Text fontSize="xs">{note}</Text> : undefined,
+    hideRemoveControl: true,
+  };
 }

--- a/src/features/dashboards/ui/DashboardMapWidget.tsx
+++ b/src/features/dashboards/ui/DashboardMapWidget.tsx
@@ -184,6 +184,10 @@ export default function DashboardMapWidget({
           type="raster"
           tiles={[layer.tileUrl]}
           tileSize={256}
+          // Imagery mosaics only exist for a bounded zoom range; spread
+          // conditionally so unset keys stay out of the source spec.
+          {...(layer.minzoom !== undefined ? { minzoom: layer.minzoom } : {})}
+          {...(layer.maxzoom !== undefined ? { maxzoom: layer.maxzoom } : {})}
         >
           <Layer
             id="widget-tiles"


### PR DESCRIPTION
## Summary

Imagery map widgets rendered with no legend and no opacity control — `DashboardMapLegend` returned `null` for any layer without a `DATASET_CARDS` entry, which made Sentinel-2 mosaics hard to interpret and impossible to fade against the AOI outline.

The widget config already carries everything needed: `add_map_widget` snapshots the full `ImageryState` from `show_imagery` (`item_count`, `date_start`/`date_end`, `target_date`, `window_days`, `max_cloud_cover`, `aoi_names`), but `mapWidgetLayer()` was discarding all of it except `tile_url`/`target_date`.

### What's in the legend

- **DATES** — acquired scene range (compact form, e.g. `May 28 – Jun 3, 2026`)
- **WINDOW** — search window (`±7 days`)
- **CLOUD** — cloud-cover *limit* (`< 20%`, deliberately phrased as a threshold — it is the STAC filter, not observed cover)
- **AREA** — the mosaic's AOI names (useful when they differ from the dashboard's area)
- **Info popover** — scene count + target date + Copernicus attribution
- **Note** — shown when the search ran above the default 20% cloud limit, so cloudy imagery doesn't read as a rendering bug
- **Opacity control** — main layer only; remove control hidden as on dataset widgets

Every chip degrades gracefully: `item_count`/`date_start`/`date_end` are absent on mosaic cache hits (only known at build time, not persisted — backend PR to fix this incoming), and older configs may lack the search-constraint fields.

### Shared with the explorer

The chip/info/note builders live in a new `app/components/legend/imageryLegend.ts`, mirroring the presentation prototyped on `feat/sentinel-2-visualization`. When that branch lands, its inline imagery block in `useLegendHook` can collapse to calls into this module — the meta type is structurally compatible with its `ImageryInfo` (same wire-format field names).

### Also

- Set the mosaic's z8–14 zoom bounds on the widget raster source: tile requests outside the range 404, and without `maxzoom` MapLibre goes blank past z14 instead of overscaling.
- `LegendParam` gained an optional `maxValueWidth` passthrough to `ParamChip` so the DATES range isn't truncated to `15ch` (which hid the end date in the 300px compact legend).

## Test plan

- [x] Unit tests for the legend builders (`imageryLegend.test.ts`, 15 cases: full metadata, cache-hit, pre-fields payloads, cross-year ranges, unparseable dates)
- [x] Unit tests for the config parser (`mapWidgets.test.ts`: metadata carried, malformed fields dropped per-field, zoom bounds set)
- [x] Verified in-browser against a mock backend: both widgets render legends (full-metadata + cache-hit variants), info popover shows scene count, opacity slider fades the raster, remove control hidden
- [x] `pnpm test` (541), `pnpm typecheck`, `pnpm lint`, `pnpm format:check` all green
- [ ] QA on staging with a real `show_imagery` → `add_map_widget` flow (needs the agent's `ff=experimental` profile)