### PR TITLE
Minor fixes for dashboards

### DIFF
--- a/app/store/__tests__/chatStore.test.ts
+++ b/app/store/__tests__/chatStore.test.ts
@@ -21,6 +21,8 @@ vi.mock("@/app/components/ui/toaster", () => ({
 
 import useChatStore from "../chatStore";
 import useViewContextStore from "../viewContextStore";
+import useAuthStore from "../authStore";
+import useAgentProfileStore from "../agentProfileStore";
 import { apiFetch } from "@/app/lib/api-client";
 import type {
   AnalyseSuggestion,
@@ -172,6 +174,77 @@ describe("chatStore view_context", () => {
     await useChatStore.getState().sendMessage("hello");
 
     expect(sentBody()).not.toHaveProperty("view_context");
+  });
+});
+
+describe("chatStore ff (agent profile default)", () => {
+  const sentBody = (): Record<string, unknown> => {
+    const init = vi.mocked(apiFetch).mock.calls[0]?.[1];
+    return JSON.parse((init?.body as string) ?? "{}");
+  };
+
+  const stubUrl = (search: string) =>
+    vi.stubGlobal("window", { location: { search } });
+
+  beforeEach(() => {
+    useChatStore.getState().reset();
+    useViewContextStore.setState({ viewContext: null });
+    useAuthStore.setState({ userType: null });
+    useAgentProfileStore.setState({ agentProfile: null });
+    vi.mocked(apiFetch).mockReset();
+    vi.mocked(apiFetch).mockResolvedValue({
+      ok: false,
+      status: 500,
+      headers: new Headers(),
+    } as unknown as Response);
+  });
+
+  afterEach(() => {
+    useViewContextStore.setState({ viewContext: null });
+    useAuthStore.setState({ userType: null });
+    useAgentProfileStore.setState({ agentProfile: null });
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+  });
+
+  it("defaults ff to experimental when the ?ff=dashboard gate is open for a privileged user", async () => {
+    useAuthStore.setState({ userType: "admin" });
+    stubUrl("?ff=dashboard");
+
+    await useChatStore.getState().sendMessage("hi");
+
+    expect(sentBody().ff).toBe("experimental");
+  });
+
+  it("omits ff for a non-privileged user even with ?ff=dashboard", async () => {
+    useAuthStore.setState({ userType: "regular" });
+    stubUrl("?ff=dashboard");
+
+    await useChatStore.getState().sendMessage("hi");
+
+    expect(sentBody()).not.toHaveProperty("ff");
+  });
+
+  it("omits ff on the map surface when the dashboard gate is closed", async () => {
+    useAuthStore.setState({ userType: "admin" });
+    stubUrl("?ff=analysis");
+
+    await useChatStore.getState().sendMessage("hi");
+
+    expect(sentBody()).not.toHaveProperty("ff");
+  });
+
+  it("still defaults to experimental on a dashboard surface without ?ff in the URL", async () => {
+    useAuthStore.setState({ userType: "admin" });
+    useViewContextStore.getState().setViewContext({
+      page: "dashboard",
+      dashboard_id: "5c9f7dd8-0000-0000-0000-000000000000",
+    });
+    stubUrl("");
+
+    await useChatStore.getState().sendMessage("hi");
+
+    expect(sentBody().ff).toBe("experimental");
   });
 });
 

--- a/app/store/chatStore.ts
+++ b/app/store/chatStore.ts
@@ -48,6 +48,7 @@ import {
 } from "@/app/config/feature-flags";
 import useAgentProfileStore from "./agentProfileStore";
 import useViewContextStore from "./viewContextStore";
+import { isFeatureEnabled } from "@/src/shared/lib/feature-flags";
 
 interface ChatState {
   messages: ChatMessage[];
@@ -538,17 +539,25 @@ const useChatStore = create<ChatState & ChatActions>((set, get) => ({
     // user type is allowed to use feature flags (else the backend 403s).
     const userType = useAuthStore.getState().userType;
     const viewContext = useViewContextStore.getState().viewContext;
-    // The dashboard agent tools (create_dashboard / add_to_dashboard) live in
-    // the backend's experimental profile (dashboards-frontend-handoff.md), so
-    // on a dashboard surface default to it — otherwise "add this to my
-    // dashboard" silently no-ops unless the user happened to have visited
-    // with ?agent_profile=experimental. Same user-type gate as above.
+    // The dashboard agent tools live in the backend's experimental profile, so
+    // default to it whenever the dashboards feature is active — either on a
+    // dashboard surface or with the ?ff=dashboard gate open — letting a single
+    // ?ff=dashboard stand in for ?agent_profile=experimental. Read live: nav
+    // helpers carry ?ff=dashboard across the thread-URL rewrite, so this tracks
+    // the visible feature rather than persisting a separate flag.
+    const dashboardsFeatureActive =
+      viewContext?.page === "dashboard" ||
+      (typeof window !== "undefined" &&
+        isFeatureEnabled(
+          new URLSearchParams(window.location.search),
+          "dashboard"
+        ));
     const ff =
       effectiveAgentProfile(
         useAgentProfileStore.getState().agentProfile,
         userType
       ) ??
-      (viewContext?.page === "dashboard" && canUseFeatureFlags(userType)
+      (dashboardsFeatureActive && canUseFeatureFlags(userType)
         ? EXPERIMENTAL_PROFILE
         : null);
     const prompt: ChatPrompt = {

--- a/src/features/dashboards/lib/__tests__/widgets.test.ts
+++ b/src/features/dashboards/lib/__tests__/widgets.test.ts
@@ -2,11 +2,14 @@ import { describe, it, expect } from "vitest";
 
 import {
   chartSize,
+  chartTitleOverride,
   computeReorder,
   dashboardWidgetToInsightWidgets,
   widgetSize,
   withChartSize,
+  withChartTitle,
   withSize,
+  withWidgetTitle,
 } from "../widgets";
 import type { DashboardWidget } from "../../api/schemas";
 
@@ -77,6 +80,47 @@ describe("chartSize / withChartSize", () => {
   });
 });
 
+describe("chartTitleOverride / withChartTitle", () => {
+  it("reads a per-chart override and ignores blanks/missing", () => {
+    expect(chartTitleOverride({}, "c-1")).toBeUndefined();
+    expect(chartTitleOverride({ titles: { "c-1": "Renamed" } }, "c-1")).toBe(
+      "Renamed"
+    );
+    expect(
+      chartTitleOverride({ titles: { "c-1": "Renamed" } }, "c-2")
+    ).toBeUndefined();
+    expect(
+      chartTitleOverride({ titles: { "c-1": "   " } }, "c-1")
+    ).toBeUndefined();
+  });
+
+  it("sets the override, preserving other config keys and sibling titles", () => {
+    expect(
+      withChartTitle({ size: "double", titles: { "c-1": "A" } }, "c-2", "B")
+    ).toEqual({ size: "double", titles: { "c-1": "A", "c-2": "B" } });
+  });
+
+  it("clears the override on a blank name and drops the empty titles key", () => {
+    expect(
+      withChartTitle({ size: "double", titles: { "c-1": "A" } }, "c-1", "  ")
+    ).toEqual({ size: "double" });
+  });
+});
+
+describe("withWidgetTitle", () => {
+  it("sets config.title and preserves other keys", () => {
+    expect(
+      withWidgetTitle({ dataset: { tile_url: "x" } }, "Forest loss")
+    ).toEqual({ dataset: { tile_url: "x" }, title: "Forest loss" });
+  });
+
+  it("clears config.title on a blank name", () => {
+    expect(withWidgetTitle({ title: "Old", size: "double" }, "")).toEqual({
+      size: "double",
+    });
+  });
+});
+
 describe("dashboardWidgetToInsightWidgets", () => {
   it("returns [] for a hidden insight or no charts", () => {
     expect(dashboardWidgetToInsightWidgets(widget({ insight: null }))).toEqual(
@@ -125,6 +169,30 @@ describe("dashboardWidgetToInsightWidgets", () => {
     expect(cards[0].description).toBe("Narrative.");
     expect(cards[1].title).toBe("Second");
     expect(cards[1].description).toBe("");
+  });
+
+  it("prefers a per-chart title override over config.title and the chart title", () => {
+    const cards = dashboardWidgetToInsightWidgets(
+      widget({
+        config: {
+          title: "First-chart override",
+          titles: { "c-2": "Renamed B" },
+        },
+        insight: {
+          id: "ins-1",
+          insight_text: "Narrative.",
+          codeact_parts: null,
+          charts: [
+            chart({ id: "c-1", position: 0, title: "First" }),
+            chart({ id: "c-2", position: 1, title: "Second" }),
+          ],
+        },
+      })
+    );
+    // c-1: no per-chart override, so the legacy first-chart config.title wins.
+    expect(cards[0].title).toBe("First-chart override");
+    // c-2: its per-chart override wins over the chart's own title.
+    expect(cards[1].title).toBe("Renamed B");
   });
 
   it("falls back to table for unknown chart types", () => {

--- a/src/features/dashboards/lib/widgets.ts
+++ b/src/features/dashboards/lib/widgets.ts
@@ -65,6 +65,64 @@ export function withChartSize(
 }
 
 /**
+ * A chart's manual title override. Charts render as individual cards, so each
+ * carries its own rename under `config.titles[chartId]` (mirrors
+ * `config.sizes`). Returns undefined when unset/blank so the caller falls back
+ * to the chart's own title.
+ */
+export function chartTitleOverride(
+  config: Record<string, unknown>,
+  chartId: string
+): string | undefined {
+  const titles = config.titles;
+  if (titles && typeof titles === "object") {
+    const own = (titles as Record<string, unknown>)[chartId];
+    if (typeof own === "string" && own.trim()) return own;
+  }
+  return undefined;
+}
+
+/**
+ * The full config to PATCH for a per-chart rename (config is replaced whole).
+ * A blank name clears the override so the card reverts to its default title;
+ * the `titles` key is dropped once empty to keep configs tidy.
+ */
+export function withChartTitle(
+  config: Record<string, unknown>,
+  chartId: string,
+  name: string
+): Record<string, unknown> {
+  const titles =
+    config.titles && typeof config.titles === "object"
+      ? { ...(config.titles as Record<string, unknown>) }
+      : {};
+  const trimmed = name.trim();
+  if (trimmed) titles[chartId] = trimmed;
+  else delete titles[chartId];
+
+  const out = { ...config };
+  if (Object.keys(titles).length > 0) out.titles = titles;
+  else delete out.titles;
+  return out;
+}
+
+/**
+ * The full config to PATCH for a single-card widget rename (map / imagery),
+ * whose title lives under `config.title` — the override `mapWidgetLayer`
+ * already reads. A blank name clears it (reverts to the default label).
+ */
+export function withWidgetTitle(
+  config: Record<string, unknown>,
+  name: string
+): Record<string, unknown> {
+  const trimmed = name.trim();
+  const out = { ...config };
+  if (trimmed) out.title = trimmed;
+  else delete out.title;
+  return out;
+}
+
+/**
  * Maps a dashboard insight widget (snake_case REST shape) to the
  * `InsightWidget`s consumed by `WidgetMessage` — the persisted counterpart
  * of `generateInsightsTool`, which produces one card per chart. Returns `[]`
@@ -110,7 +168,11 @@ export function dashboardWidgetToInsightWidgets(
         type: CHART_TYPES.has(chart.chart_type)
           ? (chart.chart_type as InsightWidget["type"])
           : "table",
-        title: (index === 0 && titleOverride) || chart.title,
+        // Per-chart rename wins; else the legacy first-chart `config.title`
+        // override; else the chart's own title.
+        title:
+          chartTitleOverride(widget.config, chart.id) ??
+          ((index === 0 && titleOverride) || chart.title),
         description: index === 0 ? (insight.insight_text ?? "") : "",
         data: chart.chart_data,
         xAxis: chart.x_axis,

--- a/src/features/dashboards/ui/AoiSearchTable.tsx
+++ b/src/features/dashboards/ui/AoiSearchTable.tsx
@@ -13,7 +13,7 @@ import {
   Text,
 } from "@chakra-ui/react";
 import {
-  ArrowRightIcon,
+  CaretRightIcon,
   MagnifyingGlassIcon,
   UploadSimpleIcon,
 } from "@phosphor-icons/react";
@@ -94,7 +94,9 @@ function ResultRow({
 }) {
   return (
     <Table.Row
-      role="group"
+      // `.group` (not role="group") is what Chakra's _groupHover targets, so
+      // the row must carry the class for the reveal-on-hover action to fire.
+      className="group"
       bg="transparent"
       opacity={disabled ? 0.6 : 1}
       _hover={disabled ? undefined : { bg: "blue.50" }}
@@ -138,12 +140,16 @@ function ResultRow({
           colorPalette="primary"
           disabled={disabled}
           opacity={{ base: 1, md: 0 }}
+          // No hover fill: the Figma shows plain text + chevron on the row's
+          // hover bg, not a nested ghost-button box. Keyboard focus still
+          // reveals it and keeps the default focus ring for a11y.
+          _hover={{ bg: "transparent" }}
           _groupHover={{ opacity: 1 }}
           _focusVisible={{ opacity: 1 }}
           onClick={() => onCreate(result)}
         >
           New dashboard
-          <ArrowRightIcon size={14} />
+          <CaretRightIcon size={16} />
         </Button>
       </Table.Cell>
     </Table.Row>

--- a/src/features/dashboards/ui/DashboardWidgetCard.tsx
+++ b/src/features/dashboards/ui/DashboardWidgetCard.tsx
@@ -8,6 +8,7 @@ import {
   Flex,
   Icon,
   IconButton,
+  Input,
   Portal,
   Text,
 } from "@chakra-ui/react";
@@ -16,6 +17,7 @@ import {
   ChartBarIcon,
   ChatTeardropDotsIcon,
   DotsSixVerticalIcon,
+  PencilSimpleIcon,
   XIcon,
 } from "@phosphor-icons/react";
 
@@ -52,6 +54,7 @@ export default function DashboardWidgetCard({
   onArmDrag,
   onDisarmDrag,
   onToggleSize,
+  onRename,
   onRemove,
 }: {
   title: string;
@@ -73,11 +76,24 @@ export default function DashboardWidgetCard({
   onArmDrag: () => void;
   onDisarmDrag: () => void;
   onToggleSize: () => void;
+  /** Persist a manual title (blank reverts to default); omitted disables rename. */
+  onRename?: (name: string) => void;
   onRemove: () => void;
 }) {
   const [confirmOpen, setConfirmOpen] = useState(false);
   const [paramsExpanded, setParamsExpanded] = useState(false);
+  // null = not editing; a string is the in-progress title draft.
+  const [draft, setDraft] = useState<string | null>(null);
+  const editing = draft !== null;
   const chips = card?.analysisParams ? buildChips(card.analysisParams) : [];
+
+  const commitRename = () => {
+    const next = draft ?? "";
+    setDraft(null);
+    // Blank clears the override (revert to default); skip a no-op rename.
+    if (next.trim() === title.trim()) return;
+    onRename?.(next);
+  };
 
   const addToConversation = () => {
     // False door — measure interest before building the real flow.
@@ -114,20 +130,54 @@ export default function DashboardWidgetCard({
             onPointerUp={onDisarmDrag}
           />
         )}
-        <Text
-          flex="1"
-          minW={0}
-          fontSize="14px"
-          fontWeight="medium"
-          lineHeight="16px"
-          color="#172B7A"
-          wordBreak="break-word"
-          pl={isOwner ? 0 : "8px"}
-        >
-          {title}
-        </Text>
+        {editing ? (
+          <Input
+            flex="1"
+            minW={0}
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            onBlur={commitRename}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") commitRename();
+              if (e.key === "Escape") setDraft(null);
+            }}
+            autoFocus
+            aria-label="Widget title"
+            variant="flushed"
+            size="sm"
+            fontSize="14px"
+            fontWeight="medium"
+            color="#172B7A"
+            pl={isOwner ? 0 : "8px"}
+          />
+        ) : (
+          <Text
+            flex="1"
+            minW={0}
+            fontSize="14px"
+            fontWeight="medium"
+            lineHeight="16px"
+            color="#172B7A"
+            wordBreak="break-word"
+            pl={isOwner ? 0 : "8px"}
+          >
+            {title}
+          </Text>
+        )}
         {isOwner && (
           <Flex align="center" gap="4px" flexShrink={0}>
+            {onRename && !editing && (
+              <IconButton
+                aria-label="Rename widget"
+                title="Rename widget"
+                size="2xs"
+                variant="ghost"
+                color="fg.muted"
+                onClick={() => setDraft(title)}
+              >
+                <PencilSimpleIcon size={16} />
+              </IconButton>
+            )}
             <IconButton
               aria-label="Add to AI conversation"
               title="Add to AI conversation"

--- a/src/features/dashboards/ui/DashboardWidgetCard.tsx
+++ b/src/features/dashboards/ui/DashboardWidgetCard.tsx
@@ -85,13 +85,27 @@ export default function DashboardWidgetCard({
   // null = not editing; a string is the in-progress title draft.
   const [draft, setDraft] = useState<string | null>(null);
   const editing = draft !== null;
+  // The value just committed by a rename. The optimistic update lands a tick
+  // after we leave edit mode, so without this the label would paint one frame
+  // of the stale `title` prop — a visible flash. Held until the prop catches
+  // up, then dropped during render (below).
+  const [pending, setPending] = useState<string | null>(null);
+
+  // Render-phase reconciliation: once the prop reflects the saved name (or a
+  // fresh server value arrives, e.g. an error rollback), drop the override so
+  // the prop is authoritative again. Runs before paint — no flash, no effect.
+  if (pending !== null && title.trim() === pending) setPending(null);
+  const displayTitle = pending ?? title;
   const chips = card?.analysisParams ? buildChips(card.analysisParams) : [];
 
   const commitRename = () => {
-    const next = draft ?? "";
+    const next = (draft ?? "").trim();
     setDraft(null);
     // Blank clears the override (revert to default); skip a no-op rename.
-    if (next.trim() === title.trim()) return;
+    if (next === title.trim()) return;
+    // Blank reverts to a default this component can't compute, so only hold a
+    // concrete new name to bridge the optimistic-update gap.
+    if (next) setPending(next);
     onRename?.(next);
   };
 
@@ -161,7 +175,7 @@ export default function DashboardWidgetCard({
             wordBreak="break-word"
             pl={isOwner ? 0 : "8px"}
           >
-            {title}
+            {displayTitle}
           </Text>
         )}
         {isOwner && (
@@ -173,7 +187,7 @@ export default function DashboardWidgetCard({
                 size="2xs"
                 variant="ghost"
                 color="fg.muted"
-                onClick={() => setDraft(title)}
+                onClick={() => setDraft(displayTitle)}
               >
                 <PencilSimpleIcon size={16} />
               </IconButton>

--- a/src/features/dashboards/ui/DashboardWidgetsGrid.tsx
+++ b/src/features/dashboards/ui/DashboardWidgetsGrid.tsx
@@ -12,7 +12,9 @@ import {
   dashboardWidgetToInsightWidgets,
   widgetSize,
   withChartSize,
+  withChartTitle,
   withSize,
+  withWidgetTitle,
 } from "../lib/widgets";
 import {
   mapWidgetLayer,
@@ -232,6 +234,22 @@ export default function DashboardWidgetsGrid({
                         ),
                   },
                 })
+              }
+              onRename={
+                // Renamable only for renderable cells (map/imagery/chart);
+                // per-chart titles key on card.id, single-card widgets on
+                // config.title.
+                cell.placeholder
+                  ? undefined
+                  : (name) =>
+                      updateWidget.mutate({
+                        widgetId: widget.id,
+                        patch: {
+                          config: card?.id
+                            ? withChartTitle(widget.config, card.id, name)
+                            : withWidgetTitle(widget.config, name),
+                        },
+                      })
               }
               onRemove={() => deleteWidget.mutate(widget.id)}
             />


### PR DESCRIPTION
## Summary

Three dashboard fixes/features, all frontend-only (no backend changes):

1. **`?ff=dashboard` now adds the experimental agent profile by default** — one URL param instead of two.
2. **Fix the "New dashboard ›" hover action** on the areas table — it never appeared on desktop.
3. **Manually rename dashboard insights** (map / satellite / chart), persisted across reload.

Targets `develop`.

---

### 1. `?ff=dashboard` implies `agent_profile=experimental` (`chatStore.ts`)

The dashboard agent tools (`create_dashboard` / `add_to_dashboard`) live in the backend's
`experimental` profile, sent as the `ff` field on `POST /api/chat`. Previously the client only
defaulted to `experimental` when *on a dashboard surface* (`viewContext.page === "dashboard"`).
On the **map** surface, `?ff=dashboard` opened the dashboards UI but the agent still ran the
`default` profile unless the user *also* added `?agent_profile=experimental` — so "add this to my
dashboard" silently no-oped.

Now the client defaults to `experimental` whenever the dashboards feature is active — a dashboard
surface **or** the `?ff=dashboard` gate being open on the current URL — still gated by the same
`canUseFeatureFlags(userType)` check (admin/superuser/machine only; the backend 403s otherwise).
The flag is read live rather than persisted, because the nav helpers already carry `?ff=dashboard`
across the thread-URL rewrite, and if the gate closes the dashboards UI hides too — so the agent
default tracks the visible feature.

> Note: the flag is `ff=dashboard` (singular). `?ff=dashboards` matches nothing.

### 2. Fix "New dashboard ›" row-hover action (`AoiSearchTable.tsx`)

The row used `role="group"`, but Chakra v3's `_groupHover` compiles to a selector targeting the
`.group` **class** (`.group:is(:hover,[data-hover]) &`), not `role="group"`. So on desktop
(`opacity md: 0`) the reveal never fired and the action was invisible (it only showed on mobile).
Switched the row to `className="group"`.

Aligned the treatment with the Figma spec: swapped the arrow (`→`) for the design's `CaretRight`
chevron (`›`) and removed the ghost button's hover fill so it's plain text + chevron on the row's
hover background (keyboard focus ring preserved for a11y).

### 3. Manually rename dashboard insights (map / satellite / chart)

Owners get a pencil affordance on each widget card (mirrors the existing dashboard-header rename):
click → inline input, commit on blur/Enter, cancel on Escape; a blank name reverts to the default.

Renames persist via the existing optimistic `updateWidget` config PATCH — **no backend change**,
since widget `config` is a free-form JSONB column the backend stores and returns verbatim
(`relativize_widget_config` only rewrites tile URLs and preserves all other keys):

- **map** & **satellite/imagery** widgets → `config.title` (the override `mapWidgetLayer` already reads).
- **chart** (insight) widgets, which can render several chart cards → `config.titles[chartId]`,
  a new per-chart map analogous to the existing `config.sizes[chartId]`.

`dashboardWidgetToInsightWidgets` now resolves titles as: per-chart override → legacy first-chart
`config.title` → the chart's own title.