### PR TITLE
fix(dashboards): prevent map widget crash on reorder/teardown

### DIFF
--- a/patches/@vis.gl__react-maplibre@8.0.4.patch
+++ b/patches/@vis.gl__react-maplibre@8.0.4.patch
@@ -1,0 +1,33 @@
+diff --git a/dist/index.cjs b/dist/index.cjs
+index 745ac68fd843bb22437fb5742b26ccfd661309c5..83c3e2de25b0eb544485e4a7c7d4373d9d72304b 100644
+--- a/dist/index.cjs
++++ b/dist/index.cjs
+@@ -542,7 +542,7 @@ var Maplibre = class {
+     var _a, _b;
+     const map = this._map;
+     const currProps = this._styleComponents;
+-    if (map.style._loaded) {
++    if (map.style && map.style._loaded) {
+       if (light && !deepEqual(light, currProps.light)) {
+         currProps.light = light;
+         map.setLight(light);
+diff --git a/dist/maplibre/maplibre.js b/dist/maplibre/maplibre.js
+index e6d332452680c953f86630ed48a908897af3dfd4..d93c412e16d5207ef0b043e0ecdfb673361a229d 100644
+--- a/dist/maplibre/maplibre.js
++++ b/dist/maplibre/maplibre.js
+@@ -371,8 +371,13 @@ class Maplibre {
+     _updateStyleComponents({ light, projection, sky, terrain }) {
+         const map = this._map;
+         const currProps = this._styleComponents;
+-        // We can safely manipulate map style once it's loaded
+-        if (map.style._loaded) {
++        // We can safely manipulate map style once it's loaded.
++        // Guard `map.style`: after map.remove() (unmount teardown) it is
++        // deleted, and this runs from async styledata/sourcedata handlers and a
++        // dep-less setProps layout effect that can fire on the removed map.
++        // Matches the `map.style &&` guard react-map-gl already uses in
++        // createSource. See fix/dashboard-map-widget-reorder-crash.
++        if (map.style && map.style._loaded) {
+             if (light && !deepEqual(light, currProps.light)) {
+                 currProps.light = light;
+                 map.setLight(light);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  '@vis.gl/react-maplibre@8.0.4':
+    hash: 8a59aa555163c3827d3242fcc08548528f1d61476b99abb6780e41f8040fdba3
+    path: patches/@vis.gl__react-maplibre@8.0.4.patch
+
 importers:
 
   .:
@@ -5539,7 +5544,7 @@ snapshots:
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
 
-  '@vis.gl/react-maplibre@8.0.4(maplibre-gl@5.6.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+  '@vis.gl/react-maplibre@8.0.4(patch_hash=8a59aa555163c3827d3242fcc08548528f1d61476b99abb6780e41f8040fdba3)(maplibre-gl@5.6.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
     dependencies:
       '@maplibre/maplibre-gl-style-spec': 19.3.3
       react: 19.1.0
@@ -8770,7 +8775,7 @@ snapshots:
   react-map-gl@8.0.4(maplibre-gl@5.6.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
     dependencies:
       '@vis.gl/react-mapbox': 8.0.4(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@vis.gl/react-maplibre': 8.0.4(maplibre-gl@5.6.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@vis.gl/react-maplibre': 8.0.4(patch_hash=8a59aa555163c3827d3242fcc08548528f1d61476b99abb6780e41f8040fdba3)(maplibre-gl@5.6.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+patchedDependencies:
+  "@vis.gl/react-maplibre@8.0.4": patches/@vis.gl__react-maplibre@8.0.4.patch

--- a/src/features/dashboards/ui/__tests__/DashboardWidgetsGrid.reorder.test.tsx
+++ b/src/features/dashboards/ui/__tests__/DashboardWidgetsGrid.reorder.test.tsx
@@ -1,0 +1,143 @@
+// @vitest-environment happy-dom
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render } from "@testing-library/react";
+import { useEffect } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// The card's toaster import reaches a .tsx module boundary — stub it.
+vi.mock("@/app/components/ui/toaster", () => ({
+  toaster: { create: vi.fn() },
+  Toaster: () => null,
+}));
+
+// Keep the geometry query off the network (the map widget fires it on mount).
+vi.mock("@/app/utils/geometryClient", () => ({
+  fetchGeometry: vi.fn(() => new Promise(() => {})),
+}));
+
+// Instrument the map: real MapLibre needs WebGL (unavailable in happy-dom), so
+// stub react-map-gl with a component that counts mounts/unmounts. That is
+// enough to assert the invariant this test guards — whether React remounts the
+// map widget — which is a property of the grid's keyed reconciliation, not of
+// MapLibre.
+const mapMounts = { count: 0 };
+const mapUnmounts = { count: 0 };
+vi.mock("react-map-gl/maplibre", () => {
+  const Passthrough = ({ children }: { children?: React.ReactNode }) => (
+    <>{children}</>
+  );
+  const MapGl = ({ children }: { children?: React.ReactNode }) => {
+    useEffect(() => {
+      mapMounts.count += 1;
+      return () => {
+        mapUnmounts.count += 1;
+      };
+    }, []);
+    return <div data-testid="mapgl">{children}</div>;
+  };
+  return {
+    __esModule: true,
+    default: MapGl,
+    AttributionControl: Passthrough,
+    Layer: Passthrough,
+    Marker: Passthrough,
+    NavigationControl: Passthrough,
+    Source: Passthrough,
+  };
+});
+
+import DashboardWidgetsGrid from "../DashboardWidgetsGrid";
+import type { Dashboard, DashboardWidget } from "../../api/schemas";
+import useAuthStore from "@/app/store/authStore";
+
+const mapWidget = (id: string, position: number): DashboardWidget => ({
+  id,
+  position,
+  widget_type: "map",
+  config: {
+    dataset: {
+      tile_url: `https://example.test/${id}/{z}/{x}/{y}.png`,
+      dataset_name: `Layer ${id}`,
+    },
+  },
+  created_at: "2026-07-01T00:00:00Z",
+  insight: null,
+});
+
+const dashboard: Dashboard = {
+  id: "d1",
+  user_id: "u1",
+  name: "Test",
+  description: null,
+  is_public: false,
+  created_at: "2026-07-01T00:00:00Z",
+  updated_at: "2026-07-01T00:00:00Z",
+  aois: [
+    {
+      source: "gadm",
+      src_id: "BRA",
+      subtype: "country",
+      name: "Brazil",
+      id: "a1",
+      position: 0,
+    },
+  ],
+  widgets: [mapWidget("m1", 0), mapWidget("m2", 1)],
+};
+
+const renderGrid = (d: Dashboard, queryClient: QueryClient) =>
+  render(
+    <QueryClientProvider client={queryClient}>
+      <ChakraProvider value={defaultSystem}>
+        <DashboardWidgetsGrid dashboard={d} />
+      </ChakraProvider>
+    </QueryClientProvider>
+  );
+
+describe("DashboardWidgetsGrid reorder", () => {
+  beforeEach(() => {
+    mapMounts.count = 0;
+    mapUnmounts.count = 0;
+    useAuthStore.setState({ userId: "u1" });
+  });
+
+  // Regression guard for the map-widget reorder crash: reordering only changes
+  // widget `position`, and cells are keyed on `widget.id`, so React must
+  // *move* the map widgets, never unmount/remount them. A remount would call
+  // react-map-gl's `map.remove()` while raster tiles are still loading, and the
+  // library's `_updateStyleComponents` then reads `map.style._loaded` on a
+  // removed map (`map.style` is deleted by `remove()`) → the reported
+  // TypeError. Keep the key stable (never fold `position` into it).
+  it("does not remount map widgets when their order changes", () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    const { rerender } = renderGrid(dashboard, queryClient);
+
+    expect(mapMounts.count).toBe(2);
+    expect(mapUnmounts.count).toBe(0);
+
+    // A reorder swaps positions and hands the grid a fresh dashboard object
+    // (new array + new widget objects, same ids) — exactly what the optimistic
+    // update and the settle-time refetch produce.
+    const reordered: Dashboard = {
+      ...dashboard,
+      widgets: [
+        { ...dashboard.widgets[1], position: 0 },
+        { ...dashboard.widgets[0], position: 1 },
+      ],
+    };
+    rerender(
+      <QueryClientProvider client={queryClient}>
+        <ChakraProvider value={defaultSystem}>
+          <DashboardWidgetsGrid dashboard={reordered} />
+        </ChakraProvider>
+      </QueryClientProvider>
+    );
+
+    // Still two live maps, none torn down.
+    expect(mapMounts.count).toBe(2);
+    expect(mapUnmounts.count).toBe(0);
+  });
+});


### PR DESCRIPTION
## Symptom

On a `?ff=dashboard` dashboard, interacting with a **map widget** throws:

```
TypeError: Cannot read properties of undefined (reading '_loaded')
    at Maplibre._updateStyleComponents (@vis.gl/react-maplibre/dist/maplibre/maplibre.js:375)
    at Maplibre.setProps (…/maplibre.js:140)
    at eval (…/components/map.js — the dep-less useIsomorphicLayoutEffect that calls setProps every render)
    at DashboardMapWidget → DashboardWidgetCard → DashboardWidgetsGrid
```

## Root cause

`maplibre.js:375` is `if (map.style._loaded)` inside `_updateStyleComponents`, with **no guard that `map.style` exists**.

- maplibre-gl's `Map.remove()` (unmount teardown) calls `setStyle(null)`, which **deletes `map.style`** (`maplibre-gl-dev.js` → `delete this.style`). So `map.style === undefined` happens only after `map.remove()`.
- react-map-gl calls `map.remove()` in its unmount cleanup (`destroy()`), since `reuseMaps` is not set.
- `_updateStyleComponents` runs from three places: a **dep-less `setProps` layout effect that fires on every render**, and the async `map.on('style.load')` / `map.on('sourcedata')` handlers that fire **as raster tiles stream in**. The widget has four raster sources, so a `sourcedata` event is almost always in flight.

So it is a **teardown race**: a style/source update lands on an already-removed map, and the unguarded `map.style._loaded` throws. This is a library-level omission — react-map-gl already uses the correct `map.style && map.style._loaded` guard in `createSource`, `updateSource`, `createLayer`, and `updateLayer`; `_updateStyleComponents` is the one spot that leaves it out.

## Does the reorder remount the map? (investigated — NO)

I verified with an instrumented test (mock `MapGl` counting mount/unmount) that a reorder does **not** remount the map widget:

- Grid cells are keyed on `widget.id`; a reorder only changes `widget.position`, so React **moves** the keyed items rather than unmounting them.
- The detail page keeps the grid mounted during the settle-time background refetch (`useDashboard` stays `success` with cached data; `isLoading` false).
- After a full reorder re-render, mounts stayed at 2 and unmounts at 0.

Because a reorder does not unmount the map, this is the async/teardown race described above — **not** a per-reorder remount. That rules out the two "obvious" fixes:

- **`reuseMaps`** only changes *unmount* behaviour (recycle vs `map.remove()`), so it can't address a crash that isn't a remount, and it is **unsafe with multiple map widgets** on one dashboard: react-map-gl's `savedMaps` pool is a shared LIFO stack that assumes ≤1 unmount / ≤1 mount at a time, so N maps unmounting together (navigation away) then remounting risk cross-assigning maps and flashing.
- **Gating `<Source>`/`<Layer>` behind a `styleLoaded` flag** does nothing here — the crash is inside react-map-gl's own `setProps` / `sourcedata` handlers, not in the child reconciliation.

## The fix

pnpm patch on `@vis.gl/react-maplibre@8.0.4` adding the `map.style &&` guard to `_updateStyleComponents` (both the ESM `dist/maplibre/maplibre.js` and the CJS `dist/index.cjs`), matching the guard the library already uses elsewhere. One line, safe for any number of maps, fixes every teardown vector. Recorded in `pnpm-workspace.yaml` + the lockfile; verified it re-applies on `pnpm install --frozen-lockfile` and that `pnpm build` succeeds. Superseded whenever we upgrade to a react-map-gl release that ships the guard upstream.

Also adds a regression test pinning the invariant that reordering does not remount map widgets (so a future key change can't start tearing a map down mid-tile-load on every reorder).

## Testing

- `pnpm typecheck` · `pnpm lint` (only pre-existing warnings) · `pnpm format:check` · `pnpm test` (574 passed) · `pnpm test:arch` (10 passed) · `pnpm build` — all pass.
- Patch verified applied to installed `node_modules` and re-applied on a frozen install.

## ⚠️ Needs manual retest

I could **not** reproduce headlessly: the committed env points at staging, I have no auth token or a dashboard containing a map widget, and happy-dom has no WebGL. Please **drag-reorder a map widget on a `?ff=dashboard` dashboard** (ideally one with 2+ map widgets, and also navigate away while its tiles are still loading) to confirm the crash is gone and no map flashing/cross-assignment appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
