### PR TITLE
fix(dashboards): search areas server-side on the new-dashboard picker

### DIFF
--- a/src/features/dashboards/api/aois.ts
+++ b/src/features/dashboards/api/aois.ts
@@ -12,6 +12,8 @@ interface SearchAoisParams {
 
 export interface BrowseAoisParams {
   source: ReferenceAoiSource | "custom";
+  /** Fuzzy name to search for within the source. Omit to browse alphabetically. */
+  name?: string;
   limit?: number;
   offset?: number;
 }
@@ -58,9 +60,13 @@ export async function searchAois({
   return AoiSearchResponseSchema.parse(data);
 }
 
-/** Browse AOIs alphabetically within a source (MVP: no name search). */
+/**
+ * Search/browse AOIs within a source. With `name`, the backend runs a fuzzy,
+ * similarity-ranked search; without it, results are browsed alphabetically.
+ */
 export async function browseAois({
   source,
+  name,
   limit = 50,
   offset = 0,
 }: BrowseAoisParams): Promise<BrowseAoisPage> {
@@ -69,6 +75,8 @@ export async function browseAois({
     limit: String(limit),
     offset: String(offset),
   });
+  const trimmed = name?.trim();
+  if (trimmed) params.set("name", trimmed);
 
   const res = await apiFetch(`/api/aois?${params.toString()}`, {
     method: "GET",

--- a/src/features/dashboards/hooks/__tests__/useAreaPickerRows.test.tsx
+++ b/src/features/dashboards/hooks/__tests__/useAreaPickerRows.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment happy-dom
 import { renderHook, waitFor } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const customAreasState = vi.hoisted(() => ({
   customAreas: [
@@ -77,13 +77,20 @@ const aoiBrowsePages = vi.hoisted(() => ({
   },
 }));
 
+const browseCalls = vi.hoisted(() => [] as { source: string; name?: string }[]);
+
 vi.mock("@/app/hooks/useCustomAreasList", () => ({
   useCustomAreasList: () => customAreasState,
 }));
 
 vi.mock("../useAoiBrowse", () => ({
-  useAoiBrowse: (source: "gadm" | "kba" | "wdpa" | "landmark") =>
-    aoiBrowsePages[source],
+  useAoiBrowse: (
+    source: "gadm" | "kba" | "wdpa" | "landmark",
+    options?: { enabled?: boolean; name?: string }
+  ) => {
+    browseCalls.push({ source, name: options?.name });
+    return aoiBrowsePages[source];
+  },
 }));
 
 vi.mock("../useDashboards", () => ({
@@ -93,6 +100,10 @@ vi.mock("../useDashboards", () => ({
 import { useAreaPickerRows } from "../useAreaPickerRows";
 
 describe("useAreaPickerRows", () => {
+  beforeEach(() => {
+    browseCalls.length = 0;
+  });
+
   it("merges reference sources and custom areas for 'all', custom last", async () => {
     const { result } = renderHook(() => useAreaPickerRows("all", ""));
 
@@ -129,9 +140,29 @@ describe("useAreaPickerRows", () => {
     expect(result.current.rows.map((r) => r.src_id)).toEqual(["area-1"]);
   });
 
-  it("applies the search filter over loaded rows", async () => {
+  it("threads the search term to every reference source as a server-side query", () => {
+    renderHook(() => useAreaPickerRows("all", "brazil"));
+    for (const source of ["gadm", "kba", "wdpa", "landmark"]) {
+      expect(browseCalls).toContainEqual({ source, name: "brazil" });
+    }
+  });
+
+  it("trusts server-side filtering for reference rows and filters custom client-side", async () => {
+    // "Some KBA" does not contain "brazil" but is kept — the server, not the
+    // client, decides which reference rows match. The custom "My farm" is
+    // dropped because custom areas are filtered locally.
     const { result } = renderHook(() => useAreaPickerRows("all", "brazil"));
     await waitFor(() => expect(result.current.isLoading).toBe(false));
-    expect(result.current.rows.map((r) => r.src_id)).toEqual(["BRA"]);
+    expect(result.current.rows.map((r) => r.src_id)).toEqual(["BRA", "KBA-1"]);
+  });
+
+  it("filters custom areas client-side by the search term", async () => {
+    const match = renderHook(() => useAreaPickerRows("custom", "farm"));
+    await waitFor(() => expect(match.result.current.isLoading).toBe(false));
+    expect(match.result.current.rows.map((r) => r.src_id)).toEqual(["area-1"]);
+
+    const miss = renderHook(() => useAreaPickerRows("custom", "zzz"));
+    await waitFor(() => expect(miss.result.current.isLoading).toBe(false));
+    expect(miss.result.current.rows).toEqual([]);
   });
 });

--- a/src/features/dashboards/hooks/useAoiBrowse.ts
+++ b/src/features/dashboards/hooks/useAoiBrowse.ts
@@ -1,4 +1,4 @@
-import { useInfiniteQuery } from "@tanstack/react-query";
+import { keepPreviousData, useInfiniteQuery } from "@tanstack/react-query";
 import { browseAois } from "../api/aois";
 import type { ReferenceAoiSource } from "../model/dashboard-area";
 
@@ -6,14 +6,19 @@ const PAGE_SIZE = 50;
 
 export function useAoiBrowse(
   source: ReferenceAoiSource | "custom",
-  options?: { enabled?: boolean }
+  options?: { enabled?: boolean; name?: string }
 ) {
+  // `name` is part of the query key so each search term is cached separately
+  // and changing it triggers a fresh server-side fuzzy search.
+  const name = options?.name?.trim() ?? "";
   return useInfiniteQuery({
-    queryKey: ["aoiBrowse", source],
+    queryKey: ["aoiBrowse", source, name],
     queryFn: ({ pageParam = 0 }) =>
-      browseAois({ source, limit: PAGE_SIZE, offset: pageParam }),
+      browseAois({ source, name, limit: PAGE_SIZE, offset: pageParam }),
     initialPageParam: 0,
     getNextPageParam: (lastPage) => lastPage.nextOffset ?? undefined,
     enabled: options?.enabled ?? true,
+    // Keep the prior results visible while a new search term loads.
+    placeholderData: keepPreviousData,
   });
 }

--- a/src/features/dashboards/hooks/useAreaPickerRows.ts
+++ b/src/features/dashboards/hooks/useAreaPickerRows.ts
@@ -46,17 +46,24 @@ export function useAreaPickerRows(
   const { customAreas, isLoading: customLoading } = useCustomAreasList();
   const { data: dashboards } = useDashboards();
 
+  // Reference sources are searched server-side (fuzzy, similarity-ranked) by
+  // threading `search` through to the /api/aois endpoint. Custom areas are all
+  // loaded locally and filtered client-side below.
   const gadm = useAoiBrowse("gadm", {
     enabled: isReferenceSourceEnabled(activeCategory, "gadm"),
+    name: search,
   });
   const kba = useAoiBrowse("kba", {
     enabled: isReferenceSourceEnabled(activeCategory, "kba"),
+    name: search,
   });
   const wdpa = useAoiBrowse("wdpa", {
     enabled: isReferenceSourceEnabled(activeCategory, "wdpa"),
+    name: search,
   });
   const landmark = useAoiBrowse("landmark", {
     enabled: isReferenceSourceEnabled(activeCategory, "landmark"),
+    name: search,
   });
   const referenceQueries = { gadm, kba, wdpa, landmark };
 
@@ -105,7 +112,9 @@ export function useAreaPickerRows(
   if (activeCategory !== "all") {
     const query = referenceQueries[activeCategory];
     return {
-      rows: filterRowsBySearch(referenceRows[activeCategory], search),
+      // Reference rows are already filtered server-side; don't re-filter here
+      // or fuzzy matches that aren't literal substrings would be dropped.
+      rows: referenceRows[activeCategory],
       isLoading: query.isLoading,
       hasNextPage: query.hasNextPage,
       isFetchingNextPage: query.isFetchingNextPage,
@@ -117,11 +126,11 @@ export function useAreaPickerRows(
 
   const merged = [
     ...REFERENCE_AOI_SOURCES.flatMap((source) => referenceRows[source]),
-    ...customRows,
+    ...filterRowsBySearch(customRows, search),
   ];
 
   return {
-    rows: filterRowsBySearch(merged, search),
+    rows: merged,
     isLoading:
       customLoading ||
       REFERENCE_AOI_SOURCES.some((s) => referenceQueries[s].isLoading),

--- a/src/features/dashboards/ui/NewDashboardScreen.tsx
+++ b/src/features/dashboards/ui/NewDashboardScreen.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import {
   Box,
@@ -83,13 +83,20 @@ export function NewDashboardScreen() {
     AreaPickerSectionId | "all"
   >("all");
   const [search, setSearch] = useState("");
+  // Debounced so each keystroke doesn't fire a server-side AOI search.
+  const [debouncedSearch, setDebouncedSearch] = useState("");
   const [creatingRowKey, setCreatingRowKey] = useState<string | null>(null);
   const [renamingId, setRenamingId] = useState<string | null>(null);
   const [renameValue, setRenameValue] = useState("");
   const uploadInputRef = useRef<HTMLInputElement>(null);
 
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedSearch(search), 300);
+    return () => clearTimeout(timer);
+  }, [search]);
+
   const { rows, isLoading, hasNextPage, isFetchingNextPage, fetchNextPage } =
-    useAreaPickerRows(activeCategory, search);
+    useAreaPickerRows(activeCategory, debouncedSearch);
   const { createDashboardAsync } = useCreateDashboard();
   const { createAreaAsync, isCreating: isUploading } = useCustomAreasCreate();
   const { renameAreaAsync, isRenaming } = useCustomAreasUpdate();


### PR DESCRIPTION
## Problem

On `/dashboards`, the **"Search areas by name…"** box appeared broken — typing almost any real area name (Kenya, Brazil, Yellowstone…) returned *"No areas match your search."*

Root cause: the search only filtered rows **already loaded in the browser**. `useAreaPickerRows` browsed each reference source alphabetically (50 rows/source via `browseAois`, with **no `name` param sent**) and then applied a client-side substring filter (`filterRowsBySearch`). So anything past the first alphabetical page of each source was never fetched and could never match. The backend endpoint already supports fuzzy, similarity-ranked search (`GET /api/aois?name=…`, `project-zeno/src/api/routers/aois.py`) — the picker just never used it.

Note: a correct server-search path (`searchAois` → `useAoiSearch` → `AoiSearchTable`) exists in the repo but has been **orphaned** since `NewDashboardScreen` replaced it in PZB-1063 (#596). This PR fixes the live picker rather than re-wiring the old component.

## Fix (frontend only — no backend change)

Thread the search term through to `GET /api/aois?name=…`:

- **`browseAois` / `useAoiBrowse`** — accept an optional `name`, forward it to the endpoint, and key the query on it (with `keepPreviousData` so results don't flash empty between terms).
- **`useAreaPickerRows`** — pass the term to all four reference sources (server-side fuzzy search) and stop re-filtering their rows client-side (that would drop non-substring fuzzy matches). Custom areas stay client-filtered since they're all loaded locally.
- **`NewDashboardScreen`** — debounce the input (300ms) before it hits the query.

The orphaned `searchAois`/`useAoiSearch`/`AoiSearchTable` path is left untouched.

## Testing

Local gates all green:

- `pnpm typecheck` ✓
- `pnpm test` — 575 passed ✓ (incl. 3 new/rewritten `useAreaPickerRows` tests: term reaches each reference source as a server-side query; reference rows trust server filtering while custom is filtered client-side)
- `pnpm test:arch` — 10 passed ✓
- `pnpm lint` — changed files clean ✓
- `pnpm build` ✓

⚠️ **Not yet verified live on staging** — the Chrome extension wasn't connected this session. Suggest a quick manual check: search `/dashboards?ff=dashboard` for e.g. "Kenya" and confirm results appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)