### PR TITLE
feat(dashboards): add existing analyses to a dashboard from the Analyses pane

### DIFF
--- a/app/ChatPanelCompact.tsx
+++ b/app/ChatPanelCompact.tsx
@@ -16,7 +16,7 @@ import {
 import { usePromptQuota } from "./hooks/usePromptQuota";
 import useChatStore from "./store/chatStore";
 import useSidebarStore from "./store/sidebarStore";
-import { isAppRoute } from "./utils/threadNavigation";
+import { isAppRoute, isDashboardDetailRoute } from "./utils/threadNavigation";
 import { usePathname } from "next/navigation";
 import { useState, useEffect, useRef, useCallback } from "react";
 
@@ -45,11 +45,14 @@ function ChatPanelCompact({ onToggleSize }: ChatPanelCompactProps) {
   const { dataCatalogOpen, areasPanelOpen, insightsPanelOpen } =
     useSidebarStore();
   const pathname = usePathname();
-  // The catalog/areas/insights panels only render in the map layout; off it
-  // (dashboard pages) their persisted open state must not push the panel sideways.
+  // On the map, any of the three column panels shifts the compact chat aside.
+  // On a dashboard's detail page only the Analyses (insights) pane renders, so
+  // the data catalog / areas open state (which can persist from the map) must
+  // not push the panel sideways there. On any other surface nothing shifts it.
   const chatLeftPx = getCompactChatLeftPx(
-    isAppRoute(pathname) &&
-      (dataCatalogOpen || areasPanelOpen || insightsPanelOpen)
+    isAppRoute(pathname)
+      ? dataCatalogOpen || areasPanelOpen || insightsPanelOpen
+      : isDashboardDetailRoute(pathname) && insightsPanelOpen
   );
   const hasConversation = messages.some(
     (m) => m.type === "user" || m.type === "assistant"

--- a/app/components/CatalogCard.tsx
+++ b/app/components/CatalogCard.tsx
@@ -22,6 +22,12 @@ export interface CatalogCardProps {
   selectedBg?: string;
   showOnMap: boolean;
   onShowOnMapChange: (checked: boolean) => void;
+  /** Visible label beside the footer toggle. Defaults to "Show on map". */
+  toggleLabel?: string;
+  /** Accessible name for the footer toggle. Defaults to a show/hide-on-map phrasing. */
+  toggleAriaLabel?: string;
+  /** Disables the footer toggle (e.g. an analysis that can't be added). */
+  toggleDisabled?: boolean;
   /** Optional info button click handler. When omitted, the info button is hidden. */
   onInfoClick?: () => void;
   /** Optional info button tooltip / aria text. Defaults to "Show dataset info". */
@@ -53,6 +59,9 @@ export function CatalogCard({
   selectedBg,
   showOnMap,
   onShowOnMapChange,
+  toggleLabel = "Show on map",
+  toggleAriaLabel,
+  toggleDisabled = false,
   onInfoClick,
   infoTooltip = "Show dataset info",
   titleActions,
@@ -169,10 +178,12 @@ export function CatalogCard({
             onCheckedChange={(e: { checked: boolean }) =>
               onShowOnMapChange(e.checked)
             }
+            disabled={toggleDisabled}
             colorPalette="primary"
             flexShrink={0}
             aria-label={
-              showOnMap ? `Hide ${title} from map` : `Show ${title} on map`
+              toggleAriaLabel ??
+              (showOnMap ? `Hide ${title} from map` : `Show ${title} on map`)
             }
           >
             <Switch.HiddenInput />
@@ -181,7 +192,7 @@ export function CatalogCard({
             </Switch.Control>
           </Switch.Root>
           <Text fontFamily="body" fontSize="12px" color="#656E7B">
-            Show on map
+            {toggleLabel}
           </Text>
         </Flex>
       </Flex>

--- a/app/components/ChatInput.tsx
+++ b/app/components/ChatInput.tsx
@@ -35,6 +35,7 @@ import { useRouter, usePathname } from "next/navigation";
 import {
   firstMessageRedirectPath,
   isAppRoute,
+  isDashboardDetailRoute,
 } from "../utils/threadNavigation";
 
 export default function ChatInput({
@@ -330,32 +331,36 @@ export default function ChatInput({
                     color={areasPanelOpen ? "primary.solid" : undefined}
                     aria-expanded={areasPanelOpen}
                   />
-                  {!isMobile && (
-                    <Button
-                      size="xs"
-                      variant="outline"
-                      borderRadius="sm"
-                      borderWidth="1px"
-                      px="2"
-                      h="8"
-                      gap="1"
-                      fontSize="xs"
-                      fontWeight="normal"
-                      onClick={openInsightsPanel}
-                      disabled={disabled}
-                      borderColor={
-                        insightsPanelOpen ? "primary.solid" : "#E0E2E5"
-                      }
-                      color={insightsPanelOpen ? "primary.solid" : undefined}
-                      aria-expanded={insightsPanelOpen}
-                      aria-label="Analyses"
-                    >
-                      <ChartLineIcon />
-                      Analyses
-                    </Button>
-                  )}
                 </>
               )}
+              {/* The Analyses pane is mounted on the map and on a dashboard's
+                  detail page, so its opener shows on both (unlike the map-only
+                  pickers above). */}
+              {(isAppRoute(pathname) || isDashboardDetailRoute(pathname)) &&
+                !isMobile && (
+                  <Button
+                    size="xs"
+                    variant="outline"
+                    borderRadius="sm"
+                    borderWidth="1px"
+                    px="2"
+                    h="8"
+                    gap="1"
+                    fontSize="xs"
+                    fontWeight="normal"
+                    onClick={openInsightsPanel}
+                    disabled={disabled}
+                    borderColor={
+                      insightsPanelOpen ? "primary.solid" : "#E0E2E5"
+                    }
+                    color={insightsPanelOpen ? "primary.solid" : undefined}
+                    aria-expanded={insightsPanelOpen}
+                    aria-label="Analyses"
+                  >
+                    <ChartLineIcon />
+                    Analyses
+                  </Button>
+                )}
             </Flex>
             <Flex gap="2" ml="auto" alignItems="center">
               {voiceInputEnabled && speech && (

--- a/app/dashboards/[id]/page.tsx
+++ b/app/dashboards/[id]/page.tsx
@@ -1,12 +1,16 @@
 "use client";
 
+import { Box } from "@chakra-ui/react";
+
 import ConversationHistoryDrawer from "@/app/components/ConversationHistoryDrawer";
 import PageHeader from "@/app/components/PageHeader";
+import { CATALOG_COLUMN_Z_INDEX } from "@/app/explorationLayout";
 import { useAuthGuard } from "@/app/hooks/useAuthGuard";
 import {
   DashboardDetailPage,
   DashboardFeatureGate,
 } from "@/src/features/dashboards";
+import { InsightsPanel } from "@/src/features/insights-history";
 
 export default function DashboardDetailRoute() {
   const isReady = useAuthGuard();
@@ -17,6 +21,24 @@ export default function DashboardDetailRoute() {
       <PageHeader />
       <ConversationHistoryDrawer />
       <DashboardDetailPage />
+      {/* Analyses pane overlay — opened from the chat input's "Analyses"
+          button (sidebarStore). Mounted here (app layer) so the dashboards
+          feature never imports the insights-history feature. Its own fixed,
+          positioned box below the 40px header gives the pane's absolute
+          positioning the same anchor it has on the map; z-index sits just
+          under the chat overlay (1100) so the chat stays on top. */}
+      <Box
+        position="fixed"
+        top="40px"
+        bottom={0}
+        left={0}
+        zIndex={CATALOG_COLUMN_Z_INDEX}
+        display={{ base: "none", md: "flex" }}
+        flexDir="column"
+        pointerEvents="none"
+      >
+        <InsightsPanel />
+      </Box>
     </DashboardFeatureGate>
   );
 }

--- a/app/utils/__tests__/threadNavigation.test.ts
+++ b/app/utils/__tests__/threadNavigation.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect } from "vitest";
 import {
   firstMessageRedirectPath,
   isAppRoute,
+  isDashboardDetailRoute,
   mapTabHref,
   newConversationTarget,
   threadClickTarget,
@@ -18,6 +19,18 @@ describe("isAppRoute", () => {
     expect(isAppRoute("/dashboards/abc")).toBe(false);
     expect(isAppRoute("/application")).toBe(false);
     expect(isAppRoute(null)).toBe(false);
+  });
+});
+
+describe("isDashboardDetailRoute", () => {
+  it("matches a single dashboard's detail page", () => {
+    expect(isDashboardDetailRoute("/dashboards/abc")).toBe(true);
+  });
+
+  it("rejects the list page, the map, and null", () => {
+    expect(isDashboardDetailRoute("/dashboards")).toBe(false);
+    expect(isDashboardDetailRoute("/app/threads/t-1")).toBe(false);
+    expect(isDashboardDetailRoute(null)).toBe(false);
   });
 });
 

--- a/app/utils/threadNavigation.ts
+++ b/app/utils/threadNavigation.ts
@@ -9,6 +9,16 @@ export function isAppRoute(pathname: string | null): boolean {
 }
 
 /**
+ * Whether the pathname is a single dashboard's detail page (`/dashboards/<id>`,
+ * not the `/dashboards` list). The Analyses pane is mounted here as well as on
+ * the map, so surfaces that gate on the pane (the chat input's opener, the
+ * compact chat's sideways shift) use this alongside {@link isAppRoute}.
+ */
+export function isDashboardDetailRoute(pathname: string | null): boolean {
+  return !!pathname?.startsWith("/dashboards/");
+}
+
+/**
  * The canonical map URL for a thread, carrying the hidden-feature flags
  * (?ff=…) from the given `location.search` — dropping them closes the
  * dashboards feature gate on the next navigation or refresh. Other params

--- a/src/features/dashboards/api/dashboards.ts
+++ b/src/features/dashboards/api/dashboards.ts
@@ -97,12 +97,19 @@ export async function updateWidget(
 // the dashboard without insight expansion — callers invalidate and refetch.
 export async function addInsightWidget(
   dashboardId: string,
-  insightId: string
+  insightId: string,
+  config?: Record<string, unknown>
 ): Promise<void> {
   await readJson<unknown>(`/api/dashboards/${dashboardId}/widgets`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ widget_type: "insight", insight_id: insightId }),
+    body: JSON.stringify({
+      widget_type: "insight",
+      insight_id: insightId,
+      // A chart subset (config.chartIds) rides along when the pane adds a single
+      // chart; omitted for a whole-insight add so the widget shows all charts.
+      ...(config ? { config } : {}),
+    }),
   });
 }
 

--- a/src/features/dashboards/lib/__tests__/widgets.test.ts
+++ b/src/features/dashboards/lib/__tests__/widgets.test.ts
@@ -5,8 +5,12 @@ import {
   chartTitleOverride,
   computeReorder,
   dashboardWidgetToInsightWidgets,
+  isChartShown,
+  shownChartIds,
   widgetSize,
   widgetText,
+  withChartHidden,
+  withChartShown,
   withChartSize,
   withChartTitle,
   withSize,
@@ -312,5 +316,91 @@ describe("computeReorder", () => {
     const { order, patches } = computeReorder(widgets, 5, 0);
     expect(order.map((w) => w.id)).toEqual(["a", "b", "c"]);
     expect(patches).toEqual([]);
+  });
+});
+
+describe("shownChartIds / isChartShown", () => {
+  const all = ["c-1", "c-2", "c-3"];
+
+  it("treats a config with no chartIds as all charts shown", () => {
+    expect(shownChartIds({}, all)).toEqual(all);
+    expect(isChartShown({}, "c-2", all)).toBe(true);
+  });
+
+  it("returns the explicit subset in insight-chart order", () => {
+    expect(shownChartIds({ chartIds: ["c-3", "c-1"] }, all)).toEqual([
+      "c-1",
+      "c-3",
+    ]);
+    expect(isChartShown({ chartIds: ["c-1"] }, "c-2", all)).toBe(false);
+  });
+});
+
+describe("withChartShown", () => {
+  const all = ["c-1", "c-2", "c-3"];
+
+  it("adds a chart to an explicit subset, ordered", () => {
+    expect(withChartShown({ chartIds: ["c-1"] }, "c-3", all)).toEqual({
+      chartIds: ["c-1", "c-3"],
+    });
+  });
+
+  it("drops chartIds once every chart is shown", () => {
+    expect(withChartShown({ chartIds: ["c-1", "c-2"] }, "c-3", all)).toEqual(
+      {}
+    );
+  });
+
+  it("is a no-op on an implicit-all config", () => {
+    expect(withChartShown({}, "c-2", all)).toEqual({});
+  });
+});
+
+describe("withChartHidden", () => {
+  const all = ["c-1", "c-2", "c-3"];
+
+  it("materialises the subset when hiding from implicit-all", () => {
+    expect(withChartHidden({}, "c-2", all)).toEqual({
+      chartIds: ["c-1", "c-3"],
+    });
+  });
+
+  it("removes a chart from an explicit subset", () => {
+    expect(withChartHidden({ chartIds: ["c-1", "c-2"] }, "c-1", all)).toEqual({
+      chartIds: ["c-2"],
+    });
+  });
+
+  it("returns null when the last shown chart is hidden", () => {
+    expect(withChartHidden({ chartIds: ["c-2"] }, "c-2", all)).toBeNull();
+  });
+});
+
+describe("dashboardWidgetToInsightWidgets — chartIds filtering", () => {
+  function twoChartWidget(config: Record<string, unknown>): DashboardWidget {
+    return widget({
+      config,
+      insight: {
+        id: "ins-1",
+        insight_text: "",
+        codeact_parts: null,
+        charts: [
+          chart({ id: "c-1", position: 0 }),
+          chart({ id: "c-2", position: 1, title: "CO2" }),
+        ],
+      },
+    });
+  }
+
+  it("renders only the shown charts", () => {
+    const out = dashboardWidgetToInsightWidgets(
+      twoChartWidget({ chartIds: ["c-2"] })
+    );
+    expect(out.map((c) => c.id)).toEqual(["c-2"]);
+  });
+
+  it("renders all charts when config has no chartIds", () => {
+    const out = dashboardWidgetToInsightWidgets(twoChartWidget({}));
+    expect(out.map((c) => c.id)).toEqual(["c-1", "c-2"]);
   });
 });

--- a/src/features/dashboards/lib/widgets.ts
+++ b/src/features/dashboards/lib/widgets.ts
@@ -139,12 +139,76 @@ export function withText(
 }
 
 /**
+ * The chart ids a widget shows. `config.chartIds` when present — the explicit
+ * subset a user assembled chart-by-chart from the Analyses pane, ordered by the
+ * insight's own chart order. Absent means "all charts", i.e. a widget added
+ * whole (chat toggle or agent), so older configs keep rendering every chart.
+ */
+export function shownChartIds(
+  config: Record<string, unknown>,
+  allChartIds: string[]
+): string[] {
+  const ids = config.chartIds;
+  if (!Array.isArray(ids)) return allChartIds;
+  const wanted = new Set(
+    ids.filter((id): id is string => typeof id === "string")
+  );
+  return allChartIds.filter((id) => wanted.has(id));
+}
+
+/** Whether a specific chart of the insight is currently shown by the widget. */
+export function isChartShown(
+  config: Record<string, unknown>,
+  chartId: string,
+  allChartIds: string[]
+): boolean {
+  return shownChartIds(config, allChartIds).includes(chartId);
+}
+
+/**
+ * The full config to PATCH to add a chart to the shown set (config is replaced
+ * whole). Idempotent. Once every chart is shown the `chartIds` key is dropped so
+ * the widget reverts to the tidy "all charts" form.
+ */
+export function withChartShown(
+  config: Record<string, unknown>,
+  chartId: string,
+  allChartIds: string[]
+): Record<string, unknown> {
+  const shown = new Set(shownChartIds(config, allChartIds));
+  shown.add(chartId);
+  const next = allChartIds.filter((id) => shown.has(id));
+  const out = { ...config };
+  if (next.length >= allChartIds.length) delete out.chartIds;
+  else out.chartIds = next;
+  return out;
+}
+
+/**
+ * The full config to PATCH to hide a chart (config is replaced whole). Returns
+ * `null` when it was the last shown chart — the caller should delete the widget
+ * rather than persist an empty one.
+ */
+export function withChartHidden(
+  config: Record<string, unknown>,
+  chartId: string,
+  allChartIds: string[]
+): Record<string, unknown> | null {
+  const next = shownChartIds(config, allChartIds).filter(
+    (id) => id !== chartId
+  );
+  if (next.length === 0) return null;
+  return { ...config, chartIds: next };
+}
+
+/**
  * Maps a dashboard insight widget (snake_case REST shape) to the
  * `InsightWidget`s consumed by `WidgetMessage` — the persisted counterpart
- * of `generateInsightsTool`, which produces one card per chart. Returns `[]`
- * when there is nothing to render (insight hidden from this viewer, or no
- * charts); the caller shows a "not available" placeholder per the API
- * contract.
+ * of `generateInsightsTool`, which produces one card per chart. Only the
+ * widget's shown charts (`config.chartIds`, or all when absent) are returned.
+ * Returns `[]` when there is nothing to render (insight hidden from this
+ * viewer, or no shown charts); the caller shows a "not available" placeholder
+ * per the API contract.
  *
  * The widget's `config.title` override and the insight narrative apply to
  * the first chart (the card's visual header); provenance parts feed the
@@ -175,8 +239,16 @@ export function dashboardWidgetToInsightWidgets(
     typeof widget.config.title === "string" ? widget.config.title : undefined;
   const analysisParams = areaName ? { areas: [areaName] } : undefined;
 
-  return [...insight.charts]
-    .sort((a, b) => a.position - b.position)
+  const sorted = [...insight.charts].sort((a, b) => a.position - b.position);
+  const shown = new Set(
+    shownChartIds(
+      widget.config,
+      sorted.map((c) => c.id)
+    )
+  );
+
+  return sorted
+    .filter((chart) => shown.has(chart.id))
     .map((chart, index) => {
       const seriesFields = chart.series_fields ?? undefined;
       return {

--- a/src/features/dashboards/ui/AddToDashboardToggle.tsx
+++ b/src/features/dashboards/ui/AddToDashboardToggle.tsx
@@ -3,88 +3,43 @@
 import { Button } from "@chakra-ui/react";
 import { CheckIcon, SquaresFourIcon } from "@phosphor-icons/react";
 
-import { toaster } from "@/app/components/ui/toaster";
-import useAuthStore from "@/app/store/authStore";
-import useViewContextStore from "@/app/store/viewContextStore";
-import {
-  useAddInsightWidget,
-  useDashboard,
-  useDeleteWidget,
-} from "./dashboardQueries";
+import { useAddInsightToDashboard } from "./useAddInsightToDashboard";
 
 /**
- * Chat-side "Add to dashboard" toggle (per the MVP handoff: a plain REST
- * widget add/remove with the analysis's persisted insight id — no chat round
- * trip). The target dashboard comes from the ambient view context, so the
- * toggle renders only while the user is on a dashboard page they own; on
- * other surfaces it renders nothing. Toggle state derives from the dashboard
- * detail cache — all charts of one analysis share the insight, so one toggle
- * adds/removes the whole analysis.
+ * Chat-side "Add to dashboard" toggle. The target dashboard, ownership check,
+ * toggle state and add/remove behaviour all come from
+ * `useAddInsightToDashboard`; this component only renders the button, and only
+ * when the analysis is actually addable (a dashboard the viewer owns).
  */
 export default function AddToDashboardToggle({
   insightId,
 }: {
   insightId: string;
 }) {
-  const viewContext = useViewContextStore((s) => s.viewContext);
-  const dashboardId =
-    viewContext?.page === "dashboard" ? viewContext.dashboard_id : "";
-  const userId = useAuthStore((s) => s.userId);
-  // Disabled (and dataless) when dashboardId is "" — off dashboard surfaces
-  // the hook never fetches and the component renders nothing.
-  const { data: dashboard } = useDashboard(dashboardId);
-  const addWidget = useAddInsightWidget(dashboardId);
-  const deleteWidget = useDeleteWidget(dashboardId);
+  const { addable, added, pending, toggle } =
+    useAddInsightToDashboard(insightId);
 
-  if (!dashboard || !userId || userId !== dashboard.user_id) return null;
-
-  const existing = dashboard.widgets.find((w) => w.insight_id === insightId);
-  const pending = addWidget.isPending || deleteWidget.isPending;
-
-  const onToggle = () => {
-    if (pending) return;
-    if (existing) {
-      deleteWidget.mutate(existing.id, {
-        onError: () =>
-          toaster.create({
-            title: "Couldn't remove from dashboard",
-            description: "The widget wasn't removed. Please try again.",
-            type: "error",
-            duration: 4000,
-          }),
-      });
-    } else {
-      addWidget.mutate(insightId, {
-        onError: () =>
-          toaster.create({
-            title: "Couldn't add to dashboard",
-            description: "The analysis wasn't added. Please try again.",
-            type: "error",
-            duration: 4000,
-          }),
-      });
-    }
-  };
+  if (!addable) return null;
 
   return (
     <Button
       size="xs"
-      variant={existing ? "solid" : "outline"}
-      colorPalette={existing ? "primary" : undefined}
-      onClick={onToggle}
+      variant={added ? "solid" : "outline"}
+      colorPalette={added ? "primary" : undefined}
+      onClick={toggle}
       h={6}
       rounded="sm"
-      color={existing ? undefined : "neutral.500"}
+      color={added ? undefined : "neutral.500"}
       loading={pending}
-      aria-pressed={!!existing}
+      aria-pressed={added}
       title={
-        existing
+        added
           ? "Remove this analysis from the dashboard"
           : "Add this analysis to the dashboard"
       }
     >
-      {existing ? <CheckIcon size={12} /> : <SquaresFourIcon size={12} />}
-      {existing ? "On dashboard" : "Add to dashboard"}
+      {added ? <CheckIcon size={12} /> : <SquaresFourIcon size={12} />}
+      {added ? "On dashboard" : "Add to dashboard"}
     </Button>
   );
 }

--- a/src/features/dashboards/ui/DashboardWidgetCard.tsx
+++ b/src/features/dashboards/ui/DashboardWidgetCard.tsx
@@ -293,12 +293,14 @@ export default function DashboardWidgetCard({
           <Dialog.Positioner>
             <Dialog.Content>
               <Dialog.Header>
-                <Dialog.Title>Remove widget?</Dialog.Title>
+                <Dialog.Title>
+                  {chartCount > 1 ? "Remove chart?" : "Remove widget?"}
+                </Dialog.Title>
               </Dialog.Header>
               <Dialog.Body>
                 <Text>
                   {chartCount > 1
-                    ? `This analysis has ${chartCount} charts shown as separate cards — removing it removes all of them. The underlying analysis is not deleted.`
+                    ? "Only this chart is removed from the dashboard — the analysis's other charts stay, and the underlying analysis is not deleted."
                     : "The widget will be removed from this dashboard. The underlying analysis is not deleted."}
                 </Text>
               </Dialog.Body>

--- a/src/features/dashboards/ui/DashboardWidgetsGrid.tsx
+++ b/src/features/dashboards/ui/DashboardWidgetsGrid.tsx
@@ -12,6 +12,7 @@ import {
   dashboardWidgetToInsightWidgets,
   widgetSize,
   widgetText,
+  withChartHidden,
   withChartSize,
   withChartTitle,
   withSize,
@@ -301,7 +302,31 @@ export default function DashboardWidgetsGrid({
                           },
                         })
                 }
-                onRemove={() => deleteWidget.mutate(widget.id)}
+                onRemove={() => {
+                  // A chart card hides just its chart from the widget's shown
+                  // set; the widget is deleted only when its last chart goes
+                  // (or for placeholder cells that have no chart id).
+                  const chartId = card?.id;
+                  const charts = widget.insight?.charts;
+                  if (!chartId || !charts) {
+                    deleteWidget.mutate(widget.id);
+                    return;
+                  }
+                  const allChartIds = [...charts]
+                    .sort((a, b) => a.position - b.position)
+                    .map((c) => c.id);
+                  const next = withChartHidden(
+                    widget.config,
+                    chartId,
+                    allChartIds
+                  );
+                  if (next === null) deleteWidget.mutate(widget.id);
+                  else
+                    updateWidget.mutate({
+                      widgetId: widget.id,
+                      patch: { config: next },
+                    });
+                }}
               />
             )}
           </GridItem>

--- a/src/features/dashboards/ui/__tests__/useAddChartToDashboard.test.tsx
+++ b/src/features/dashboards/ui/__tests__/useAddChartToDashboard.test.tsx
@@ -1,0 +1,176 @@
+// @vitest-environment happy-dom
+import type { ReactNode } from "react";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/app/components/ui/toaster", () => ({
+  toaster: { create: vi.fn() },
+  Toaster: () => null,
+}));
+
+vi.mock("../../api/dashboards", async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  getDashboard: vi.fn(() => new Promise(() => {})),
+  addInsightWidget: vi.fn().mockResolvedValue(undefined),
+  updateWidget: vi.fn().mockResolvedValue(undefined),
+  deleteWidget: vi.fn().mockResolvedValue(undefined),
+}));
+
+import {
+  addInsightWidget,
+  deleteWidget,
+  updateWidget,
+} from "../../api/dashboards";
+import { dashboardKeys } from "../dashboardQueries";
+import { useAddChartToDashboard } from "../useAddChartToDashboard";
+import type { Dashboard } from "../../api/schemas";
+import useAuthStore from "@/app/store/authStore";
+import useViewContextStore from "@/app/store/viewContextStore";
+
+function chart(id: string, position: number) {
+  return {
+    id,
+    position,
+    title: id,
+    chart_type: "bar",
+    x_axis: "year",
+    y_axis: "loss_ha",
+    series_fields: null,
+    chart_data: [],
+  };
+}
+
+/** A dashboard whose single insight widget ("ins-1") shows the given chart set
+ *  (config.chartIds; omit for all). The insight has three charts (c-a, c-b, c-c)
+ *  so a two-chart subset stays explicit rather than collapsing to "all". */
+function dashboardWith(chartIds?: string[]): Dashboard {
+  return {
+    id: "d1",
+    user_id: "u1",
+    name: "Pará",
+    description: null,
+    is_public: false,
+    created_at: "2026-07-01T00:00:00Z",
+    updated_at: "2026-07-01T00:00:00Z",
+    aois: [],
+    widgets: [
+      {
+        id: "w-1",
+        position: 0,
+        widget_type: "insight",
+        insight_id: "ins-1",
+        config: chartIds ? { chartIds } : {},
+        created_at: "2026-07-01T00:00:00Z",
+        insight: {
+          id: "ins-1",
+          insight_text: "",
+          codeact_parts: null,
+          charts: [chart("c-a", 0), chart("c-b", 1), chart("c-c", 2)],
+        },
+      },
+    ],
+  };
+}
+
+function makeWrapper(seed: Dashboard) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  queryClient.setQueryData(dashboardKeys.detail(seed.id), seed);
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  };
+}
+
+describe("useAddChartToDashboard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useAuthStore.setState({ userId: "u1" });
+    useViewContextStore
+      .getState()
+      .setViewContext({ page: "dashboard", dashboard_id: "d1" });
+  });
+
+  it("adds the first chart of an analysis as a new widget carrying config.chartIds", async () => {
+    const { result } = renderHook(
+      () => useAddChartToDashboard("ins-new", "c-x"),
+      { wrapper: makeWrapper(dashboardWith()) }
+    );
+
+    expect(result.current.shown).toBe(false);
+    act(() => result.current.toggle());
+
+    await waitFor(() =>
+      expect(addInsightWidget).toHaveBeenCalledWith("d1", "ins-new", {
+        chartIds: ["c-x"],
+      })
+    );
+  });
+
+  it("adds a second chart by patching the widget's config", async () => {
+    const { result } = renderHook(
+      () => useAddChartToDashboard("ins-1", "c-b"),
+      {
+        wrapper: makeWrapper(dashboardWith(["c-a"])),
+      }
+    );
+
+    expect(result.current.shown).toBe(false);
+    act(() => result.current.toggle());
+
+    await waitFor(() =>
+      expect(updateWidget).toHaveBeenCalledWith("d1", "w-1", {
+        config: { chartIds: ["c-a", "c-b"] },
+      })
+    );
+  });
+
+  it("hides a shown chart by patching config (not the last one)", async () => {
+    const { result } = renderHook(
+      () => useAddChartToDashboard("ins-1", "c-a"),
+      {
+        wrapper: makeWrapper(dashboardWith(["c-a", "c-b"])),
+      }
+    );
+
+    expect(result.current.shown).toBe(true);
+    act(() => result.current.toggle());
+
+    await waitFor(() =>
+      expect(updateWidget).toHaveBeenCalledWith("d1", "w-1", {
+        config: { chartIds: ["c-b"] },
+      })
+    );
+    expect(deleteWidget).not.toHaveBeenCalled();
+  });
+
+  it("deletes the widget when its last shown chart is hidden", async () => {
+    const { result } = renderHook(
+      () => useAddChartToDashboard("ins-1", "c-a"),
+      {
+        wrapper: makeWrapper(dashboardWith(["c-a"])),
+      }
+    );
+
+    expect(result.current.shown).toBe(true);
+    act(() => result.current.toggle());
+
+    await waitFor(() => expect(deleteWidget).toHaveBeenCalledWith("d1", "w-1"));
+    expect(updateWidget).not.toHaveBeenCalled();
+  });
+
+  it("is not addable off a dashboard or without ids", () => {
+    useViewContextStore.getState().setViewContext({ page: "map" });
+    const { result } = renderHook(
+      () => useAddChartToDashboard("ins-1", "c-a"),
+      {
+        wrapper: makeWrapper(dashboardWith(["c-a"])),
+      }
+    );
+    expect(result.current.active).toBe(false);
+    expect(result.current.addable).toBe(false);
+  });
+});

--- a/src/features/dashboards/ui/__tests__/useAddInsightToDashboard.test.tsx
+++ b/src/features/dashboards/ui/__tests__/useAddInsightToDashboard.test.tsx
@@ -1,0 +1,132 @@
+// @vitest-environment happy-dom
+import type { ReactNode } from "react";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/app/components/ui/toaster", () => ({
+  toaster: { create: vi.fn() },
+  Toaster: () => null,
+}));
+
+// Keep the detail query off the network (we seed the cache instead), and spy on
+// the widget add/remove calls.
+vi.mock("../../api/dashboards", async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  getDashboard: vi.fn(() => new Promise(() => {})),
+  addInsightWidget: vi.fn().mockResolvedValue(undefined),
+  deleteWidget: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { addInsightWidget, deleteWidget } from "../../api/dashboards";
+import { dashboardKeys } from "../dashboardQueries";
+import { useAddInsightToDashboard } from "../useAddInsightToDashboard";
+import type { Dashboard } from "../../api/schemas";
+import useAuthStore from "@/app/store/authStore";
+import useViewContextStore from "@/app/store/viewContextStore";
+
+const dashboard: Dashboard = {
+  id: "d1",
+  user_id: "u1",
+  name: "Pará forest watch",
+  description: null,
+  is_public: false,
+  created_at: "2026-07-01T00:00:00Z",
+  updated_at: "2026-07-01T00:00:00Z",
+  aois: [],
+  widgets: [
+    {
+      id: "w-existing",
+      position: 0,
+      widget_type: "insight",
+      insight_id: "already-added",
+      config: {},
+      created_at: "2026-07-01T00:00:00Z",
+      insight: null,
+    },
+  ],
+};
+
+function makeWrapper(seed: Dashboard | null) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  if (seed) {
+    queryClient.setQueryData(dashboardKeys.detail(seed.id), seed);
+  }
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  };
+}
+
+describe("useAddInsightToDashboard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useAuthStore.setState({ userId: "u1" });
+    useViewContextStore
+      .getState()
+      .setViewContext({ page: "dashboard", dashboard_id: "d1" });
+  });
+
+  it("is inactive off a dashboard surface", () => {
+    useViewContextStore.getState().setViewContext({ page: "map" });
+    const { result } = renderHook(() => useAddInsightToDashboard("ins-1"), {
+      wrapper: makeWrapper(dashboard),
+    });
+    expect(result.current.active).toBe(false);
+    expect(result.current.addable).toBe(false);
+  });
+
+  it("adds a new insight as a widget", async () => {
+    const { result } = renderHook(() => useAddInsightToDashboard("ins-new"), {
+      wrapper: makeWrapper(dashboard),
+    });
+
+    expect(result.current.addable).toBe(true);
+    expect(result.current.added).toBe(false);
+
+    act(() => result.current.toggle());
+
+    await waitFor(() =>
+      expect(addInsightWidget).toHaveBeenCalledWith("d1", "ins-new")
+    );
+    expect(deleteWidget).not.toHaveBeenCalled();
+  });
+
+  it("removes the insight's widget when it is already on the dashboard", async () => {
+    const { result } = renderHook(
+      () => useAddInsightToDashboard("already-added"),
+      { wrapper: makeWrapper(dashboard) }
+    );
+
+    expect(result.current.added).toBe(true);
+
+    act(() => result.current.toggle());
+
+    await waitFor(() =>
+      expect(deleteWidget).toHaveBeenCalledWith("d1", "w-existing")
+    );
+    expect(addInsightWidget).not.toHaveBeenCalled();
+  });
+
+  it("is not addable without a real insight id", () => {
+    const { result } = renderHook(() => useAddInsightToDashboard(undefined), {
+      wrapper: makeWrapper(dashboard),
+    });
+    expect(result.current.active).toBe(true);
+    expect(result.current.addable).toBe(false);
+
+    act(() => result.current.toggle());
+    expect(addInsightWidget).not.toHaveBeenCalled();
+  });
+
+  it("is not addable on a dashboard the viewer does not own", () => {
+    useAuthStore.setState({ userId: "someone-else" });
+    const { result } = renderHook(() => useAddInsightToDashboard("ins-1"), {
+      wrapper: makeWrapper(dashboard),
+    });
+    expect(result.current.addable).toBe(false);
+  });
+});

--- a/src/features/dashboards/ui/__tests__/useAddInsightToDashboard.test.tsx
+++ b/src/features/dashboards/ui/__tests__/useAddInsightToDashboard.test.tsx
@@ -95,6 +95,22 @@ describe("useAddInsightToDashboard", () => {
     expect(deleteWidget).not.toHaveBeenCalled();
   });
 
+  it("ignores a second add while the first is still settling (no duplicate widget)", async () => {
+    const { result } = renderHook(() => useAddInsightToDashboard("ins-new"), {
+      wrapper: makeWrapper(dashboard),
+    });
+
+    act(() => result.current.toggle());
+    await waitFor(() => expect(addInsightWidget).toHaveBeenCalledTimes(1));
+
+    // The POST has resolved, but the detail refetch (mocked to hang) has not,
+    // so the mutation must stay pending and a fast second click is a no-op —
+    // otherwise it would re-POST and create a duplicate widget.
+    expect(result.current.pending).toBe(true);
+    act(() => result.current.toggle());
+    expect(addInsightWidget).toHaveBeenCalledTimes(1);
+  });
+
   it("removes the insight's widget when it is already on the dashboard", async () => {
     const { result } = renderHook(
       () => useAddInsightToDashboard("already-added"),

--- a/src/features/dashboards/ui/__tests__/useAddInsightToDashboard.test.tsx
+++ b/src/features/dashboards/ui/__tests__/useAddInsightToDashboard.test.tsx
@@ -90,7 +90,7 @@ describe("useAddInsightToDashboard", () => {
     act(() => result.current.toggle());
 
     await waitFor(() =>
-      expect(addInsightWidget).toHaveBeenCalledWith("d1", "ins-new")
+      expect(addInsightWidget).toHaveBeenCalledWith("d1", "ins-new", undefined)
     );
     expect(deleteWidget).not.toHaveBeenCalled();
   });

--- a/src/features/dashboards/ui/dashboardQueries.ts
+++ b/src/features/dashboards/ui/dashboardQueries.ts
@@ -184,11 +184,15 @@ export function useAddInsightWidget(dashboardId: string) {
 
   return useMutation({
     mutationFn: (insightId: string) => addInsightWidget(dashboardId, insightId),
-    onSettled: () => {
+    // Return the invalidation promise so the mutation stays `pending` until the
+    // detail refetch lands. This add is not optimistic — `added` only flips once
+    // the refetch reflects the new widget — so without this the button/switch
+    // re-enables the instant the POST resolves, and a fast second click would
+    // re-POST the same insight and create a duplicate widget.
+    onSettled: () =>
       queryClient.invalidateQueries({
         queryKey: dashboardKeys.detail(dashboardId),
-      });
-    },
+      }),
   });
 }
 

--- a/src/features/dashboards/ui/dashboardQueries.ts
+++ b/src/features/dashboards/ui/dashboardQueries.ts
@@ -183,7 +183,13 @@ export function useAddInsightWidget(dashboardId: string) {
   const queryClient = useQueryClient();
 
   return useMutation({
-    mutationFn: (insightId: string) => addInsightWidget(dashboardId, insightId),
+    mutationFn: ({
+      insightId,
+      config,
+    }: {
+      insightId: string;
+      config?: Record<string, unknown>;
+    }) => addInsightWidget(dashboardId, insightId, config),
     // Return the invalidation promise so the mutation stays `pending` until the
     // detail refetch lands. This add is not optimistic — `added` only flips once
     // the refetch reflects the new widget — so without this the button/switch

--- a/src/features/dashboards/ui/useAddChartToDashboard.ts
+++ b/src/features/dashboards/ui/useAddChartToDashboard.ts
@@ -1,0 +1,114 @@
+"use client";
+
+import { toaster } from "@/app/components/ui/toaster";
+import useAuthStore from "@/app/store/authStore";
+import useViewContextStore from "@/app/store/viewContextStore";
+import { isChartShown, withChartHidden, withChartShown } from "../lib/widgets";
+import {
+  useAddInsightWidget,
+  useDashboard,
+  useDeleteWidget,
+  useUpdateWidget,
+} from "./dashboardQueries";
+
+export interface AddChartToDashboard {
+  /** True while the viewer is on a dashboard page (add/remove semantics apply). */
+  active: boolean;
+  /** True when this chart can be added: an owned dashboard + real insight/chart ids. */
+  addable: boolean;
+  /** True when this chart is currently shown by the insight's widget. */
+  shown: boolean;
+  pending: boolean;
+  /** Adds the chart if hidden, hides it if shown. No-op unless `addable`. */
+  toggle: () => void;
+}
+
+/**
+ * Adds or removes a single chart of an analysis on the current dashboard,
+ * tracked in the insight widget's `config.chartIds` (the shown subset). One
+ * insight still maps to one widget — this hook just edits which of its charts
+ * that widget renders:
+ *
+ * - no widget yet → POST a widget carrying `config.chartIds: [chartId]`
+ * - widget exists, chart hidden → PATCH config to add the chart
+ * - widget exists, chart shown → PATCH config to drop it, or DELETE the widget
+ *   when it was the last shown chart
+ *
+ * Sibling of `useAddInsightToDashboard` (whole-analysis add, used by the
+ * chat-side toggle); this is the per-chart control used by the Analyses pane.
+ */
+export function useAddChartToDashboard(
+  insightId?: string,
+  chartId?: string
+): AddChartToDashboard {
+  const viewContext = useViewContextStore((s) => s.viewContext);
+  const dashboardId =
+    viewContext?.page === "dashboard" ? viewContext.dashboard_id : "";
+  const userId = useAuthStore((s) => s.userId);
+  const { data: dashboard } = useDashboard(dashboardId);
+  const addWidget = useAddInsightWidget(dashboardId);
+  const updateWidget = useUpdateWidget(dashboardId);
+  const deleteWidget = useDeleteWidget(dashboardId);
+
+  const active = dashboardId.length > 0;
+  const isOwner = !!userId && !!dashboard && userId === dashboard.user_id;
+  const addable = active && isOwner && !!insightId && !!chartId;
+
+  const widget = insightId
+    ? dashboard?.widgets.find((w) => w.insight_id === insightId)
+    : undefined;
+  const allChartIds = widget?.insight?.charts
+    ? [...widget.insight.charts]
+        .sort((a, b) => a.position - b.position)
+        .map((c) => c.id)
+    : [];
+  const shown =
+    !!widget && !!chartId && isChartShown(widget.config, chartId, allChartIds);
+  const pending =
+    addWidget.isPending || updateWidget.isPending || deleteWidget.isPending;
+
+  const errorToast = (adding: boolean) => () =>
+    toaster.create({
+      title: adding
+        ? "Couldn't add to dashboard"
+        : "Couldn't remove from dashboard",
+      description: `The chart wasn't ${adding ? "added" : "removed"}. Please try again.`,
+      type: "error",
+      duration: 4000,
+    });
+
+  const toggle = () => {
+    if (!addable || pending || !insightId || !chartId) return;
+
+    if (!widget) {
+      addWidget.mutate(
+        { insightId, config: { chartIds: [chartId] } },
+        { onError: errorToast(true) }
+      );
+      return;
+    }
+
+    if (shown) {
+      const next = withChartHidden(widget.config, chartId, allChartIds);
+      if (next === null) {
+        deleteWidget.mutate(widget.id, { onError: errorToast(false) });
+      } else {
+        updateWidget.mutate(
+          { widgetId: widget.id, patch: { config: next } },
+          { onError: errorToast(false) }
+        );
+      }
+      return;
+    }
+
+    updateWidget.mutate(
+      {
+        widgetId: widget.id,
+        patch: { config: withChartShown(widget.config, chartId, allChartIds) },
+      },
+      { onError: errorToast(true) }
+    );
+  };
+
+  return { active, addable, shown, pending, toggle };
+}

--- a/src/features/dashboards/ui/useAddInsightToDashboard.ts
+++ b/src/features/dashboards/ui/useAddInsightToDashboard.ts
@@ -1,0 +1,84 @@
+"use client";
+
+import { toaster } from "@/app/components/ui/toaster";
+import useAuthStore from "@/app/store/authStore";
+import useViewContextStore from "@/app/store/viewContextStore";
+import {
+  useAddInsightWidget,
+  useDashboard,
+  useDeleteWidget,
+} from "./dashboardQueries";
+
+export interface AddInsightToDashboard {
+  /** True while the viewer is on a dashboard page (add/remove semantics apply). */
+  active: boolean;
+  /**
+   * True when this insight can actually be added: a dashboard the viewer owns,
+   * with a real persisted insight id. False for other people's dashboards and
+   * for insights that have no backend id (verified fixtures, unsaved in-session
+   * analyses).
+   */
+  addable: boolean;
+  /** True when the insight is already a widget on the current dashboard. */
+  added: boolean;
+  pending: boolean;
+  /** Adds the insight if absent, removes it if present. No-op unless `addable`. */
+  toggle: () => void;
+}
+
+/**
+ * Shared "add this analysis to the current dashboard" behaviour, driven by the
+ * ambient view context (no chat round trip — a plain REST widget add/remove
+ * with the analysis's persisted insight id). Backs both the chat-side
+ * `AddToDashboardToggle` and the Analyses pane's per-card add control. All
+ * charts of one analysis share the insight, so one toggle adds/removes the
+ * whole analysis.
+ */
+export function useAddInsightToDashboard(
+  insightId?: string
+): AddInsightToDashboard {
+  const viewContext = useViewContextStore((s) => s.viewContext);
+  const dashboardId =
+    viewContext?.page === "dashboard" ? viewContext.dashboard_id : "";
+  const userId = useAuthStore((s) => s.userId);
+  // Disabled (and dataless) when dashboardId is "" — off dashboard surfaces the
+  // hook never fetches.
+  const { data: dashboard } = useDashboard(dashboardId);
+  const addWidget = useAddInsightWidget(dashboardId);
+  const deleteWidget = useDeleteWidget(dashboardId);
+
+  const active = dashboardId.length > 0;
+  const isOwner = !!userId && !!dashboard && userId === dashboard.user_id;
+  const addable = active && isOwner && !!insightId;
+  const existing = insightId
+    ? dashboard?.widgets.find((w) => w.insight_id === insightId)
+    : undefined;
+  const pending = addWidget.isPending || deleteWidget.isPending;
+
+  const toggle = () => {
+    if (!addable || pending || !insightId) return;
+    if (existing) {
+      deleteWidget.mutate(existing.id, {
+        onError: () =>
+          toaster.create({
+            title: "Couldn't remove from dashboard",
+            description: "The widget wasn't removed. Please try again.",
+            type: "error",
+            duration: 4000,
+          }),
+      });
+    } else {
+      addWidget.mutate(insightId, {
+        onError: () =>
+          toaster.create({
+            title: "Couldn't add to dashboard",
+            description: "The analysis wasn't added. Please try again.",
+            type: "error",
+            duration: 4000,
+          }),
+      });
+    }
+  };
+
+  return { active, addable, added: !!existing, pending, toggle };
+}

--- a/src/features/dashboards/ui/useAddInsightToDashboard.ts
+++ b/src/features/dashboards/ui/useAddInsightToDashboard.ts
@@ -68,15 +68,18 @@ export function useAddInsightToDashboard(
           }),
       });
     } else {
-      addWidget.mutate(insightId, {
-        onError: () =>
-          toaster.create({
-            title: "Couldn't add to dashboard",
-            description: "The analysis wasn't added. Please try again.",
-            type: "error",
-            duration: 4000,
-          }),
-      });
+      addWidget.mutate(
+        { insightId },
+        {
+          onError: () =>
+            toaster.create({
+              title: "Couldn't add to dashboard",
+              description: "The analysis wasn't added. Please try again.",
+              type: "error",
+              duration: 4000,
+            }),
+        }
+      );
     }
   };
 

--- a/src/features/dashboards/ui/useCurrentDashboardArea.ts
+++ b/src/features/dashboards/ui/useCurrentDashboardArea.ts
@@ -1,0 +1,25 @@
+"use client";
+
+import useViewContextStore from "@/app/store/viewContextStore";
+import { useDashboard } from "./dashboardQueries";
+
+/** The current dashboard's AOI as the (source, src_id) pair the insights list
+ *  scopes by. Null off a dashboard, or before the detail query resolves. */
+export interface CurrentDashboardArea {
+  aoiSource: string;
+  aoiId: string;
+}
+
+/**
+ * The AOI of the dashboard the viewer is currently on. A dashboard is scoped to
+ * exactly one AOI, so the Analyses pane uses this to filter analyses to "this
+ * area" without knowing anything about how dashboards are fetched.
+ */
+export function useCurrentDashboardArea(): CurrentDashboardArea | null {
+  const viewContext = useViewContextStore((s) => s.viewContext);
+  const dashboardId =
+    viewContext?.page === "dashboard" ? viewContext.dashboard_id : "";
+  const { data: dashboard } = useDashboard(dashboardId);
+  const aoi = dashboard?.aois[0];
+  return aoi ? { aoiSource: aoi.source, aoiId: aoi.src_id } : null;
+}

--- a/src/features/insights-history/api/__tests__/rest-insights-gateway.test.ts
+++ b/src/features/insights-history/api/__tests__/rest-insights-gateway.test.ts
@@ -52,16 +52,34 @@ describe("RestInsightsGateway.list", () => {
 
   it("appends ?thread_id when a thread is given", async () => {
     const fetch = mockFetch([]);
-    await new RestInsightsGateway(fetch).list("t 1");
+    await new RestInsightsGateway(fetch).list({ threadId: "t 1" });
     expect(fetch).toHaveBeenCalledWith(
-      "/api/insights?thread_id=t%201",
+      "/api/insights?thread_id=t+1",
       expect.anything()
     );
   });
 
-  it("omits the query when threadId is null (unfiltered)", async () => {
+  it("appends aoi_source + aoi_id together when scoped to an area", async () => {
     const fetch = mockFetch([]);
-    await new RestInsightsGateway(fetch).list(null);
+    await new RestInsightsGateway(fetch).list({
+      aoiSource: "gadm",
+      aoiId: "BRA.1_1",
+    });
+    expect(fetch).toHaveBeenCalledWith(
+      "/api/insights?aoi_source=gadm&aoi_id=BRA.1_1",
+      expect.anything()
+    );
+  });
+
+  it("omits an AOI param unless both source and id are present", async () => {
+    const fetch = mockFetch([]);
+    await new RestInsightsGateway(fetch).list({ aoiSource: "gadm" });
+    expect(fetch).toHaveBeenCalledWith("/api/insights", expect.anything());
+  });
+
+  it("omits the query when unfiltered", async () => {
+    const fetch = mockFetch([]);
+    await new RestInsightsGateway(fetch).list({ threadId: null });
     expect(fetch).toHaveBeenCalledWith("/api/insights", expect.anything());
   });
 

--- a/src/features/insights-history/api/rest-insights-gateway.ts
+++ b/src/features/insights-history/api/rest-insights-gateway.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import { apiFetch } from "@/app/lib/api-client";
 import type { Chart, InsightRecord } from "@/src/entities/insight";
-import type { InsightsGateway } from "../model/insights-gateway";
+import type { InsightQuery, InsightsGateway } from "../model/insights-gateway";
 
 // ── Raw API shapes (anti-corruption layer — never leave this file) ─────────────
 // Tolerant by design: chart fields default so a sparse row still parses; only a
@@ -69,11 +69,21 @@ export class RestInsightsGateway implements InsightsGateway {
   constructor(private readonly fetch: FetchFn = apiFetch) {}
 
   async list(
-    threadId?: string | null,
+    query?: InsightQuery,
     signal?: AbortSignal
   ): Promise<InsightRecord[]> {
-    const query = threadId ? `?thread_id=${encodeURIComponent(threadId)}` : "";
-    const response = await this.fetch(`/api/insights${query}`, { signal });
+    const params = new URLSearchParams();
+    if (query?.threadId) params.set("thread_id", query.threadId);
+    // aoi_source + aoi_id are only meaningful as a pair — the backend 400s on
+    // one without the other, so send them only when both are present.
+    if (query?.aoiSource && query?.aoiId) {
+      params.set("aoi_source", query.aoiSource);
+      params.set("aoi_id", query.aoiId);
+    }
+    const qs = params.toString();
+    const response = await this.fetch(`/api/insights${qs ? `?${qs}` : ""}`, {
+      signal,
+    });
 
     // Unauthenticated → empty list (the panel renders a signed-out empty state).
     if (response.status === 401) return [];

--- a/src/features/insights-history/model/insights-gateway.ts
+++ b/src/features/insights-history/model/insights-gateway.ts
@@ -1,18 +1,30 @@
 import type { InsightRecord } from "@/src/entities/insight";
 
 /**
+ * Optional server-side filters for a insights list request. All omitted →
+ * every insight the user owns.
+ */
+export interface InsightQuery {
+  /** Scope to one conversation. */
+  threadId?: string | null;
+  /**
+   * Scope to insights derived from one AOI. `aoiSource` and `aoiId` are the
+   * (source, src_id) pair and must be supplied **together** — the backend
+   * rejects one without the other (src_id is only unique per source).
+   */
+  aoiSource?: string;
+  aoiId?: string;
+}
+
+/**
  * Driven port for reading the user's stored insights. The only seam the browse
  * feature uses to reach the backend; all transport knowledge lives in the
  * adapter (`api/`).
  */
 export interface InsightsGateway {
   /**
-   * Lists the authenticated user's insights, newest-first. A `threadId` scopes
-   * the result to one conversation; `null`/`undefined` returns everything.
-   * Resolves to `[]` when unauthenticated.
+   * Lists the authenticated user's insights, newest-first, optionally scoped by
+   * `query`. Resolves to `[]` when unauthenticated.
    */
-  list(
-    threadId?: string | null,
-    signal?: AbortSignal
-  ): Promise<InsightRecord[]>;
+  list(query?: InsightQuery, signal?: AbortSignal): Promise<InsightRecord[]>;
 }

--- a/src/features/insights-history/ui/__tests__/use-user-insights.test.tsx
+++ b/src/features/insights-history/ui/__tests__/use-user-insights.test.tsx
@@ -35,12 +35,22 @@ describe("useUserInsights", () => {
     expect(result.current.insights[0].id).toBe("ins-1");
   });
 
-  it("passes the threadId to the gateway", async () => {
+  it("passes the thread and area scope to the gateway", async () => {
     const gateway: InsightsGateway = { list: vi.fn().mockResolvedValue([]) };
-    renderHook(() => useUserInsights("thread-9", gateway), { wrapper });
+    renderHook(
+      () =>
+        useUserInsights(
+          { threadId: "thread-9", aoiSource: "gadm", aoiId: "BRA.1_1" },
+          gateway
+        ),
+      { wrapper }
+    );
 
     await waitFor(() =>
-      expect(gateway.list).toHaveBeenCalledWith("thread-9", expect.anything())
+      expect(gateway.list).toHaveBeenCalledWith(
+        { threadId: "thread-9", aoiSource: "gadm", aoiId: "BRA.1_1" },
+        expect.anything()
+      )
     );
   });
 });

--- a/src/features/insights-history/ui/insights-panel.tsx
+++ b/src/features/insights-history/ui/insights-panel.tsx
@@ -39,7 +39,7 @@ import {
 // the dashboards pages into its bundle, and so mounting the pane on a dashboard
 // can't create a feature import cycle — matching how the app already reaches
 // dashboards/ui (e.g. WidgetMessage → AddToDashboardToggle).
-import { useAddInsightToDashboard } from "@/src/features/dashboards/ui/useAddInsightToDashboard";
+import { useAddChartToDashboard } from "@/src/features/dashboards/ui/useAddChartToDashboard";
 import { useCurrentDashboardArea } from "@/src/features/dashboards/ui/useCurrentDashboardArea";
 import { useUserInsights } from "./use-user-insights";
 import { verifiedInsights } from "../lib/verified-fixtures";
@@ -91,15 +91,10 @@ interface InsightCardItem {
   createdAt: string;
   verification: InsightVerification;
   /**
-   * The parent insight's id — the grouping key that folds an analysis's many
-   * charts into one card on the dashboard. Undefined for unsaved in-session
-   * analyses (each live widget stands alone).
-   */
-  recordId?: string;
-  /**
-   * The parent insight's backend id — what "Add to dashboard" posts. Present
-   * only for real, persisted AI insights; undefined for verified fixtures and
-   * unsaved in-session analyses, which can't be added to a dashboard by id.
+   * The parent insight's backend id — the analysis a chart belongs to, used to
+   * find (or create) that analysis's dashboard widget when adding this chart.
+   * Present only for real, persisted AI insights; undefined for verified
+   * fixtures and unsaved in-session analyses, which can't be added by id.
    */
   addableInsightId?: string;
 }
@@ -115,7 +110,6 @@ function recordToItems(record: InsightRecord): InsightCardItem[] {
     source: record.source ?? "",
     createdAt: record.createdAt,
     verification: record.verification,
-    recordId: record.id,
     addableInsightId,
   }));
 }
@@ -143,26 +137,6 @@ function mergeById(...lists: InsightCardItem[][]): InsightCardItem[] {
       seen.add(id);
       out.push(item);
     }
-  }
-  return out;
-}
-
-/**
- * Folds an analysis's many charts into a single card, keeping the first chart
- * as the representative. Used on the dashboard, where the unit of action is the
- * whole insight (one "Add to dashboard" adds all its charts) — showing one card
- * per chart would make the charts of one analysis toggle together. Items with
- * no `recordId` (unsaved in-session widgets) fall back to their chart id, so
- * they are never merged with each other.
- */
-function collapseByRecord(items: InsightCardItem[]): InsightCardItem[] {
-  const seen = new Set<string>();
-  const out: InsightCardItem[] = [];
-  for (const item of items) {
-    const key = item.recordId ?? itemId(item);
-    if (seen.has(key)) continue;
-    seen.add(key);
-    out.push(item);
   }
   return out;
 }
@@ -361,9 +335,6 @@ function InsightsList({
 }) {
   const currentThreadId = useChatStore((s) => s.currentThreadId);
   const liveWidgets = useInsightStore(useShallow((s) => s.insights));
-  const isDashboard = useViewContextStore(
-    (s) => s.viewContext?.page === "dashboard"
-  );
   const dashboardArea = useCurrentDashboardArea();
   // On a dashboard, scope the AI list to its area (both aoi params travel
   // together). Off a dashboard, or when the "This area" toggle is off, the query
@@ -376,28 +347,17 @@ function InsightsList({
   });
   const { insights: allInsights } = useUserInsights(aiScope);
 
+  // One card per chart on every surface: the map shows each chart on the map,
+  // and the dashboard adds each chart to the grid independently (its widget's
+  // config.chartIds tracks which are shown).
   const items = useMemo<InsightCardItem[]>(() => {
-    const base =
-      filter === "verified"
-        ? verifiedInsights.flatMap(recordToItems)
-        : filter === "ai"
-          ? allInsights.flatMap(recordToItems)
-          : mergeById(
-              currentThreadId ? threadInsights.flatMap(recordToItems) : [],
-              liveWidgets.map(liveWidgetToItem)
-            );
-    // On a dashboard the unit of action is the whole analysis, so fold each
-    // insight's charts into one card; on the map each chart is its own
-    // (independently show-on-map-able) card.
-    return isDashboard ? collapseByRecord(base) : base;
-  }, [
-    filter,
-    allInsights,
-    threadInsights,
-    liveWidgets,
-    currentThreadId,
-    isDashboard,
-  ]);
+    if (filter === "verified") return verifiedInsights.flatMap(recordToItems);
+    if (filter === "ai") return allInsights.flatMap(recordToItems);
+    return mergeById(
+      currentThreadId ? threadInsights.flatMap(recordToItems) : [],
+      liveWidgets.map(liveWidgetToItem)
+    );
+  }, [filter, allInsights, threadInsights, liveWidgets, currentThreadId]);
 
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const selectedIndex = selectedId
@@ -457,13 +417,13 @@ function InsightCard({
   );
   const addInsight = useInsightStore((s) => s.addInsight);
   const removeInsight = useInsightStore((s) => s.removeInsight);
-  const dashboard = useAddInsightToDashboard(item.addableInsightId);
+  const chart = useAddChartToDashboard(item.addableInsightId, item.widget.id);
   const title = item.widget.title;
 
-  // On a dashboard the card's footer toggle adds/removes the analysis to the
-  // grid (show-on-map has no target there); elsewhere it drives the on-map
+  // On a dashboard the card's footer toggle adds/removes this chart to the grid
+  // (show-on-map has no target there); elsewhere it drives the on-map
   // InsightWorkspace overlay.
-  if (dashboard.active) {
+  if (chart.active) {
     return (
       <Box w={`${CATALOG_CARD_WIDTH_PX}px`} maxW="100%" flexShrink={0}>
         <CatalogCard
@@ -472,17 +432,17 @@ function InsightCard({
           typeLabelColor={INSIGHT_LABEL_COLOR}
           title={title}
           description={cardDescription(item)}
-          selected={dashboard.added}
+          selected={chart.shown}
           selectedBg={INSIGHT_SELECTED_BG}
-          showOnMap={dashboard.added}
-          onShowOnMapChange={() => dashboard.toggle()}
-          toggleLabel={dashboard.added ? "On dashboard" : "Add to dashboard"}
+          showOnMap={chart.shown}
+          onShowOnMapChange={() => chart.toggle()}
+          toggleLabel={chart.shown ? "On dashboard" : "Add to dashboard"}
           toggleAriaLabel={
-            dashboard.added
+            chart.shown
               ? `Remove ${title} from dashboard`
               : `Add ${title} to dashboard`
           }
-          toggleDisabled={!dashboard.addable || dashboard.pending}
+          toggleDisabled={!chart.addable || chart.pending}
           onInfoClick={onOpen}
           infoTooltip="View analysis"
           badge={<VerificationBadge verification={item.verification} />}

--- a/src/features/insights-history/ui/insights-panel.tsx
+++ b/src/features/insights-history/ui/insights-panel.tsx
@@ -91,6 +91,12 @@ interface InsightCardItem {
   createdAt: string;
   verification: InsightVerification;
   /**
+   * The parent insight's id — the grouping key that folds an analysis's many
+   * charts into one card on the dashboard. Undefined for unsaved in-session
+   * analyses (each live widget stands alone).
+   */
+  recordId?: string;
+  /**
    * The parent insight's backend id — what "Add to dashboard" posts. Present
    * only for real, persisted AI insights; undefined for verified fixtures and
    * unsaved in-session analyses, which can't be added to a dashboard by id.
@@ -109,6 +115,7 @@ function recordToItems(record: InsightRecord): InsightCardItem[] {
     source: record.source ?? "",
     createdAt: record.createdAt,
     verification: record.verification,
+    recordId: record.id,
     addableInsightId,
   }));
 }
@@ -136,6 +143,26 @@ function mergeById(...lists: InsightCardItem[][]): InsightCardItem[] {
       seen.add(id);
       out.push(item);
     }
+  }
+  return out;
+}
+
+/**
+ * Folds an analysis's many charts into a single card, keeping the first chart
+ * as the representative. Used on the dashboard, where the unit of action is the
+ * whole insight (one "Add to dashboard" adds all its charts) — showing one card
+ * per chart would make the charts of one analysis toggle together. Items with
+ * no `recordId` (unsaved in-session widgets) fall back to their chart id, so
+ * they are never merged with each other.
+ */
+function collapseByRecord(items: InsightCardItem[]): InsightCardItem[] {
+  const seen = new Set<string>();
+  const out: InsightCardItem[] = [];
+  for (const item of items) {
+    const key = item.recordId ?? itemId(item);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(item);
   }
   return out;
 }
@@ -334,6 +361,9 @@ function InsightsList({
 }) {
   const currentThreadId = useChatStore((s) => s.currentThreadId);
   const liveWidgets = useInsightStore(useShallow((s) => s.insights));
+  const isDashboard = useViewContextStore(
+    (s) => s.viewContext?.page === "dashboard"
+  );
   const dashboardArea = useCurrentDashboardArea();
   // On a dashboard, scope the AI list to its area (both aoi params travel
   // together). Off a dashboard, or when the "This area" toggle is off, the query
@@ -347,13 +377,27 @@ function InsightsList({
   const { insights: allInsights } = useUserInsights(aiScope);
 
   const items = useMemo<InsightCardItem[]>(() => {
-    if (filter === "verified") return verifiedInsights.flatMap(recordToItems);
-    if (filter === "ai") return allInsights.flatMap(recordToItems);
-    const historical = currentThreadId
-      ? threadInsights.flatMap(recordToItems)
-      : [];
-    return mergeById(historical, liveWidgets.map(liveWidgetToItem));
-  }, [filter, allInsights, threadInsights, liveWidgets, currentThreadId]);
+    const base =
+      filter === "verified"
+        ? verifiedInsights.flatMap(recordToItems)
+        : filter === "ai"
+          ? allInsights.flatMap(recordToItems)
+          : mergeById(
+              currentThreadId ? threadInsights.flatMap(recordToItems) : [],
+              liveWidgets.map(liveWidgetToItem)
+            );
+    // On a dashboard the unit of action is the whole analysis, so fold each
+    // insight's charts into one card; on the map each chart is its own
+    // (independently show-on-map-able) card.
+    return isDashboard ? collapseByRecord(base) : base;
+  }, [
+    filter,
+    allInsights,
+    threadInsights,
+    liveWidgets,
+    currentThreadId,
+    isDashboard,
+  ]);
 
   const [selectedId, setSelectedId] = useState<string | null>(null);
   const selectedIndex = selectedId

--- a/src/features/insights-history/ui/insights-panel.tsx
+++ b/src/features/insights-history/ui/insights-panel.tsx
@@ -6,9 +6,8 @@ import {
   Button,
   Flex,
   IconButton,
-  Menu,
-  Portal,
   Stack,
+  Switch,
   Text,
   Wrap,
 } from "@chakra-ui/react";
@@ -18,7 +17,6 @@ import {
   ArrowArcRightIcon,
   CaretLeftIcon,
   ChartLineIcon,
-  DotsThreeVerticalIcon,
   XIcon,
 } from "@phosphor-icons/react";
 import { format } from "date-fns";
@@ -37,11 +35,18 @@ import {
   type InsightRecord,
   type InsightVerification,
 } from "@/src/entities/insight";
+// Deep imports (not the feature barrel) so the map's InsightsPanel doesn't pull
+// the dashboards pages into its bundle, and so mounting the pane on a dashboard
+// can't create a feature import cycle — matching how the app already reaches
+// dashboards/ui (e.g. WidgetMessage → AddToDashboardToggle).
+import { useAddInsightToDashboard } from "@/src/features/dashboards/ui/useAddInsightToDashboard";
+import { useCurrentDashboardArea } from "@/src/features/dashboards/ui/useCurrentDashboardArea";
 import { useUserInsights } from "./use-user-insights";
 import { verifiedInsights } from "../lib/verified-fixtures";
 import useChatStore from "@/app/store/chatStore";
 import useInsightStore from "@/app/store/insightStore";
 import useSidebarStore from "@/app/store/sidebarStore";
+import useViewContextStore from "@/app/store/viewContextStore";
 import type { InsightWidget } from "@/app/types/chat";
 
 import { CatalogCard } from "@/app/components/CatalogCard";
@@ -85,15 +90,26 @@ interface InsightCardItem {
   source: string;
   createdAt: string;
   verification: InsightVerification;
+  /**
+   * The parent insight's backend id — what "Add to dashboard" posts. Present
+   * only for real, persisted AI insights; undefined for verified fixtures and
+   * unsaved in-session analyses, which can't be added to a dashboard by id.
+   */
+  addableInsightId?: string;
 }
 
 function recordToItems(record: InsightRecord): InsightCardItem[] {
   const curated = record.verification === "verified";
+  // Only real backend (ai-generated) insights have an id the dashboards API
+  // knows; verified fixtures are client-side stubs.
+  const addableInsightId =
+    record.verification === "ai-generated" ? record.id : undefined;
   return chartsToWidgets(record.charts).map((widget) => ({
     widget: { ...widget, curated },
     source: record.source ?? "",
     createdAt: record.createdAt,
     verification: record.verification,
+    addableInsightId,
   }));
 }
 
@@ -146,11 +162,18 @@ function cardDescription(item: InsightCardItem): string {
  */
 export function InsightsPanel() {
   const [filter, setFilter] = useState<InsightFilter>("conversation");
+  // On a dashboard the AI list scopes to the dashboard's area by default; the
+  // "This area" toggle broadens it to every AI analysis the user owns.
+  const [areaScoped, setAreaScoped] = useState(true);
   const { insightsPanelOpen, setInsightsPanelOpen, isChatFullSize } =
     useSidebarStore();
+  const isDashboard = useViewContextStore(
+    (s) => s.viewContext?.page === "dashboard"
+  );
 
   const leftPx = getCatalogLeftPx(isChatFullSize);
   const compactSlide = !isChatFullSize;
+  const showAreaToggle = isDashboard && filter === "ai";
 
   return (
     <AnimatePresence>
@@ -202,6 +225,32 @@ export function InsightsPanel() {
                   );
                 })}
               </Wrap>
+              {showAreaToggle && (
+                <Switch.Root
+                  size="sm"
+                  checked={areaScoped}
+                  onCheckedChange={(e: { checked: boolean }) =>
+                    setAreaScoped(e.checked)
+                  }
+                  colorPalette="primary"
+                  flexShrink={0}
+                  display="flex"
+                  alignItems="center"
+                  gap="8px"
+                >
+                  <Switch.HiddenInput />
+                  <Switch.Control>
+                    <Switch.Thumb bg="white" />
+                  </Switch.Control>
+                  <Switch.Label
+                    fontFamily="body"
+                    fontSize="12px"
+                    color="#656E7B"
+                  >
+                    This area only
+                  </Switch.Label>
+                </Switch.Root>
+              )}
               <Stack
                 gap={4}
                 flex={1}
@@ -210,7 +259,7 @@ export function InsightsPanel() {
                 pb={2}
                 css={insightsListScrollStyle}
               >
-                <InsightsList filter={filter} />
+                <InsightsList filter={filter} areaScoped={areaScoped} />
               </Stack>
             </Flex>
           </Flex>
@@ -268,13 +317,26 @@ function InsightsPanelHeader({ onClose }: { onClose: () => void }) {
   );
 }
 
-function InsightsList({ filter }: { filter: InsightFilter }) {
+function InsightsList({
+  filter,
+  areaScoped,
+}: {
+  filter: InsightFilter;
+  areaScoped: boolean;
+}) {
   const currentThreadId = useChatStore((s) => s.currentThreadId);
   const liveWidgets = useInsightStore(useShallow((s) => s.insights));
-  // Both queries are cached separately by thread id; when there is no thread the
+  const dashboardArea = useCurrentDashboardArea();
+  // On a dashboard, scope the AI list to its area (both aoi params travel
+  // together). Off a dashboard, or when the "This area" toggle is off, the query
+  // is unscoped. Each scope caches under its own key, so toggling is instant.
+  const aiScope = areaScoped && dashboardArea ? dashboardArea : undefined;
+  // Both queries are cached separately by scope key; when there is no thread the
   // scoped query collapses onto the unscoped one (same key) and is ignored below.
-  const { insights: threadInsights } = useUserInsights(currentThreadId);
-  const { insights: allInsights } = useUserInsights();
+  const { insights: threadInsights } = useUserInsights({
+    threadId: currentThreadId,
+  });
+  const { insights: allInsights } = useUserInsights(aiScope);
 
   const items = useMemo<InsightCardItem[]>(() => {
     if (filter === "verified") return verifiedInsights.flatMap(recordToItems);
@@ -343,12 +405,45 @@ function InsightCard({
   );
   const addInsight = useInsightStore((s) => s.addInsight);
   const removeInsight = useInsightStore((s) => s.removeInsight);
+  const dashboard = useAddInsightToDashboard(item.addableInsightId);
+  const title = item.widget.title;
 
-  function handleToggle(checked: boolean) {
+  // On a dashboard the card's footer toggle adds/removes the analysis to the
+  // grid (show-on-map has no target there); elsewhere it drives the on-map
+  // InsightWorkspace overlay.
+  if (dashboard.active) {
+    return (
+      <Box w={`${CATALOG_CARD_WIDTH_PX}px`} maxW="100%" flexShrink={0}>
+        <CatalogCard
+          thumbnail={<InsightThumbnail type={item.widget.type} />}
+          typeLabel="ANALYSIS"
+          typeLabelColor={INSIGHT_LABEL_COLOR}
+          title={title}
+          description={cardDescription(item)}
+          selected={dashboard.added}
+          selectedBg={INSIGHT_SELECTED_BG}
+          showOnMap={dashboard.added}
+          onShowOnMapChange={() => dashboard.toggle()}
+          toggleLabel={dashboard.added ? "On dashboard" : "Add to dashboard"}
+          toggleAriaLabel={
+            dashboard.added
+              ? `Remove ${title} from dashboard`
+              : `Add ${title} to dashboard`
+          }
+          toggleDisabled={!dashboard.addable || dashboard.pending}
+          onInfoClick={onOpen}
+          infoTooltip="View analysis"
+          badge={<VerificationBadge verification={item.verification} />}
+        />
+      </Box>
+    );
+  }
+
+  const handleToggle = (checked: boolean) => {
     if (!widgetId) return;
     if (checked) addInsight(item.widget);
     else removeInsight(widgetId);
-  }
+  };
 
   return (
     <Box w={`${CATALOG_CARD_WIDTH_PX}px`} maxW="100%" flexShrink={0}>
@@ -356,7 +451,7 @@ function InsightCard({
         thumbnail={<InsightThumbnail type={item.widget.type} />}
         typeLabel="ANALYSIS"
         typeLabelColor={INSIGHT_LABEL_COLOR}
-        title={item.widget.title}
+        title={title}
         description={cardDescription(item)}
         selected={shown}
         selectedBg={INSIGHT_SELECTED_BG}
@@ -365,7 +460,6 @@ function InsightCard({
         onInfoClick={onOpen}
         infoTooltip="View analysis"
         badge={<VerificationBadge verification={item.verification} />}
-        titleActions={<AddToDashboardMenu />}
       />
     </Box>
   );
@@ -393,38 +487,6 @@ function VerificationBadge({
       curated={verification === "verified"}
       showLearnMore={false}
     />
-  );
-}
-
-function AddToDashboardMenu() {
-  return (
-    <Menu.Root positioning={{ placement: "bottom-end" }}>
-      <Menu.Trigger asChild>
-        <IconButton
-          aria-label="More analysis actions"
-          variant="ghost"
-          size="2xs"
-          p={0}
-          minW="16px"
-          h="16px"
-          w="16px"
-          color={INSIGHT_LABEL_COLOR}
-          onClick={(e) => e.stopPropagation()}
-        >
-          <DotsThreeVerticalIcon size={16} color={INSIGHT_LABEL_COLOR} />
-        </IconButton>
-      </Menu.Trigger>
-      <Portal>
-        <Menu.Positioner>
-          <Menu.Content>
-            {/* Disabled until dashboards land (PZB-890). */}
-            <Menu.Item value="add-to-dashboard" disabled>
-              Add to dashboard (coming soon)
-            </Menu.Item>
-          </Menu.Content>
-        </Menu.Positioner>
-      </Portal>
-    </Menu.Root>
   );
 }
 

--- a/src/features/insights-history/ui/insights-panel.tsx
+++ b/src/features/insights-history/ui/insights-panel.tsx
@@ -74,9 +74,12 @@ const INSIGHT_SELECTED_BG = "rgba(0, 73, 170, 0.06)";
 
 type InsightFilter = "conversation" | "verified" | "ai";
 
+// The "Curated" (verified) filter is hidden for now: product is rearchitecting
+// curated analyses, so the hand-written fixtures shouldn't be surfaced. The
+// filter branch and `verifiedInsights` are left in place so putting the chip
+// back is a one-line change once the real source exists.
 const INSIGHT_FILTERS: { id: InsightFilter; label: string }[] = [
   { id: "conversation", label: "In this conversation" },
-  { id: "verified", label: "Curated" },
   { id: "ai", label: "AI generated" },
 ];
 

--- a/src/features/insights-history/ui/insights-panel.tsx
+++ b/src/features/insights-history/ui/insights-panel.tsx
@@ -170,6 +170,13 @@ export function InsightsPanel() {
   const isDashboard = useViewContextStore(
     (s) => s.viewContext?.page === "dashboard"
   );
+  // The AI list can only actually scope once the dashboard's AOI is known
+  // (detail query resolved). Until then the switch is disabled and reads
+  // unchecked so its "This area only" label never overstates a scope the list
+  // isn't applying — `InsightsList` falls back to the unscoped query the same
+  // way (aiScope = areaScoped && dashboardArea).
+  const dashboardArea = useCurrentDashboardArea();
+  const areaScopeReady = !!dashboardArea;
 
   const leftPx = getCatalogLeftPx(isChatFullSize);
   const compactSlide = !isChatFullSize;
@@ -228,7 +235,8 @@ export function InsightsPanel() {
               {showAreaToggle && (
                 <Switch.Root
                   size="sm"
-                  checked={areaScoped}
+                  checked={areaScoped && areaScopeReady}
+                  disabled={!areaScopeReady}
                   onCheckedChange={(e: { checked: boolean }) =>
                     setAreaScoped(e.checked)
                   }

--- a/src/features/insights-history/ui/use-user-insights.ts
+++ b/src/features/insights-history/ui/use-user-insights.ts
@@ -1,6 +1,6 @@
 import { useQuery } from "@tanstack/react-query";
 import type { InsightRecord } from "@/src/entities/insight";
-import type { InsightsGateway } from "../model/insights-gateway";
+import type { InsightQuery, InsightsGateway } from "../model/insights-gateway";
 import { RestInsightsGateway } from "../api/rest-insights-gateway";
 
 // Composition root: the real adapter. Tests inject a fake gateway.
@@ -13,22 +13,24 @@ export interface UseUserInsights {
 }
 
 /**
- * Reads the user's stored insights (newest-first). Pass a `threadId` to scope to
- * the current conversation; omit it for everything. The query key includes the
- * thread id, so filtered and unfiltered results are cached separately.
+ * Reads the user's stored insights (newest-first). Pass a `query` to scope by
+ * thread and/or AOI; omit it for everything. Each scope key is part of the
+ * query key, so scoped and unscoped results are cached separately.
  */
 export function useUserInsights(
-  threadId?: string | null,
+  query?: InsightQuery,
   gateway: InsightsGateway = defaultGateway
 ): UseUserInsights {
-  const query = useQuery({
-    queryKey: ["userInsights", threadId ?? null],
-    queryFn: ({ signal }) => gateway.list(threadId, signal),
+  const { threadId = null, aoiSource, aoiId } = query ?? {};
+  const result = useQuery({
+    queryKey: ["userInsights", threadId, aoiSource ?? null, aoiId ?? null],
+    queryFn: ({ signal }) =>
+      gateway.list({ threadId, aoiSource, aoiId }, signal),
   });
 
   return {
-    insights: query.data ?? [],
-    isLoading: query.isLoading,
-    error: (query.error as Error | null) ?? null,
+    insights: result.data ?? [],
+    isLoading: result.isLoading,
+    error: (result.error as Error | null) ?? null,
   };
 }


### PR DESCRIPTION
## Summary

On a dashboard, opening the **Analyses pane** from the chat input's "Analyses" button now lets you add an existing insight (curated/verified, or one you generated earlier) to the grid. It's added at the next free slot as an insight block and persists across reloads. The AI-generated list is scoped to the dashboard's area by default, with a "This area only" toggle to broaden it.

Most of the machinery already existed on `develop` — this is wiring, not green-field: the pane (`InsightsPanel`), the malformed-record-tolerant `GET /api/insights` gateway, and the add-widget backend (`POST /api/dashboards/:id/widgets`, which appends + persists) were all in place.

## What changed

- **`feat(catalog-card)`** — optional `toggleLabel` / `toggleAriaLabel` / `toggleDisabled` props on `CatalogCard`, defaulting to today's show-on-map behaviour (datasets/areas panels unaffected).
- **`refactor(dashboards)`** — extract the add/remove logic from `AddToDashboardToggle` into a reusable `useAddInsightToDashboard` hook, plus `useCurrentDashboardArea`. The chat-side toggle now just renders off the hook (no behaviour change).
- **`feat(insights)`** — on a dashboard, each pane card's footer toggle becomes add/remove-to-grid instead of the inert show-on-map. Gated to real backend insight ids, so verified fixtures / unsaved in-session analyses render the toggle disabled. The AI list scopes to the dashboard AOI via the `aoi_source`+`aoi_id` filter (both sent only together); the read path (`InsightQuery`) caches thread and area scopes separately.
- **`feat(dashboards)`** — mount `InsightsPanel` on the dashboard route (app layer composes both features; the dashboards feature never imports insights-history). Expose the chat input's "Analyses" button on the dashboard-detail route (it was gated to `/app`), keeping the map-only catalog/area pickers hidden. Compact chat shifts aside for the pane there.

## Design notes

- **Filtering is server-side (API), by necessity.** The `InsightResponse` payload carries no AOI (only `statistics_ids`), so client-side filtering is impossible; the backend matches the `(source, src_id)` pair against the statistics rows. Single-area today matches both contracts (dashboard create is `aois.min(1).max(1)`, and the endpoint takes one pair); multi-area later is a localized change in `useCurrentDashboardArea` + `InsightQuery`, not a re-architecture. See the comment on `useCurrentDashboardArea`.
- **FSD** — the pane is mounted at the app-route layer so the `dashboards` feature never imports `insights-history`; the two hooks are deep-imported into the pane, matching the repo's existing `dashboards/ui/*` deep-import convention (avoids a cycle + bundle bloat; `sideEffects` is unset).

## Testing

- `typecheck`, full suite (594), `lint`, `format:check`, and a production `build` all green.
- New/updated unit tests: `useAddInsightToDashboard` (add/remove/gating), the `aoi_source`+`aoi_id` gateway querystring, `useUserInsights` scope plumbing, and `isDashboardDetailRoute`.
- **Not yet browser-verified:** the pane's visual layout on the dashboard (compact vs full-size chat) — the one spot worth a manual pass.

## Follow-ups (not in scope)

- Default the pane's filter to "AI generated" on a dashboard (currently "In this conversation", which can be empty). Deferred due to a `viewContext` timing nuance.
- Search / quick filters (separate story).

🤖 Generated with [Claude Code](https://claude.com/claude-code)