### PR TITLE
fix(chat): stop surfacing agent-guidance tool errors as chat warnings

### DIFF
--- a/app/components/Reasoning.tsx
+++ b/app/components/Reasoning.tsx
@@ -142,7 +142,14 @@ function Reasoning({
                     <Timeline.Indicator boxSize="8px" top={1} left={1} />
                   </Timeline.Connector>
                   <Timeline.Content>
-                    <Timeline.Title>{formatToolName(tool.name)}</Timeline.Title>
+                    <Timeline.Title>
+                      {formatToolName(tool.name)}
+                      {tool.status === "error" && (
+                        <Text as="span" fontSize="xs" color="fg.muted">
+                          (did not complete)
+                        </Text>
+                      )}
+                    </Timeline.Title>
                     <Box fontSize="xs" maxW="100%">
                       <Markdown
                         remarkPlugins={[remarkBreaks]}

--- a/app/lib/__tests__/parse-stream-message.test.ts
+++ b/app/lib/__tests__/parse-stream-message.test.ts
@@ -138,13 +138,42 @@ describe("parseStreamMessage — tool response_metadata write signals", () => {
       msg_type: "dashboard_updated",
       dashboard_id: "dash-1",
     });
-    // Content mentioning "Error:" routes the message down the error branch.
-    update.messages[0].kwargs.content = "Recovered from Error: retried ok";
+    // An error status routes the message down the error branch.
+    (update.messages[0].kwargs as { status?: string }).status = "error";
 
     const msg = parseStreamMessage(update, "tools", TS);
     expect(msg?.type).toBe("error");
     expect(msg?.msg_type).toBe("dashboard_updated");
     expect(msg?.dashboard_id).toBe("dash-1");
+  });
+});
+
+describe("parseStreamMessage — tool error classification", () => {
+  it("classifies a status=error tool message as an error", () => {
+    const update = toolUpdate("create_dashboard");
+    (update.messages[0].kwargs as { status?: string }).status = "error";
+    update.messages[0].kwargs.content =
+      "The current selection spans 2 areas. Ask the user which one.";
+
+    const msg = parseStreamMessage(update, "tools", TS);
+    expect(msg).toMatchObject({ type: "error", name: "create_dashboard" });
+  });
+
+  it("classifies a legacy 'Error:'-prefixed tool message as an error", () => {
+    const update = toolUpdate("pull_data");
+    update.messages[0].kwargs.content = "Error: upstream service unavailable";
+
+    const msg = parseStreamMessage(update, "tools", TS);
+    expect(msg?.type).toBe("error");
+  });
+
+  it("keeps a successful tool message that mentions 'Error:' mid-content as a tool message", () => {
+    const update = toolUpdate("pull_data");
+    update.messages[0].kwargs.content =
+      "Pulled 16 data points. One row was skipped (Error: bad geometry).";
+
+    const msg = parseStreamMessage(update, "tools", TS);
+    expect(msg?.type).toBe("tool");
   });
 });
 

--- a/app/lib/parse-stream-message.ts
+++ b/app/lib/parse-stream-message.ts
@@ -58,10 +58,13 @@ export function parseStreamMessage(
       trace_id: traceId,
     };
   } else if (messageType === "tools") {
-    // Check if this is an error from a tool
+    // Check if this is an error from a tool. `status` is the canonical
+    // signal; the "Error:" prefix is a legacy one from older backend tool
+    // errors that carried no status. Prefix only — a successful result that
+    // merely mentions "Error:" mid-content must not be classified as one.
     if (
       kwargs.status === "error" ||
-      (typeof content === "string" && content.includes("Error:"))
+      (typeof content === "string" && content.startsWith("Error:"))
     ) {
       return {
         type: "error",

--- a/app/lib/tool-display.ts
+++ b/app/lib/tool-display.ts
@@ -31,6 +31,19 @@ export function formatToolName(toolName: string): string {
   return TOOL_DISPLAY[toolName]?.active ?? `Processing ${toolName}`;
 }
 
+/**
+ * Whether the tool is a user-visible pipeline step with display strings.
+ *
+ * Error results from tools outside this map are not surfaced as chat
+ * warnings: the backend uses `status: "error"` tool messages as guidance to
+ * the agent (e.g. create_dashboard's "selection spans 2 areas — ask the user
+ * which one"), and the agent always follows up with text that explains the
+ * situation in its own words.
+ */
+export function isKnownTool(toolName?: string): boolean {
+  return toolName !== undefined && toolName in TOOL_DISPLAY;
+}
+
 // Recoverable tool error: the agent continues with a follow-up assistant
 // message, so the wording names the failed step and prompts retry rather
 // than implying the chat is broken.

--- a/app/store/__tests__/chatStore.test.ts
+++ b/app/store/__tests__/chatStore.test.ts
@@ -248,6 +248,139 @@ describe("chatStore ff (agent profile default)", () => {
   });
 });
 
+// A Response-like object that streams the given NDJSON lines in one chunk,
+// then reports the stream as done — the happy-path counterpart of
+// makeAbortableResponse.
+function makeNdjsonResponse(lines: string[]): Response {
+  const encoder = new TextEncoder();
+  let sent = false;
+  const reader = {
+    read: () => {
+      if (sent) {
+        return Promise.resolve({ value: undefined, done: true });
+      }
+      sent = true;
+      return Promise.resolve({
+        value: encoder.encode(lines.join("\n") + "\n"),
+        done: false,
+      });
+    },
+    releaseLock: () => {},
+    cancel: () => Promise.resolve(),
+  };
+  return {
+    ok: true,
+    headers: new Headers(),
+    body: { getReader: () => reader },
+  } as unknown as Response;
+}
+
+// One NDJSON line as the backend packs it: an error-status ToolMessage from
+// the tools node. `name === null` mimics the backend's generic tool-error
+// funnel, which builds ToolMessages without a name.
+function errorToolLine(name: string | null, content: string): string {
+  return JSON.stringify({
+    node: "tools",
+    timestamp: "2026-07-21T00:00:00.000Z",
+    update: JSON.stringify({
+      messages: [
+        {
+          lc: 1,
+          type: "constructor",
+          id: ["langchain", "schema", "messages", "ToolMessage"],
+          kwargs: {
+            content,
+            type: "tool",
+            ...(name ? { name } : {}),
+            id: "msg-1",
+            tool_call_id: "tc-1",
+            status: "error",
+          },
+        },
+      ],
+    }),
+  });
+}
+
+describe("chatStore recoverable tool errors", () => {
+  beforeEach(() => {
+    useChatStore.getState().reset();
+    useChatStore.getState().clearToolSteps();
+    vi.mocked(apiFetch).mockReset();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  const warnings = () =>
+    useChatStore.getState().messages.filter((m) => m.type === "warning");
+
+  it("renders a warning for an error from a known pipeline tool", async () => {
+    vi.mocked(apiFetch).mockResolvedValue(
+      makeNdjsonResponse([
+        errorToolLine("generate_insights", "Failed to generate chart data."),
+      ])
+    );
+
+    await useChatStore.getState().sendMessage("hello");
+
+    expect(warnings()).toHaveLength(1);
+    expect(warnings()[0].message).toBe(
+      "Unable to generate a chart. Please try again."
+    );
+  });
+
+  it("suppresses the warning for agent-guidance errors from tools outside the display map", async () => {
+    // create_dashboard returns status=error as instructions to the agent
+    // ("ask the user which area") — not a user-facing failure.
+    vi.mocked(apiFetch).mockResolvedValue(
+      makeNdjsonResponse([
+        errorToolLine(
+          "create_dashboard",
+          "The current selection spans 2 areas. Ask the user which one."
+        ),
+      ])
+    );
+
+    await useChatStore.getState().sendMessage("hello");
+
+    expect(warnings()).toHaveLength(0);
+  });
+
+  it("keeps the failed step in the reasoning timeline, marked as an error", async () => {
+    vi.mocked(apiFetch).mockResolvedValue(
+      makeNdjsonResponse([
+        errorToolLine(
+          "create_dashboard",
+          "The current selection spans 2 areas. Ask the user which one."
+        ),
+      ])
+    );
+
+    await useChatStore.getState().sendMessage("hello");
+
+    const step = useChatStore
+      .getState()
+      .toolSteps.find((s) => s.name === "create_dashboard");
+    expect(step).toBeDefined();
+    expect(step?.status).toBe("error");
+  });
+
+  it("stays silent for a nameless error from the backend's generic tool-error funnel", async () => {
+    vi.mocked(apiFetch).mockResolvedValue(
+      makeNdjsonResponse([
+        errorToolLine(null, "Tool 'x' failed unexpectedly (KeyError)."),
+      ])
+    );
+
+    await useChatStore.getState().sendMessage("hello");
+
+    expect(warnings()).toHaveLength(0);
+    expect(useChatStore.getState().toolSteps).toHaveLength(0);
+  });
+});
+
 const suggestion = (areaName: string): AnalyseSuggestion => ({
   areaName,
   datasetId: 4,

--- a/app/store/chatStore.ts
+++ b/app/store/chatStore.ts
@@ -27,7 +27,7 @@ import { parseStreamMessage } from "@/app/lib/parse-stream-message";
 import { buildInsightChatMessages } from "@/app/lib/insight-chat-messages";
 import { mergeCitedArticlesIntoMap } from "@/app/lib/blog-citations";
 import { apiFetch } from "@/app/lib/api-client";
-import { getToolErrorMessage } from "@/app/lib/tool-display";
+import { getToolErrorMessage, isKnownTool } from "@/app/lib/tool-display";
 import { generateInsightsTool } from "./chat-tools/generateInsights";
 import { pickAoiTool } from "./chat-tools/pickAoi";
 import { pickDatasetTool } from "./chat-tools/pickDataset";
@@ -248,13 +248,23 @@ async function processStreamMessage(
         { title: "Request Timed Out" }
       );
     } else {
-      // No toast: the agent recovers with a follow-up assistant message,
-      // so a toast would falsely suggest the chat itself is broken.
-      addMessage({
-        type: "warning",
-        message: getToolErrorMessage(streamMessage.name),
-        timestamp: streamMessage.timestamp,
-      });
+      // Keep the failed step visible in the reasoning timeline either way.
+      if (streamMessage.name) {
+        addToolStep(streamMessage);
+      }
+      if (isKnownTool(streamMessage.name)) {
+        // No toast: the agent recovers with a follow-up assistant message,
+        // so a toast would falsely suggest the chat itself is broken.
+        addMessage({
+          type: "warning",
+          message: getToolErrorMessage(streamMessage.name),
+          timestamp: streamMessage.timestamp,
+        });
+      }
+      // Tools outside the display map get no chat warning: their error
+      // results are agent guidance (e.g. create_dashboard's "ask the user
+      // which area" redirect) or unexpected failures, and in both cases the
+      // agent's follow-up text explains the situation to the user.
     }
     // TODO: StreamMessage.type "text" currently represents assistant messages.
     // Consider renaming server-emitted type to "assistant" and updating this
@@ -778,6 +788,7 @@ const useChatStore = create<ChatState & ChatActions>((set, get) => ({
         ...state.toolSteps,
         {
           name: toolData.name || "unknown",
+          ...(toolData.type === "error" ? { status: "error" as const } : {}),
           content: toolData.content,
           dataset: toolData.dataset,
           insights: toolData.insights,

--- a/app/types/chat.ts
+++ b/app/types/chat.ts
@@ -16,6 +16,9 @@ export interface MessageContext {
 // Type for storing tool execution data
 export interface ToolStepData {
   name: string;
+  /** Set when the tool result was error-classified (recoverable failure or
+   * agent guidance) so the reasoning timeline can mark the step. */
+  status?: "error";
   content?: string;
   dataset?: object;
   insights?: object[];


### PR DESCRIPTION
## Problem

Turns where the agent comes back with a question or dataset nudge ("Pick one to continue and I'll run the analysis") always rendered a spurious **"Unable to process this step. Please try again."** warning first.

Reproduced live on staging (`agent_profile=experimental`, two areas selected, e.g. *"compare annual rainfall and cropland area between Nigeria and Ghana in 2024"*). The stream contains:

```
ToolMessage { name: "create_dashboard", status: "error",
  content: "The current selection spans 2 areas, but dashboards currently cover a single area… Ask the user which one area the dashboard is for and re-run pick_aoi." }
```

This is not a failure — the backend uses `status: "error"` ToolMessages (`error_command()` in project-zeno `src/agent/tools/common.py`) as **instructions to the agent**, which then asks the user in its follow-up text. The frontend treated every error-status tool message as a user-facing failure, and since the dashboard-family tools aren't in `TOOL_DISPLAY`, the generic default string rendered — right before the agent's own nudge.

## Changes

- `processStreamMessage`: only render the recoverable-error chat warning for tools registered in `TOOL_DISPLAY` (`generate_insights`, `pick_aoi`, `pick_dataset`, `pull_data`, `search_blogs`). Errors from other tools (agent guidance, or unexpected crashes from the backend's nameless tool-error funnel) get no chat bubble — the agent narrates those itself. New `isKnownTool()` helper in `tool-display.ts`.
- Failed steps are no longer invisible: they're added to the reasoning timeline (`ToolStepData.status: "error"`) and rendered under "Reasoned for Ns" with a muted *"(did not complete)"* marker, so internal testers keep full visibility.
- `parse-stream-message.ts`: legacy content heuristic tightened from `includes("Error:")` to `startsWith("Error:")` so successful tool results that merely mention an error mid-content aren't misclassified.

Live streaming and thread replay share `processStreamMessage`, so reloaded threads stop showing the persisted spurious warning too.

## Test plan

- [x] 4 new chatStore tests driving `sendMessage` with NDJSON streams shaped exactly like the captured staging lines (known-tool error → warning; guidance error → silent + timeline step marked `error`; nameless error → fully silent)
- [x] 3 new parse-stream-message tests covering the error-classification rules; 1 existing test updated to use `status: "error"` (its intent — write-signal preservation — unchanged)
- [x] Full suite: 594/594 passing; `format:check`, `lint`, `typecheck`, `build` all green locally
- [ ] Manual QA on staging with `agent_profile=experimental`: repeat the two-area repro prompt and confirm no warning precedes the agent's follow-up; confirm a real `generate_insights` failure still shows "Unable to generate a chart. Please try again."

## Follow-up (backend, project-zeno)

Tag `error_command()` messages with explicit metadata (e.g. `response_metadata.msg_type: "agent_guidance"`) so the frontend can key on intent instead of a tool allowlist — ticket drafted separately.