### PR TITLE
feat(chat): surface a dashboard navigation card on dashboard writes

### DIFF
--- a/app/components/DashboardChatCard.tsx
+++ b/app/components/DashboardChatCard.tsx
@@ -1,0 +1,54 @@
+"use client";
+import { useRouter } from "next/navigation";
+import { SquaresFourIcon } from "@phosphor-icons/react";
+import { InfoCard } from "./InfoCard";
+import { useDashboard } from "@/src/features/dashboards/ui/dashboardQueries";
+
+const DASHBOARD_LABEL_COLOR = "#7B61FF";
+
+export interface DashboardChatCardProps {
+  dashboardId: string;
+  /** Streamed with the dashboard_updated signal; threads recorded before the
+   * backend sent it carry only the id. */
+  dashboardName?: string;
+}
+
+function CardShell({
+  dashboardId,
+  title,
+}: {
+  dashboardId: string;
+  title: string;
+}) {
+  const router = useRouter();
+  return (
+    <InfoCard
+      thumbnail={<SquaresFourIcon size={32} color="#656E7B" />}
+      thumbnailBg="gray.100"
+      typeLabel="DASHBOARD"
+      typeLabelColor={DASHBOARD_LABEL_COLOR}
+      title={title}
+      description="Open dashboard"
+      onClick={() => router.push(`/dashboards/${dashboardId}?ff=dashboard`)}
+    />
+  );
+}
+
+// Fallback for threads that predate the streamed dashboard_name: resolve the
+// title from the dashboards API instead of showing a nameless card.
+function FetchedTitleCard({ dashboardId }: { dashboardId: string }) {
+  const { data } = useDashboard(dashboardId);
+  return (
+    <CardShell dashboardId={dashboardId} title={data?.name ?? "Dashboard"} />
+  );
+}
+
+export function DashboardChatCard({
+  dashboardId,
+  dashboardName,
+}: DashboardChatCardProps) {
+  if (dashboardName) {
+    return <CardShell dashboardId={dashboardId} title={dashboardName} />;
+  }
+  return <FetchedTitleCard dashboardId={dashboardId} />;
+}

--- a/app/components/DashboardChatCard.tsx
+++ b/app/components/DashboardChatCard.tsx
@@ -1,10 +1,15 @@
 "use client";
 import { useRouter } from "next/navigation";
 import { SquaresFourIcon } from "@phosphor-icons/react";
+import { formatDistanceToNow } from "date-fns";
 import { InfoCard } from "./InfoCard";
 import { useDashboard } from "@/src/features/dashboards/ui/dashboardQueries";
 
-const DASHBOARD_LABEL_COLOR = "#7B61FF";
+// Figma: data-visualisation/semantics/attention — the DASHBOARD label colour.
+const LABEL_COLOR = "#CE8303";
+// Same blue shades as the insight AnalysisCard thumbnail, for consistency.
+const ICON_COLOR = "#0049AA";
+const ICON_BG = "#F7F9FF";
 
 export interface DashboardChatCardProps {
   dashboardId: string;
@@ -13,42 +18,44 @@ export interface DashboardChatCardProps {
   dashboardName?: string;
 }
 
-function CardShell({
-  dashboardId,
-  title,
-}: {
-  dashboardId: string;
-  title: string;
-}) {
-  const router = useRouter();
-  return (
-    <InfoCard
-      thumbnail={<SquaresFourIcon size={32} color="#656E7B" />}
-      thumbnailBg="gray.100"
-      typeLabel="DASHBOARD"
-      typeLabelColor={DASHBOARD_LABEL_COLOR}
-      title={title}
-      description="Open dashboard"
-      onClick={() => router.push(`/dashboards/${dashboardId}?ff=dashboard`)}
-    />
-  );
-}
-
-// Fallback for threads that predate the streamed dashboard_name: resolve the
-// title from the dashboards API instead of showing a nameless card.
-function FetchedTitleCard({ dashboardId }: { dashboardId: string }) {
-  const { data } = useDashboard(dashboardId);
-  return (
-    <CardShell dashboardId={dashboardId} title={data?.name ?? "Dashboard"} />
-  );
-}
-
 export function DashboardChatCard({
   dashboardId,
   dashboardName,
 }: DashboardChatCardProps) {
-  if (dashboardName) {
-    return <CardShell dashboardId={dashboardId} title={dashboardName} />;
+  const router = useRouter();
+  // The subtitle (creation time, insight count) comes from the dashboard
+  // resource; dashboard_updated invalidates the query, so the count stays
+  // live while the agent keeps adding widgets. The title prefers the
+  // streamed name and falls back to the fetched one for older threads.
+  const { data: dashboard } = useDashboard(dashboardId);
+
+  let description: string | undefined;
+  if (dashboard) {
+    const created = new Date(dashboard.created_at);
+    const createdAgo = isNaN(created.getTime())
+      ? null
+      : formatDistanceToNow(created, { addSuffix: true });
+    const insightCount = dashboard.widgets.filter(
+      (widget) => widget.widget_type === "insight"
+    ).length;
+    description = [
+      createdAgo,
+      `${insightCount} insight${insightCount === 1 ? "" : "s"}`,
+    ]
+      .filter(Boolean)
+      .join(" · ");
   }
-  return <FetchedTitleCard dashboardId={dashboardId} />;
+
+  return (
+    <InfoCard
+      thumbnail={<SquaresFourIcon size={32} color={ICON_COLOR} />}
+      thumbnailBg={ICON_BG}
+      typeLabel="DASHBOARD"
+      typeLabelColor={LABEL_COLOR}
+      title={dashboardName ?? dashboard?.name ?? "Dashboard"}
+      description={description}
+      interactive
+      onClick={() => router.push(`/dashboards/${dashboardId}?ff=dashboard`)}
+    />
+  );
 }

--- a/app/components/InfoCard.tsx
+++ b/app/components/InfoCard.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { Box, Flex, Text } from "@chakra-ui/react";
+import { ArrowRightIcon } from "@phosphor-icons/react";
 import * as React from "react";
 
 export interface InfoCardProps {
@@ -24,6 +25,10 @@ export interface InfoCardProps {
   titleActions?: React.ReactNode;
   /** Optional action node placed inline after the description text. */
   descriptionActions?: React.ReactNode;
+  /** Opts into the navigation-card treatment: a right arrow revealed on
+   * hover and a pressed state that tints the card (primary shades) while
+   * active. Pair with onClick. */
+  interactive?: boolean;
 }
 
 export function InfoCard({
@@ -38,11 +43,13 @@ export function InfoCard({
   selected = false,
   titleActions,
   descriptionActions,
+  interactive = false,
 }: InfoCardProps) {
   return (
     <Flex
       flexDirection="row"
       alignItems="center"
+      position="relative"
       w="100%"
       h="80px"
       bg="#FFFFFF"
@@ -52,8 +59,23 @@ export function InfoCard({
       overflow="hidden"
       cursor={onClick ? "pointer" : "default"}
       onClick={onClick}
-      _hover={onClick ? { borderColor: "primary.300" } : undefined}
-      transition="border-color 0.16s ease"
+      _hover={
+        onClick && !interactive ? { borderColor: "primary.300" } : undefined
+      }
+      _active={
+        interactive && onClick
+          ? { bg: "#F0F4FF", borderColor: "#0049AA" }
+          : undefined
+      }
+      css={
+        interactive
+          ? {
+              "&:hover .info-card-arrow": { opacity: 1 },
+              "&:active .info-card-arrow": { color: "#0049AA" },
+            }
+          : undefined
+      }
+      transition="border-color 0.16s ease, background 0.16s ease"
     >
       <Flex
         w="80px"
@@ -72,7 +94,8 @@ export function InfoCard({
         display="flex"
         flexDirection="column"
         gap="2px"
-        px="16px"
+        pl="16px"
+        pr={interactive ? "44px" : "16px"}
         py={0}
         minW={0}
       >
@@ -132,6 +155,22 @@ export function InfoCard({
           </Flex>
         )}
       </Box>
+      {interactive && (
+        <Flex
+          className="info-card-arrow"
+          position="absolute"
+          right="16px"
+          top="50%"
+          transform="translateY(-50%)"
+          opacity={0}
+          transition="opacity 0.16s ease, color 0.16s ease"
+          color="#656E7B"
+          pointerEvents="none"
+          aria-hidden="true"
+        >
+          <ArrowRightIcon size={20} color="currentColor" />
+        </Flex>
+      )}
     </Flex>
   );
 }

--- a/app/components/InfoCard.tsx
+++ b/app/components/InfoCard.tsx
@@ -59,12 +59,32 @@ export function InfoCard({
       overflow="hidden"
       cursor={onClick ? "pointer" : "default"}
       onClick={onClick}
+      // The interactive card is the sole affordance for opening the dashboard,
+      // so it must be reachable and operable from the keyboard, not just the
+      // mouse. Expose it as a button and activate on Enter/Space.
+      role={interactive && onClick ? "button" : undefined}
+      tabIndex={interactive && onClick ? 0 : undefined}
+      onKeyDown={
+        interactive && onClick
+          ? (e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                onClick();
+              }
+            }
+          : undefined
+      }
       _hover={
         onClick && !interactive ? { borderColor: "primary.300" } : undefined
       }
       _active={
         interactive && onClick
           ? { bg: "#F0F4FF", borderColor: "#0049AA" }
+          : undefined
+      }
+      _focusVisible={
+        interactive && onClick
+          ? { outline: "2px solid #0049AA", outlineOffset: "2px" }
           : undefined
       }
       css={

--- a/app/components/MessageBubble.tsx
+++ b/app/components/MessageBubble.tsx
@@ -15,6 +15,7 @@ import { ChatMessage } from "@/app/types/chat";
 import WidgetMessage from "./WidgetMessage";
 import { AnalysisCard } from "./AnalysisCard";
 import { AreaCard } from "./AreaCard";
+import { DashboardChatCard } from "./DashboardChatCard";
 import Markdown, { type Components } from "react-markdown";
 import {
   ArrowBendDownRightIcon,
@@ -261,6 +262,17 @@ function MessageBubble({
     return (
       <Box my={2} width="100%">
         <AreaCard aoiSelection={message.aoiSelection} />
+      </Box>
+    );
+  }
+
+  if (message.type === "dashboard-card" && message.dashboardId) {
+    return (
+      <Box my={2} width="100%">
+        <DashboardChatCard
+          dashboardId={message.dashboardId}
+          dashboardName={message.dashboardName}
+        />
       </Box>
     );
   }

--- a/app/lib/__tests__/parse-stream-message.test.ts
+++ b/app/lib/__tests__/parse-stream-message.test.ts
@@ -60,11 +60,12 @@ function toolUpdate(
 }
 
 describe("parseStreamMessage — tool response_metadata write signals", () => {
-  it("carries msg_type and dashboard_id through on tool messages", () => {
+  it("carries msg_type, dashboard_id and dashboard_name through on tool messages", () => {
     const msg = parseStreamMessage(
       toolUpdate("add_to_dashboard", {
         msg_type: "dashboard_updated",
         dashboard_id: "5c9f7dd8-0000-0000-0000-000000000000",
+        dashboard_name: "Paraná",
       }),
       "tools",
       TS
@@ -74,6 +75,7 @@ describe("parseStreamMessage — tool response_metadata write signals", () => {
       name: "add_to_dashboard",
       msg_type: "dashboard_updated",
       dashboard_id: "5c9f7dd8-0000-0000-0000-000000000000",
+      dashboard_name: "Paraná",
     });
   });
 
@@ -91,6 +93,7 @@ describe("parseStreamMessage — tool response_metadata write signals", () => {
     const signalBearing = toolUpdate("add_to_dashboard", {
       msg_type: "dashboard_updated",
       dashboard_id: "dash-1",
+      dashboard_name: "Paraná",
     }).messages[0];
     const narration = agentUpdate("Added it to your dashboard.").messages[0];
     const update = {
@@ -103,6 +106,7 @@ describe("parseStreamMessage — tool response_metadata write signals", () => {
       text: "Added it to your dashboard.",
       msg_type: "dashboard_updated",
       dashboard_id: "dash-1",
+      dashboard_name: "Paraná",
     });
   });
 

--- a/app/lib/parse-stream-message.ts
+++ b/app/lib/parse-stream-message.ts
@@ -32,15 +32,18 @@ export function parseStreamMessage(
   // the update (the agent's narration can follow it in the same update), and
   // the carrying message may be classified as an error. Scan every message so
   // the signal rides on whatever StreamMessage this update produces.
-  let writeSignal: { msg_type: string; dashboard_id?: string } | undefined;
+  let writeSignal:
+    | { msg_type: string; dashboard_id?: string; dashboard_name?: string }
+    | undefined;
   for (const message of langChainMessage.messages ?? []) {
     const meta = message?.kwargs?.response_metadata as
-      | { msg_type?: string; dashboard_id?: string }
+      | { msg_type?: string; dashboard_id?: string; dashboard_name?: string }
       | undefined;
     if (meta?.msg_type) {
       writeSignal = {
         msg_type: meta.msg_type,
         dashboard_id: meta.dashboard_id,
+        dashboard_name: meta.dashboard_name,
       };
       break;
     }
@@ -95,6 +98,7 @@ export function parseStreamMessage(
       // refetch what the agent just changed.
       msg_type: writeSignal?.msg_type,
       dashboard_id: writeSignal?.dashboard_id,
+      dashboard_name: writeSignal?.dashboard_name,
     };
   } else if (messageType === "agent") {
     // For AI messages, handle different content formats

--- a/app/store/__tests__/chatStore.test.ts
+++ b/app/store/__tests__/chatStore.test.ts
@@ -431,3 +431,137 @@ describe("chatStore.acceptAnalyseNudge", () => {
     ).toBe(true);
   });
 });
+
+// --- dashboard_updated → dashboard-card emission -------------------------
+
+/**
+ * One NDJSON line as the backend streams it for a dashboard write: a tools
+ * node whose ToolMessage carries the dashboard_updated signal (and, since the
+ * backend started sending it, the dashboard's name) in response_metadata.
+ */
+function dashboardWriteLine(
+  dashboardId: string,
+  dashboardName?: string,
+  tool = "create_dashboard"
+): string {
+  const update = {
+    dashboard_id: dashboardId,
+    messages: [
+      {
+        lc: 1,
+        type: "constructor",
+        id: ["x"],
+        kwargs: {
+          content: "ok",
+          type: "tool",
+          name: tool,
+          id: `m-${dashboardId}-${tool}`,
+          status: "success",
+          response_metadata: {
+            msg_type: "dashboard_updated",
+            dashboard_id: dashboardId,
+            ...(dashboardName ? { dashboard_name: dashboardName } : {}),
+          },
+        },
+      },
+    ],
+  };
+  return JSON.stringify({
+    node: "tools",
+    timestamp: "2026-07-21T00:00:00.000Z",
+    update: JSON.stringify(update),
+  });
+}
+
+/** A Response-like object that streams the given NDJSON lines, then ends. */
+function ndjsonResponse(lines: string[]): Response {
+  const encoder = new TextEncoder();
+  let delivered = false;
+  const reader = {
+    read: () => {
+      if (delivered) {
+        return Promise.resolve({ done: true, value: undefined });
+      }
+      delivered = true;
+      return Promise.resolve({
+        done: false,
+        value: encoder.encode(lines.join("\n") + "\n"),
+      });
+    },
+    releaseLock: () => {},
+    cancel: () => Promise.resolve(),
+  };
+  return {
+    ok: true,
+    headers: new Headers(),
+    body: { getReader: () => reader },
+  } as unknown as Response;
+}
+
+function dashboardCards() {
+  return useChatStore
+    .getState()
+    .messages.filter((m) => m.type === "dashboard-card");
+}
+
+describe("dashboard_updated stream signal → dashboard-card message", () => {
+  beforeEach(() => {
+    useChatStore.getState().reset();
+    vi.mocked(apiFetch).mockReset();
+  });
+
+  it("surfaces a navigation card with the streamed id and name", async () => {
+    vi.mocked(apiFetch).mockResolvedValue(
+      ndjsonResponse([dashboardWriteLine("dash-1", "Paraná")])
+    );
+
+    await useChatStore.getState().sendMessage("create a dashboard");
+
+    expect(dashboardCards()).toHaveLength(1);
+    expect(dashboardCards()[0]).toMatchObject({
+      dashboardId: "dash-1",
+      dashboardName: "Paraná",
+    });
+  });
+
+  it("emits one card per dashboard per turn across create + widget adds", async () => {
+    vi.mocked(apiFetch).mockResolvedValue(
+      ndjsonResponse([
+        dashboardWriteLine("dash-1", "Paraná"),
+        dashboardWriteLine("dash-1", "Paraná", "add_to_dashboard"),
+        dashboardWriteLine("dash-1", "Paraná", "add_map_widget"),
+      ])
+    );
+
+    await useChatStore.getState().sendMessage("dashboard with widgets");
+
+    expect(dashboardCards()).toHaveLength(1);
+  });
+
+  it("surfaces the card again when a later turn touches the same dashboard", async () => {
+    vi.mocked(apiFetch).mockResolvedValue(
+      ndjsonResponse([dashboardWriteLine("dash-1", "Paraná")])
+    );
+    await useChatStore.getState().sendMessage("create a dashboard");
+
+    vi.mocked(apiFetch).mockResolvedValue(
+      ndjsonResponse([
+        dashboardWriteLine("dash-1", "Paraná", "add_to_dashboard"),
+      ])
+    );
+    await useChatStore.getState().sendMessage("add the insight to it");
+
+    expect(dashboardCards()).toHaveLength(2);
+  });
+
+  it("keeps the card (without a name) when the backend predates dashboard_name", async () => {
+    vi.mocked(apiFetch).mockResolvedValue(
+      ndjsonResponse([dashboardWriteLine("dash-1")])
+    );
+
+    await useChatStore.getState().sendMessage("create a dashboard");
+
+    expect(dashboardCards()).toHaveLength(1);
+    expect(dashboardCards()[0].dashboardName).toBeUndefined();
+  });
+});

--- a/app/store/__tests__/chatStore.test.ts
+++ b/app/store/__tests__/chatStore.test.ts
@@ -524,6 +524,43 @@ describe("dashboard_updated stream signal → dashboard-card message", () => {
     });
   });
 
+  it("announces a create with an assistant message ahead of the card", async () => {
+    vi.mocked(apiFetch).mockResolvedValue(
+      ndjsonResponse([dashboardWriteLine("dash-1", "Paraná")])
+    );
+
+    await useChatStore.getState().sendMessage("create a dashboard");
+
+    const messages = useChatStore.getState().messages;
+    const noteIndex = messages.findIndex(
+      (m) =>
+        m.type === "assistant" &&
+        m.message.includes('created the "Paraná" dashboard')
+    );
+    const cardIndex = messages.findIndex((m) => m.type === "dashboard-card");
+    expect(noteIndex).toBeGreaterThan(-1);
+    expect(cardIndex).toBe(noteIndex + 1);
+  });
+
+  it("uses the updated wording when the write is not a create", async () => {
+    vi.mocked(apiFetch).mockResolvedValue(
+      ndjsonResponse([
+        dashboardWriteLine("dash-1", "Paraná", "add_to_dashboard"),
+      ])
+    );
+
+    await useChatStore.getState().sendMessage("add it to my dashboard");
+
+    const note = useChatStore
+      .getState()
+      .messages.find(
+        (m) =>
+          m.type === "assistant" &&
+          m.message.includes('updated the "Paraná" dashboard')
+      );
+    expect(note).toBeDefined();
+  });
+
   it("emits one card per dashboard per turn across create + widget adds", async () => {
     vi.mocked(apiFetch).mockResolvedValue(
       ndjsonResponse([
@@ -536,6 +573,15 @@ describe("dashboard_updated stream signal → dashboard-card message", () => {
     await useChatStore.getState().sendMessage("dashboard with widgets");
 
     expect(dashboardCards()).toHaveLength(1);
+    // The synthetic announcement is deduped with its card — and since the
+    // create streamed first, it keeps the "created" wording.
+    const notes = useChatStore
+      .getState()
+      .messages.filter(
+        (m) => m.type === "assistant" && m.message.includes("dashboard")
+      );
+    expect(notes).toHaveLength(1);
+    expect(notes[0].message).toContain("created");
   });
 
   it("surfaces the card again when a later turn touches the same dashboard", async () => {

--- a/app/store/chatStore.ts
+++ b/app/store/chatStore.ts
@@ -180,6 +180,25 @@ function parseLangChainLine(rawLine: string): StreamMessage | null {
   return parseStreamMessage(updateObject, messageType, date);
 }
 
+// One dashboard card per dashboard per user turn: dashboard_updated fires on
+// creation and again for every widget add, but a single navigation card is
+// enough. Scanning back only to the last user message lets a later turn that
+// touches the same dashboard surface the card again.
+function dashboardCardExistsThisTurn(dashboardId: string): boolean {
+  const messages = useChatStore.getState().messages;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const message = messages[i];
+    if (message.type === "user") return false;
+    if (
+      message.type === "dashboard-card" &&
+      message.dashboardId === dashboardId
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
 // Helper function to process stream messages and add them to chat
 async function processStreamMessage(
   streamMessage: StreamMessage,
@@ -206,6 +225,23 @@ async function processStreamMessage(
     streamMessage.msg_type === "insight_updated"
   ) {
     queryClient.invalidateQueries({ queryKey: dashboardKeys.all });
+  }
+
+  // A dashboard write also surfaces a navigation card in the thread — the
+  // stream carries only the dashboard's id and name, so this is the user's
+  // one affordance to open what the agent just created or changed.
+  if (
+    streamMessage.msg_type === "dashboard_updated" &&
+    streamMessage.dashboard_id &&
+    !dashboardCardExistsThisTurn(streamMessage.dashboard_id)
+  ) {
+    addMessage({
+      type: "dashboard-card",
+      message: "",
+      dashboardId: streamMessage.dashboard_id,
+      dashboardName: streamMessage.dashboard_name,
+      timestamp: streamMessage.timestamp,
+    });
   }
 
   // Capture standalone trace metadata sent as a separate stream message

--- a/app/store/chatStore.ts
+++ b/app/store/chatStore.ts
@@ -227,14 +227,34 @@ async function processStreamMessage(
     queryClient.invalidateQueries({ queryKey: dashboardKeys.all });
   }
 
-  // A dashboard write also surfaces a navigation card in the thread — the
-  // stream carries only the dashboard's id and name, so this is the user's
-  // one affordance to open what the agent just created or changed.
+  // A dashboard write also surfaces a synthetic assistant line plus a
+  // navigation card in the thread — the stream carries only the dashboard's
+  // id and name, so the card is the user's one affordance to open what the
+  // agent just created or changed.
   if (
     streamMessage.msg_type === "dashboard_updated" &&
     streamMessage.dashboard_id &&
     !dashboardCardExistsThisTurn(streamMessage.dashboard_id)
   ) {
+    // The signal itself doesn't distinguish a create from a widget add, but
+    // the tool result it rides on does. When it rides on agent narration or
+    // an error-classified message instead, there is no tool name — default
+    // to the "updated" wording.
+    const isCreate =
+      streamMessage.type === "tool" &&
+      streamMessage.name === "create_dashboard";
+    const name = streamMessage.dashboard_name;
+    addMessage({
+      type: "assistant",
+      message: isCreate
+        ? name
+          ? `I've created the "${name}" dashboard. Open the card below to view it — I can keep adding insights to it as we explore.`
+          : "I've created a dashboard for you. Open the card below to view it — I can keep adding insights to it as we explore."
+        : name
+          ? `I've updated the "${name}" dashboard. Open the card below to see the changes.`
+          : "I've updated your dashboard. Open the card below to see the changes.",
+      timestamp: streamMessage.timestamp,
+    });
     addMessage({
       type: "dashboard-card",
       message: "",

--- a/app/types/chat.ts
+++ b/app/types/chat.ts
@@ -35,6 +35,7 @@ export interface ChatMessage {
     | "system"
     | "widget"
     | "area-card"
+    | "dashboard-card"
     | "error"
     | "warning"
     | "dataset-nudge"
@@ -45,6 +46,8 @@ export interface ChatMessage {
   timestamp: string;
   widgets?: InsightWidget[]; // For widget messages
   aoiSelection?: AOISelection; // For area-card messages
+  dashboardId?: string; // For dashboard-card messages
+  dashboardName?: string; // For dashboard-card messages; absent on threads that predate the backend streaming it
   suggestedDatasets?: SuggestedDataset[]; // For dataset-nudge messages
   analyseSuggestion?: AnalyseSuggestion; // For analyse-nudge messages
   context?: MessageContext; // Read-only context snapshot for user messages
@@ -184,6 +187,7 @@ export interface StreamMessage {
   // tells the client to refetch the named resource.
   msg_type?: string;
   dashboard_id?: string;
+  dashboard_name?: string;
 }
 
 export interface AOI {


### PR DESCRIPTION
## What

When the agent creates or updates a dashboard (`create_dashboard`, `add_to_dashboard`, `add_map_widget`), the chat thread now surfaces a **dashboard card** — mirroring the existing area/dataset/analysis cards — that links to `/dashboards/:id?ff=dashboard`.

<img width="798" height="513" alt="Screenshot 2026-07-23 at 13 51 58" src="https://github.com/user-attachments/assets/80b05010-8982-482d-9db7-c3ae0bfb4bb1" />


Previously the `dashboard_updated` stream signal only invalidated the dashboards TanStack query; on the map page nothing visible happened, and the `dashboard_id` the backend streams was parsed but never consumed.

## How

- `parse-stream-message.ts` now also carries `dashboard_name` from the tool message's `response_metadata` (new structured field, backend PR: wri/project-zeno#757).
- `chatStore.processStreamMessage` emits a `dashboard-card` chat message alongside the existing query invalidation — keyed on the `msg_type` signal (not the tool name), so future backend dashboard tools get the card for free.
- **One card per dashboard per user turn**: the signal fires on the create and again for every widget add; the emission scans back to the last user message before adding another card. A later turn touching the same dashboard surfaces it again.
- New `DashboardChatCard` component built on `InfoCard` (same pattern as `AreaCard`); title from the streamed name, with a `useDashboard` fetch fallback for threads that predate the backend field.
- Works identically for live streams and `fetchThread` replay, since both share the pipeline.

## Backend dependency

Soft dependency on wri/project-zeno#757 (`dashboard_name` in `response_metadata`). Without it the card still renders — the title just resolves via `GET /api/dashboards/:id` instead of the stream.

## Testing

- `pnpm test`: 623 passed — the 4 failures in `NewDashboardScreen.test.tsx` are pre-existing on `develop` (verified via stash; they came in with the nested-areas picker and CI doesn't run unit tests). New coverage: `dashboard_name` pass-through in `parse-stream-message.test.ts`; card emission, per-turn dedupe, cross-turn re-surface, and missing-name fallback driven through the real NDJSON pipeline in `chatStore.test.ts`.
- `pnpm typecheck`, `pnpm test:arch`, `pnpm lint`, `pnpm build`: all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)