### PR TITLE
feat: Sentinel-2 imagery on the map with Satellite Imagery legend

### DIFF
--- a/app/components/legend/ImageryLegendEntry.tsx
+++ b/app/components/legend/ImageryLegendEntry.tsx
@@ -181,6 +181,7 @@ export function ImageryLegendEntry(
             </IconButton>
           </OpacityControl>
           <IconButton
+            aria-label="Remove satellite imagery"
             onClick={() => onLayerAction({ action: "remove", payload: { id } })}
           >
             <XIcon />

--- a/app/components/legend/ImageryLegendEntry.tsx
+++ b/app/components/legend/ImageryLegendEntry.tsx
@@ -1,0 +1,485 @@
+import { Fragment, useState } from "react";
+import {
+  Box,
+  ButtonGroup,
+  Collapsible,
+  Flex,
+  Heading,
+  IconButton,
+  Image,
+  Popover,
+  Portal,
+  Spinner,
+  Switch,
+  Text,
+} from "@chakra-ui/react";
+import {
+  ArrowBendDownRightIcon,
+  CaretDownIcon,
+  CircleHalfIcon,
+  InfoIcon,
+  PolygonIcon,
+  XIcon,
+} from "@phosphor-icons/react";
+import { OpacityControl } from "./OpacityControl";
+import type {
+  ImageryLegendCapture,
+  ImageryLegendGroup,
+  LayerActionHandler,
+} from "./types";
+import { ParamChip } from "@/app/components/ui/ParamChip";
+
+/**
+ * The "Satellite Imagery" legend section: one entry grouping every Sentinel-2
+ * capture on the map (Figma node 1473:8288). Header controls act on the whole
+ * group; the collapsed-by-default captures list toggles individual mosaics.
+ * While the agent rebuilds a mosaic the body collapses to an updating state.
+ */
+export function ImageryLegendEntry(
+  props: ImageryLegendGroup & {
+    onLayerAction: LayerActionHandler;
+    expanded?: boolean;
+    onToggleExpand?: () => void;
+    /** Tighter type and spacing for small hosts (dashboard map widgets). */
+    compact?: boolean;
+  }
+) {
+  const {
+    id,
+    title,
+    subtitle,
+    opacity,
+    params,
+    info,
+    note,
+    captures,
+    areaCount,
+    updating,
+    thumbnailUrl,
+    onLayerAction,
+    expanded = false,
+    onToggleExpand,
+    compact,
+  } = props;
+
+  // "Collapse state as default" (Figma) — captures expand on demand.
+  const [capturesOpen, setCapturesOpen] = useState(false);
+
+  // Captures grouped by area, preserving capture order (newest first).
+  const areaGroups: { areaLabel: string; captures: ImageryLegendCapture[] }[] =
+    [];
+  for (const capture of captures) {
+    const group = areaGroups.find((g) => g.areaLabel === capture.areaLabel);
+    if (group) {
+      group.captures.push(capture);
+    } else {
+      areaGroups.push({ areaLabel: capture.areaLabel, captures: [capture] });
+    }
+  }
+
+  return (
+    <Flex
+      flexDir="column"
+      w="100%"
+      minW={0}
+      fontFamily="body"
+      lineHeight="shorter"
+    >
+      {/* Header row — always visible */}
+      <Flex justifyContent="space-between" gap={1} alignItems="center">
+        <Flex
+          gap={1}
+          alignItems="center"
+          fontSize="sm"
+          cursor="pointer"
+          onClick={onToggleExpand}
+          flex={1}
+          minW={0}
+        >
+          <IconButton
+            variant="ghost"
+            size="xs"
+            p={0}
+            minW="14px"
+            h="14px"
+            pointerEvents="none"
+            css={{
+              transform: expanded ? "rotate(0deg)" : "rotate(-90deg)",
+              transition: "transform 0.15s ease",
+            }}
+          >
+            <CaretDownIcon size={12} />
+          </IconButton>
+          <Heading as="h3" size={compact ? "xs" : "sm"} m={0} truncate>
+            {title}
+          </Heading>
+          {/* IMAGERY badge — secondary/200 per Figma */}
+          <Flex
+            h="16px"
+            px="5px"
+            alignItems="center"
+            rounded="4px"
+            bg="#F0F9B9"
+            flexShrink={0}
+          >
+            <Text
+              fontFamily="mono"
+              fontSize="9px"
+              lineHeight="16px"
+              color="#23271A"
+              textTransform="uppercase"
+            >
+              Imagery
+            </Text>
+          </Flex>
+        </Flex>
+        <ButtonGroup
+          variant="ghost"
+          size="xs"
+          gap={0}
+          flexShrink={0}
+          css={{
+            "& button": {
+              h: compact ? 5 : 6,
+              minW: compact ? 5 : 6,
+            },
+          }}
+        >
+          {info && (
+            <Popover.Root>
+              <Popover.Trigger asChild>
+                <IconButton>
+                  <InfoIcon />
+                </IconButton>
+              </Popover.Trigger>
+              <Portal>
+                <Popover.Positioner>
+                  <Popover.Content>
+                    <Popover.Arrow />
+                    <Popover.Body>
+                      <Popover.Title fontWeight="medium">
+                        Layer information
+                      </Popover.Title>
+                      <Text my="4">{info}</Text>
+                    </Popover.Body>
+                  </Popover.Content>
+                </Popover.Positioner>
+              </Portal>
+            </Popover.Root>
+          )}
+          <OpacityControl
+            value={opacity}
+            onValueChange={(value) =>
+              onLayerAction({
+                action: "opacity",
+                payload: { id, opacity: value },
+              })
+            }
+          >
+            <IconButton>
+              <CircleHalfIcon />
+            </IconButton>
+          </OpacityControl>
+          <IconButton
+            onClick={() => onLayerAction({ action: "remove", payload: { id } })}
+          >
+            <XIcon />
+          </IconButton>
+        </ButtonGroup>
+      </Flex>
+
+      {/* Collapsible body */}
+      <Collapsible.Root open={expanded}>
+        <Collapsible.Content css={{ transition: "height 0.15s ease" }}>
+          {updating ? (
+            <UpdatingBody compact={compact} />
+          ) : (
+            <Flex
+              flexDir="column"
+              gap={compact ? 1.5 : 2}
+              pt={compact ? 1.5 : 2}
+              pr={compact ? 2 : 4}
+            >
+              {/* Summary row: thumbnail + source/rendering label */}
+              <Flex gap={2} alignItems="center" pl={compact ? 2 : 3}>
+                <ImageryThumbnail src={thumbnailUrl} size={32} captioned />
+                <Text fontSize="xs" color="#44505A" truncate>
+                  {subtitle}
+                </Text>
+              </Flex>
+              {params.length > 0 && (
+                <Flex gap={1} flexWrap="wrap" alignItems="center">
+                  {params.map((p) => (
+                    <ParamChip
+                      key={p.label}
+                      label={p.label}
+                      value={p.value}
+                      colorScheme="purple"
+                      bg="white"
+                      maxValueWidth={p.maxValueWidth}
+                    />
+                  ))}
+                </Flex>
+              )}
+              {note && <Text fontSize="xs">{note}</Text>}
+              {captures.length > 0 && (
+                <>
+                  <Box h="1px" bg="border" mx={compact ? -2 : -4} />
+                  {/* Captures summary row — toggles the captures list */}
+                  <Flex
+                    alignItems="center"
+                    justifyContent="space-between"
+                    cursor="pointer"
+                    onClick={() => setCapturesOpen((prev) => !prev)}
+                    role="button"
+                    aria-expanded={capturesOpen}
+                    aria-label={
+                      capturesOpen ? "Collapse captures" : "Expand captures"
+                    }
+                  >
+                    <Flex alignItems="center" gap={1}>
+                      <ArrowBendDownRightIcon
+                        size={12}
+                        color="var(--chakra-colors-fg-muted)"
+                      />
+                      <Text fontFamily="mono" fontSize="10px" color="#737C94">
+                        {captures.length} capture
+                        {captures.length === 1 ? "" : "s"} · {areaCount} area
+                        {areaCount === 1 ? "" : "s"}
+                      </Text>
+                    </Flex>
+                    <Box
+                      as="span"
+                      color="#737C94"
+                      css={{
+                        transform: capturesOpen
+                          ? "rotate(180deg)"
+                          : "rotate(0deg)",
+                        transition: "transform 0.15s ease",
+                      }}
+                    >
+                      <CaretDownIcon size={12} />
+                    </Box>
+                  </Flex>
+                  <Collapsible.Root open={capturesOpen}>
+                    <Collapsible.Content
+                      css={{ transition: "height 0.15s ease" }}
+                    >
+                      <Flex
+                        flexDir="column"
+                        gap="10px"
+                        pl={compact ? 2 : 4}
+                        pt={1}
+                        pb={1}
+                      >
+                        {areaGroups.map((group, index) => (
+                          <Fragment key={group.areaLabel}>
+                            {index > 0 && <Box h="1px" bg="border" />}
+                            <Flex flexDir="column" gap="6px">
+                              <Flex gap={1} alignItems="center">
+                                <PolygonIcon size={14} color="#3A4048" />
+                                <Text
+                                  fontSize="10px"
+                                  fontWeight="semibold"
+                                  color="#3A4048"
+                                >
+                                  {group.areaLabel}
+                                </Text>
+                              </Flex>
+                              {group.captures.map((capture) => (
+                                <CaptureRow
+                                  key={capture.layerId}
+                                  capture={capture}
+                                  onLayerAction={onLayerAction}
+                                />
+                              ))}
+                            </Flex>
+                          </Fragment>
+                        ))}
+                      </Flex>
+                    </Collapsible.Content>
+                  </Collapsible.Root>
+                </>
+              )}
+            </Flex>
+          )}
+        </Collapsible.Content>
+      </Collapsible.Root>
+    </Flex>
+  );
+}
+
+/**
+ * One capture (mosaic) row: thumbnail, date, search meta, LIVE badge on the
+ * newest capture and a visibility toggle.
+ */
+function CaptureRow(props: {
+  capture: ImageryLegendCapture;
+  onLayerAction: LayerActionHandler;
+}) {
+  const { capture, onLayerAction } = props;
+
+  return (
+    <Flex alignItems="center" justifyContent="space-between" pl={2} gap={2}>
+      <Flex gap={2} alignItems="center" minW={0}>
+        <ImageryThumbnail src={capture.thumbnailUrl} size={24} />
+        <Flex flexDir="column" gap="2px" minW={0}>
+          <Text
+            fontSize="xs"
+            fontWeight={capture.live ? "semibold" : "normal"}
+            color={capture.live ? "#3A4048" : "#737C94"}
+            truncate
+          >
+            {capture.dateLabel}
+          </Text>
+          {capture.metaLabel && (
+            <Text fontFamily="mono" fontSize="10px" color="#737C94" truncate>
+              {capture.metaLabel}
+            </Text>
+          )}
+        </Flex>
+      </Flex>
+      <Flex gap={2} alignItems="center" flexShrink={0}>
+        {capture.live && (
+          <Flex
+            h="16px"
+            px="4px"
+            alignItems="center"
+            rounded="4px"
+            bg="#F0F4FF"
+          >
+            <Text
+              fontFamily="mono"
+              fontSize="8px"
+              fontWeight="bold"
+              letterSpacing="0.08px"
+              color="#21509A"
+            >
+              LIVE
+            </Text>
+          </Flex>
+        )}
+        <Switch.Root
+          size="sm"
+          checked={capture.visible}
+          onCheckedChange={(e: { checked: boolean }) =>
+            onLayerAction({
+              action: "visibility",
+              payload: { id: capture.layerId, visible: e.checked },
+            })
+          }
+          colorPalette="primary"
+          aria-label={
+            capture.visible
+              ? `Hide ${capture.dateLabel} capture`
+              : `Show ${capture.dateLabel} capture`
+          }
+        >
+          <Switch.HiddenInput />
+          <Switch.Control>
+            <Switch.Thumb bg="white" />
+          </Switch.Control>
+        </Switch.Root>
+      </Flex>
+    </Flex>
+  );
+}
+
+/**
+ * Mosaic preview: a single tile from the mosaic itself, with the Figma
+ * "IMAGERY" caption strip on the 32px summary variant. Falls back to a plain
+ * swatch when there is no URL (or the tile fails to load).
+ */
+function ImageryThumbnail(props: {
+  src?: string;
+  size: number;
+  captioned?: boolean;
+}) {
+  const { src, size, captioned } = props;
+  const [failed, setFailed] = useState(false);
+
+  return (
+    <Box
+      position="relative"
+      w={`${size}px`}
+      h={`${size}px`}
+      rounded={captioned ? "4px" : "6px"}
+      overflow="hidden"
+      bg="#E0E2E5"
+      flexShrink={0}
+    >
+      {src && !failed && (
+        <Image
+          src={src}
+          alt=""
+          w="100%"
+          h="100%"
+          objectFit="cover"
+          onError={() => setFailed(true)}
+        />
+      )}
+      {captioned && (
+        <Flex
+          position="absolute"
+          bottom={0}
+          left={0}
+          right={0}
+          h="8px"
+          alignItems="center"
+          justifyContent="center"
+          bg="rgba(15, 27, 36, 0.8)"
+        >
+          <Text
+            fontFamily="mono"
+            fontSize="6px"
+            color="white"
+            letterSpacing="0.03px"
+          >
+            IMAGERY
+          </Text>
+        </Flex>
+      )}
+    </Box>
+  );
+}
+
+/** Body shown while the agent is rebuilding the mosaic (Figma 1473:8197). */
+function UpdatingBody(props: { compact?: boolean }) {
+  const { compact } = props;
+  return (
+    <Flex
+      flexDir="column"
+      gap={compact ? 1.5 : 2}
+      pt={compact ? 1.5 : 2}
+      pr={compact ? 2 : 4}
+    >
+      <Flex gap={2} alignItems="center" pl={compact ? 2 : 3}>
+        <Box
+          w="32px"
+          h="32px"
+          rounded="4px"
+          bg="#F4F5F6"
+          border="1px solid"
+          borderColor="#E0E2E5"
+          flexShrink={0}
+        />
+        <Text fontSize="xs" color="#737C94">
+          Updating mosaic…
+        </Text>
+      </Flex>
+      <Flex
+        alignItems="center"
+        gap={2}
+        px={2}
+        py="6px"
+        rounded="4px"
+        bg="#F4F5F6"
+      >
+        <Spinner size="xs" color="#737C94" />
+        <Text fontSize="10px" color="#3A4048">
+          Fetching new imagery for this view…
+        </Text>
+      </Flex>
+    </Flex>
+  );
+}

--- a/app/components/legend/Legend.tsx
+++ b/app/components/legend/Legend.tsx
@@ -15,9 +15,10 @@ import {
 } from "@phosphor-icons/react";
 import { Reorder, useDragControls } from "motion/react";
 
-import { LayerActionHandler, LegendLayer } from "./types";
+import { isImageryGroup, LayerActionHandler, LegendEntry } from "./types";
 import type { LegendAoi } from "./useLegendHook";
 import { LayerEntry } from "./LayerEntry";
+import { ImageryLegendEntry } from "./ImageryLegendEntry";
 import { ParamChip } from "@/app/components/ui/ParamChip";
 
 const ChReorderGroup = chakra(Reorder.Group);
@@ -27,7 +28,7 @@ const ChReorderItem = chakra(Reorder.Item);
  * Props for the Legend component.
  */
 interface LegendProps {
-  layers: LegendLayer[];
+  layers: LegendEntry[];
   onLayerAction?: LayerActionHandler;
   aois?: LegendAoi[];
   onRemoveAoi?: (layerId: string) => void;
@@ -166,7 +167,7 @@ export function Legend(props: LegendProps) {
             <ChReorderGroup
               axis="y"
               values={layers}
-              onReorder={(layers: LegendLayer[]) =>
+              onReorder={(layers: LegendEntry[]) =>
                 onLayerAction?.({ action: "reorder", payload: { layers } })
               }
               listStyleType="none"
@@ -238,7 +239,7 @@ export function Legend(props: LegendProps) {
  * legend.
  */
 function Item(props: {
-  item: LegendLayer;
+  item: LegendEntry;
   expanded: boolean;
   onToggleExpand: () => void;
   onLayerAction: LayerActionHandler;
@@ -274,13 +275,23 @@ function Item(props: {
       >
         <DotsSixVerticalIcon />
       </IconButton>
-      <LayerEntry
-        {...item}
-        compact={compact}
-        expanded={expanded}
-        onToggleExpand={onToggleExpand}
-        onLayerAction={onLayerAction}
-      />
+      {isImageryGroup(item) ? (
+        <ImageryLegendEntry
+          {...item}
+          compact={compact}
+          expanded={expanded}
+          onToggleExpand={onToggleExpand}
+          onLayerAction={onLayerAction}
+        />
+      ) : (
+        <LayerEntry
+          {...item}
+          compact={compact}
+          expanded={expanded}
+          onToggleExpand={onToggleExpand}
+          onLayerAction={onLayerAction}
+        />
+      )}
     </ChReorderItem>
   );
 }

--- a/app/components/legend/__tests__/ImageryLegendEntry.test.tsx
+++ b/app/components/legend/__tests__/ImageryLegendEntry.test.tsx
@@ -1,0 +1,142 @@
+// @vitest-environment happy-dom
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { ImageryLegendEntry } from "../ImageryLegendEntry";
+import type { ImageryLegendGroup, LayerActionArgs } from "../types";
+
+const baseGroup: ImageryLegendGroup = {
+  kind: "imagery",
+  id: "imagery-group",
+  title: "Satellite Imagery",
+  subtitle: "Sentinel-2 · True-colour",
+  opacity: 100,
+  params: [
+    { label: "DATES", value: "Jun 12 – Jun 16, 2026", maxValueWidth: "26ch" },
+    { label: "WINDOW", value: "±30 days" },
+    { label: "CLOUD", value: "< 50%" },
+    { label: "AREA", value: "Paracas National Reserve" },
+  ],
+  info: "Sentinel-2 true-colour mosaic built from 9 scenes.",
+  note: undefined,
+  captures: [
+    {
+      layerId: "imagery-new",
+      areaLabel: "Paracas National Reserve",
+      dateLabel: "15 Jun 2026",
+      metaLabel: "cloud <50% · 9 scenes",
+      visible: true,
+      live: true,
+    },
+    {
+      layerId: "imagery-old",
+      areaLabel: "Paracas National Reserve",
+      dateLabel: "15 May 2026",
+      metaLabel: "cloud <30% · 8 scenes",
+      visible: false,
+      live: false,
+    },
+    {
+      layerId: "imagery-other",
+      areaLabel: "Pacaya-Samiria",
+      dateLabel: "02 Jun 2026",
+      metaLabel: "cloud <30% · 6 scenes",
+      visible: false,
+      live: false,
+    },
+  ],
+  areaCount: 2,
+  updating: false,
+};
+
+let actions: LayerActionArgs[];
+
+function renderEntry(overrides: Partial<ImageryLegendGroup> = {}) {
+  return render(
+    <ChakraProvider value={defaultSystem}>
+      <ImageryLegendEntry
+        {...baseGroup}
+        {...overrides}
+        expanded
+        onLayerAction={(args) => actions.push(args)}
+      />
+    </ChakraProvider>
+  );
+}
+
+describe("ImageryLegendEntry", () => {
+  beforeEach(() => {
+    actions = [];
+  });
+
+  it("renders title, badge, subtitle and parameter chips", () => {
+    renderEntry();
+
+    expect(screen.getByText("Satellite Imagery")).toBeDefined();
+    expect(screen.getByText("Imagery")).toBeDefined();
+    expect(screen.getByText("Sentinel-2 · True-colour")).toBeDefined();
+    for (const label of ["DATES", "WINDOW", "CLOUD", "AREA"]) {
+      expect(screen.getByText(label)).toBeDefined();
+    }
+  });
+
+  it("collapses the captures list by default and expands it on demand", () => {
+    renderEntry();
+
+    expect(screen.getByText("3 captures · 2 areas")).toBeDefined();
+    const toggle = screen.getByRole("button", { name: "Expand captures" });
+
+    fireEvent.click(toggle);
+
+    // "Paracas National Reserve" appears twice: the AREA chip and the
+    // captures-list area header revealed by the toggle.
+    expect(screen.getAllByText("Paracas National Reserve")).toHaveLength(2);
+    expect(screen.getByText("Pacaya-Samiria")).toBeDefined();
+    expect(screen.getByText("15 Jun 2026")).toBeDefined();
+    expect(screen.getByText("LIVE")).toBeDefined();
+  });
+
+  it("renders capture toggles reflecting layer visibility", () => {
+    // Zag's switch state machine cannot be actuated through happy-dom
+    // synthetic events, so assert the rendered checked state; the
+    // onCheckedChange → visibility-action wiring is a one-line callback.
+    const { container } = renderEntry();
+    fireEvent.click(screen.getByRole("button", { name: "Expand captures" }));
+
+    const inputs = Array.from(
+      container.querySelectorAll<HTMLInputElement>("input[type=checkbox]")
+    );
+    expect(inputs.map((i) => i.checked)).toEqual([true, false, false]);
+  });
+
+  it("fires a group remove action from the header control", () => {
+    renderEntry();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: "Remove satellite imagery" })
+    );
+
+    expect(actions).toContainEqual({
+      action: "remove",
+      payload: { id: "imagery-group" },
+    });
+  });
+
+  it("shows the updating state instead of the summary while rebuilding", () => {
+    renderEntry({ updating: true });
+
+    expect(screen.getByText("Updating mosaic…")).toBeDefined();
+    expect(screen.queryByText("DATES")).toBeNull();
+    expect(screen.queryByText(/captures ·/)).toBeNull();
+  });
+
+  it("pluralises the captures summary correctly for a single capture", () => {
+    renderEntry({
+      captures: [baseGroup.captures[0]],
+      areaCount: 1,
+    });
+
+    expect(screen.getByText("1 capture · 1 area")).toBeDefined();
+  });
+});

--- a/app/components/legend/types.ts
+++ b/app/components/legend/types.ts
@@ -7,6 +7,8 @@ import { ReactNode } from "react";
 export interface LegendParam {
   label: string;
   value: string;
+  /** ParamChip passthrough for values wider than the 15ch default (dates). */
+  maxValueWidth?: string;
 }
 
 /**
@@ -37,6 +39,53 @@ export interface LegendLayer {
   hideRemoveControl?: boolean;
 }
 
+/**
+ * One Sentinel-2 mosaic in the imagery legend group — a single show_imagery
+ * run, backed by one raster map layer.
+ */
+export interface ImageryLegendCapture {
+  layerId: string;
+  /** Mosaic AOI names joined — the group header the capture sorts under. */
+  areaLabel: string;
+  /** e.g. "15 Jun 2026" */
+  dateLabel: string;
+  /** e.g. "cloud <50% · 9 scenes" — empty when the payload lacks the fields */
+  metaLabel: string;
+  visible: boolean;
+  /** The most recent capture — the one the agent updates in place. */
+  live: boolean;
+  thumbnailUrl?: string;
+}
+
+/**
+ * The single "Satellite Imagery" legend section grouping every imagery
+ * capture on the map. Summary fields (params/info/note/thumbnail) reflect
+ * the live capture.
+ */
+export interface ImageryLegendGroup {
+  kind: "imagery";
+  id: string;
+  title: string;
+  opacity: number;
+  subtitle: string;
+  params: LegendParam[];
+  info?: string;
+  note?: string;
+  captures: ImageryLegendCapture[];
+  areaCount: number;
+  /** show_imagery announced but its result not yet streamed. */
+  updating: boolean;
+  thumbnailUrl?: string;
+}
+
+/** A renderable legend entry: a dataset layer card or the imagery group. */
+export type LegendEntry = LegendLayer | ImageryLegendGroup;
+
+export const isImageryGroup = (
+  entry: LegendEntry
+): entry is ImageryLegendGroup =>
+  (entry as ImageryLegendGroup).kind === "imagery";
+
 export type LayerActionArgs =
   | {
       action: "remove";
@@ -47,8 +96,12 @@ export type LayerActionArgs =
       payload: { id: string; opacity: number };
     }
   | {
+      action: "visibility";
+      payload: { id: string; visible: boolean };
+    }
+  | {
       action: "reorder";
-      payload: { layers: LegendLayer[] };
+      payload: { layers: LegendEntry[] };
     };
 
 export type LayerActionHandler = (args: LayerActionArgs) => void;

--- a/app/components/legend/useLegendHook.tsx
+++ b/app/components/legend/useLegendHook.tsx
@@ -2,7 +2,6 @@ import { useCallback, useEffect, useState } from "react";
 import { Text } from "@chakra-ui/react";
 
 import {
-  ImageryLegendGroup,
   isImageryGroup,
   LayerActionHandler,
   LegendContextLayer,
@@ -22,17 +21,10 @@ import {
 import { buildYearParam, YearParam } from "@/app/utils/formatYearRange";
 import { formatCanopyThreshold } from "@/app/utils/formatCanopyThreshold";
 import type { DatasetLegendConfig } from "@/app/constants/datasets";
-import { isAreaLayer, type Layer } from "@/app/store/layerManagerSlice";
+import { isAreaLayer } from "@/app/store/layerManagerSlice";
 import {
-  captureMetaLabel,
-  formatCaptureDate,
-  IMAGERY_LAYER_NAME,
+  buildImageryGroup,
   IMAGERY_LEGEND_GROUP_ID,
-  IMAGERY_SUBTITLE,
-  imageryCloudNote,
-  imageryLegendInfo,
-  imageryLegendParams,
-  imageryThumbnailUrl,
 } from "@/app/utils/imagery";
 
 // Maps internal parameter keys to the badge label shown in the legend.
@@ -110,55 +102,6 @@ export interface LegendAoi {
   /** Id of the map layer this AOI belongs to — used to remove it. */
   layerId: string;
   name: string;
-}
-
-/**
- * Builds the single "Satellite Imagery" legend group from the imagery map
- * layers (one per show_imagery capture, newest first in the layer array).
- * Summary fields come from the newest (live) capture. Returns null when
- * there is nothing to show.
- */
-function buildImageryGroup(
-  imageryLayers: Layer[],
-  updating: boolean
-): ImageryLegendGroup | null {
-  if (imageryLayers.length === 0 && !updating) return null;
-
-  const live = imageryLayers[0];
-  const captures = imageryLayers.map((layer, index) => {
-    const imagery = layer.imagery!;
-    return {
-      layerId: layer.id,
-      areaLabel: imagery.aoi_names?.join(", ") || layer.name,
-      dateLabel: formatCaptureDate(imagery.target_date),
-      metaLabel: captureMetaLabel(imagery),
-      visible: layer.visible,
-      live: index === 0,
-      thumbnailUrl: layer.tileUrl
-        ? imageryThumbnailUrl(
-            layer.tileUrl,
-            layer.bounds,
-            layer.minzoom,
-            layer.maxzoom
-          )
-        : undefined,
-    };
-  });
-
-  return {
-    kind: "imagery",
-    id: IMAGERY_LEGEND_GROUP_ID,
-    title: IMAGERY_LAYER_NAME,
-    subtitle: IMAGERY_SUBTITLE,
-    opacity: (live?.opacity ?? 1) * 100,
-    params: live?.imagery ? imageryLegendParams(live.imagery) : [],
-    info: live?.imagery ? imageryLegendInfo(live.imagery) : undefined,
-    note: live?.imagery ? imageryCloudNote(live.imagery) : undefined,
-    captures,
-    areaCount: new Set(captures.map((c) => c.areaLabel)).size,
-    updating,
-    thumbnailUrl: captures[0]?.thumbnailUrl,
-  };
 }
 
 export function useLegendHook() {

--- a/app/components/legend/useLegendHook.tsx
+++ b/app/components/legend/useLegendHook.tsx
@@ -2,9 +2,11 @@ import { useCallback, useEffect, useState } from "react";
 import { Text } from "@chakra-ui/react";
 
 import {
+  ImageryLegendGroup,
+  isImageryGroup,
   LayerActionHandler,
   LegendContextLayer,
-  LegendLayer,
+  LegendEntry,
   LegendParam,
 } from "@/app/components/legend/types";
 import { LegendSequential } from "@/app/components/legend/LegendSequential";
@@ -12,6 +14,7 @@ import { LegendSymbolList } from "@/app/components/legend/LegendSymbolList";
 import { LegendCategorical } from "@/app/components/legend/LegendCategorical";
 import { LegendDivergent } from "@/app/components/legend/LegendDivergent";
 import useMapStore from "@/app/store/mapStore";
+import useChatStore from "@/app/store/chatStore";
 import {
   CONTEXT_LAYER_METADATA,
   DATASET_CARDS,
@@ -19,7 +22,18 @@ import {
 import { buildYearParam, YearParam } from "@/app/utils/formatYearRange";
 import { formatCanopyThreshold } from "@/app/utils/formatCanopyThreshold";
 import type { DatasetLegendConfig } from "@/app/constants/datasets";
-import { isAreaLayer } from "@/app/store/layerManagerSlice";
+import { isAreaLayer, type Layer } from "@/app/store/layerManagerSlice";
+import {
+  captureMetaLabel,
+  formatCaptureDate,
+  IMAGERY_LAYER_NAME,
+  IMAGERY_LEGEND_GROUP_ID,
+  IMAGERY_SUBTITLE,
+  imageryCloudNote,
+  imageryLegendInfo,
+  imageryLegendParams,
+  imageryThumbnailUrl,
+} from "@/app/utils/imagery";
 
 // Maps internal parameter keys to the badge label shown in the legend.
 const PARAMETER_LABELS: Record<string, string> = {
@@ -98,18 +112,69 @@ export interface LegendAoi {
   name: string;
 }
 
+/**
+ * Builds the single "Satellite Imagery" legend group from the imagery map
+ * layers (one per show_imagery capture, newest first in the layer array).
+ * Summary fields come from the newest (live) capture. Returns null when
+ * there is nothing to show.
+ */
+function buildImageryGroup(
+  imageryLayers: Layer[],
+  updating: boolean
+): ImageryLegendGroup | null {
+  if (imageryLayers.length === 0 && !updating) return null;
+
+  const live = imageryLayers[0];
+  const captures = imageryLayers.map((layer, index) => {
+    const imagery = layer.imagery!;
+    return {
+      layerId: layer.id,
+      areaLabel: imagery.aoi_names?.join(", ") || layer.name,
+      dateLabel: formatCaptureDate(imagery.target_date),
+      metaLabel: captureMetaLabel(imagery),
+      visible: layer.visible,
+      live: index === 0,
+      thumbnailUrl: layer.tileUrl
+        ? imageryThumbnailUrl(
+            layer.tileUrl,
+            layer.bounds,
+            layer.minzoom,
+            layer.maxzoom
+          )
+        : undefined,
+    };
+  });
+
+  return {
+    kind: "imagery",
+    id: IMAGERY_LEGEND_GROUP_ID,
+    title: IMAGERY_LAYER_NAME,
+    subtitle: IMAGERY_SUBTITLE,
+    opacity: (live?.opacity ?? 1) * 100,
+    params: live?.imagery ? imageryLegendParams(live.imagery) : [],
+    info: live?.imagery ? imageryLegendInfo(live.imagery) : undefined,
+    note: live?.imagery ? imageryCloudNote(live.imagery) : undefined,
+    captures,
+    areaCount: new Set(captures.map((c) => c.areaLabel)).size,
+    updating,
+    thumbnailUrl: captures[0]?.thumbnailUrl,
+  };
+}
+
 export function useLegendHook() {
-  const [layers, setLayers] = useState<LegendLayer[]>([]);
+  const [layers, setLayers] = useState<LegendEntry[]>([]);
 
   const {
     layers: managedLayers,
     setLayerOpacity,
+    setLayerVisibility,
     removeLayer,
     reorderLayers,
   } = useMapStore();
+  const isImageryUpdating = useChatStore((s) => s.isImageryUpdating);
 
   useEffect(() => {
-    const buildEntries = (): LegendLayer[] => {
+    const buildEntries = (): LegendEntry[] => {
       // First pass: build a map of parentLayerId → contextLayer data so we can
       // attach sub-layers to their parent entries in the second pass.
       const contextLayerByParentId = new Map<string, LegendContextLayer>();
@@ -132,10 +197,25 @@ export function useLegendHook() {
       // Second pass: build root-level legend entries.
       // AOI layers are surfaced as chips separately — skip them.
       // Sub-layers are embedded in their parent via contextLayer — skip them too.
-      const entries: LegendLayer[] = [];
+      // Imagery layers collapse into one group entry, placed where the first
+      // (newest) capture sits in the layer order.
+      const imageryGroup = buildImageryGroup(
+        managedLayers.filter((l) => !!l.imagery),
+        isImageryUpdating
+      );
+      let imageryGroupPushed = false;
+
+      const entries: LegendEntry[] = [];
       for (const layer of managedLayers) {
         if (layer.parentLayerId) continue;
         if (isAreaLayer(layer)) continue;
+        if (layer.imagery) {
+          if (imageryGroup && !imageryGroupPushed) {
+            entries.push(imageryGroup);
+            imageryGroupPushed = true;
+          }
+          continue;
+        }
 
         const relatedDataset = DATASET_CARDS.find(
           (d) => `dataset-${d.dataset_id}` === layer.id
@@ -159,11 +239,17 @@ export function useLegendHook() {
         });
       }
 
+      // First-run updating state: show_imagery announced but no capture has
+      // landed yet, so no imagery layer marked the group's position above.
+      if (imageryGroup && !imageryGroupPushed) {
+        entries.push(imageryGroup);
+      }
+
       return entries;
     };
 
     setLayers(buildEntries());
-  }, [managedLayers]);
+  }, [managedLayers, isImageryUpdating]);
 
   // One chip per visible area layer, using the selection name as the label.
   // The visible layer IS the scope — removing the chip removes the layer.
@@ -180,12 +266,38 @@ export function useLegendHook() {
   const handleLayerAction = useCallback<LayerActionHandler>(
     ({ action, payload }) => {
       if (action === "reorder") {
-        reorderLayers(payload.layers.map((l) => l.id));
+        // Expand legend entries to map-layer ids: the imagery group stands
+        // for all its capture layers, and each dataset root drags its context
+        // sub-layers along. Layers with no legend entry (AOI layers) keep
+        // their position at the end — reorderLayers drops any id not listed.
+        const orderedIds = payload.layers.flatMap((entry) => {
+          if (isImageryGroup(entry)) {
+            return entry.captures.map((c) => c.layerId);
+          }
+          const childIds = managedLayers
+            .filter((l) => l.parentLayerId === entry.id)
+            .map((l) => l.id);
+          return [entry.id, ...childIds];
+        });
+        const rest = managedLayers
+          .map((l) => l.id)
+          .filter((id) => !orderedIds.includes(id));
+        reorderLayers([...orderedIds, ...rest]);
         return;
       }
 
+      // The imagery group's header controls act on every capture layer.
+      const isImageryGroupId = payload.id === IMAGERY_LEGEND_GROUP_ID;
+      const imageryLayers = isImageryGroupId
+        ? managedLayers.filter((l) => !!l.imagery)
+        : [];
+
       switch (action) {
         case "remove":
+          if (isImageryGroupId) {
+            imageryLayers.forEach((l) => removeLayer(l.id));
+            break;
+          }
           // The visible layer IS the scope — removing it is the only mutation.
           // Also drop any context sub-layers parented to this dataset layer.
           managedLayers
@@ -194,11 +306,26 @@ export function useLegendHook() {
           removeLayer(payload.id);
           break;
         case "opacity":
+          if (isImageryGroupId) {
+            imageryLayers.forEach((l) =>
+              setLayerOpacity(l.id, payload.opacity / 100)
+            );
+            break;
+          }
           setLayerOpacity(payload.id, payload.opacity / 100);
+          break;
+        case "visibility":
+          setLayerVisibility(payload.id, payload.visible);
           break;
       }
     },
-    [managedLayers, removeLayer, setLayerOpacity, reorderLayers]
+    [
+      managedLayers,
+      removeLayer,
+      setLayerOpacity,
+      setLayerVisibility,
+      reorderLayers,
+    ]
   );
 
   return { layers, handleLayerAction, aois, handleRemoveAoi };

--- a/app/components/map/layers/DynamicTileLayers.tsx
+++ b/app/components/map/layers/DynamicTileLayers.tsx
@@ -22,14 +22,19 @@ export function layerId(id: string) {
  */
 function DynamicTileLayers() {
   const allLayers = useMapStore((s) => s.layers);
-  const rasterLayers = useMemo(
-    () =>
-      allLayers.filter(
-        (l): l is ManagedLayer & { tileUrl: string } =>
-          l.type === "raster" && !!l.tileUrl
-      ),
-    [allLayers]
-  );
+  const rasterLayers = useMemo(() => {
+    const rasters = allLayers.filter(
+      (l): l is ManagedLayer & { tileUrl: string } =>
+        l.type === "raster" && !!l.tileUrl
+    );
+    // Imagery mosaics are opaque, basemap-like layers: keep them at the
+    // bottom of the raster stack regardless of insertion order so dataset
+    // and context overlays stay visible above them.
+    return [
+      ...rasters.filter((l) => !l.imagery),
+      ...rasters.filter((l) => l.imagery),
+    ];
+  }, [allLayers]);
 
   return (
     <>
@@ -45,6 +50,21 @@ function DynamicTileLayers() {
           ? layerId(aboveLayer.id)
           : RASTER_TOP_SENTINEL_ID;
 
+        // Optional source tuning (set on imagery layers from their TileJSON).
+        // Spread conditionally so unset keys stay out of the source spec.
+        const sourceOptions = {
+          ...(rasterLayer.minzoom !== undefined
+            ? { minzoom: rasterLayer.minzoom }
+            : {}),
+          ...(rasterLayer.maxzoom !== undefined
+            ? { maxzoom: rasterLayer.maxzoom }
+            : {}),
+          ...(rasterLayer.bounds ? { bounds: rasterLayer.bounds } : {}),
+          ...(rasterLayer.attribution
+            ? { attribution: rasterLayer.attribution }
+            : {}),
+        };
+
         return (
           <Source
             key={rasterLayer.id}
@@ -52,6 +72,7 @@ function DynamicTileLayers() {
             type="raster"
             tiles={[rasterLayer.tileUrl]}
             tileSize={256}
+            {...sourceOptions}
           >
             <Layer
               id={id}

--- a/app/lib/__tests__/parse-stream-message.test.ts
+++ b/app/lib/__tests__/parse-stream-message.test.ts
@@ -84,6 +84,27 @@ describe("parseStreamMessage — tool response_metadata write signals", () => {
     expect(msg?.dashboard_id).toBeUndefined();
   });
 
+  it("carries the imagery state through on tool messages", () => {
+    const imagery = {
+      tile_url: "https://tiles.example.com/{z}/{x}/{y}.png",
+      tilejson_url: "https://tiles.example.com/tilejson.json",
+      mosaic_id: "abc123",
+      target_date: "2026-06-15",
+      aoi_names: ["Paracas"],
+    };
+    const update = {
+      ...toolUpdate("show_imagery"),
+      imagery,
+    } as unknown as LangChainUpdate;
+
+    const msg = parseStreamMessage(update, "tools", TS);
+    expect(msg).toMatchObject({
+      type: "tool",
+      name: "show_imagery",
+      imagery,
+    });
+  });
+
   it("finds the signal on an earlier message when the update ends with narration", () => {
     // The signal-bearing tool result and the agent's follow-up can arrive in
     // one update; only the last message decides the StreamMessage type, but

--- a/app/lib/parse-stream-message.ts
+++ b/app/lib/parse-stream-message.ts
@@ -92,6 +92,7 @@ export function parseStreamMessage(
       insight_count: langChainMessage.insight_count || 0,
       aoi: langChainMessage.aoi || undefined,
       aoi_selection: langChainMessage.aoi_selection || undefined,
+      imagery: langChainMessage.imagery || undefined,
       timestamp: timestamp.toISOString(),
       trace_id: traceId,
       // Write signals (e.g. dashboard_updated) ride along so the client can

--- a/app/lib/tool-display.ts
+++ b/app/lib/tool-display.ts
@@ -23,6 +23,10 @@ const TOOL_DISPLAY: Record<string, { active: string; error: string }> = {
     active: "Searching WRI Insights",
     error: "Unable to search WRI Insights articles. Please try again.",
   },
+  show_imagery: {
+    active: "Loading satellite imagery",
+    error: "Unable to load satellite imagery. Please try again.",
+  },
 };
 
 const DEFAULT_TOOL_ERROR = "Unable to process this step. Please try again.";

--- a/app/store/chat-tools/__tests__/showImagery.test.ts
+++ b/app/store/chat-tools/__tests__/showImagery.test.ts
@@ -33,7 +33,14 @@ vi.mock("@/app/hooks/useErrorHandler", () => ({
   showApiError: (...args: unknown[]) => showApiError(...args),
 }));
 
+// getAuthHeaders reads localStorage, which the node test environment lacks —
+// stub a signed-in user so the origin gating is observable either way.
+vi.mock("@/app/lib/api-client", () => ({
+  getAuthHeaders: () => ({ Authorization: "Bearer test-token" }),
+}));
+
 import { showImageryTool } from "../showImagery";
+import { API_CONFIG } from "@/app/config/api";
 import type { ImageryInfo, StreamMessage } from "@/app/types/chat";
 
 const timestamp = new Date().toISOString();
@@ -116,6 +123,30 @@ describe("showImageryTool", () => {
     });
   });
 
+  it("attaches auth when the tiler is the Zeno API itself", async () => {
+    const fetchMock = mockFetch({});
+    const url = `${API_CONFIG.API_HOST}/api/tiles/tilejson.json`;
+
+    await showImageryTool(
+      baseMsg({ imagery: { ...imagery, tilejson_url: url } })
+    );
+
+    expect(fetchMock).toHaveBeenCalledWith(url, {
+      headers: { Authorization: "Bearer test-token" },
+    });
+  });
+
+  it("does not leak the token to a host that merely starts with the API host", async () => {
+    const fetchMock = mockFetch({});
+    const url = `${API_CONFIG.API_HOST}.evil.example.com/tilejson.json`;
+
+    await showImageryTool(
+      baseMsg({ imagery: { ...imagery, tilejson_url: url } })
+    );
+
+    expect(fetchMock).toHaveBeenCalledWith(url, { headers: {} });
+  });
+
   it("hides earlier captures and stacks the new one on top of them", async () => {
     mockFetch({});
     mapState.layers = [
@@ -160,12 +191,24 @@ describe("showImageryTool", () => {
     expect(mapState.addLayer).not.toHaveBeenCalled();
   });
 
-  it("surfaces an auth error and adds no layer on 401", async () => {
+  it("surfaces an auth error and adds no layer on 401 from the Zeno API", async () => {
     mockFetch({ ok: false, status: 401 });
+    const url = `${API_CONFIG.API_HOST}/api/tiles/tilejson.json`;
+
+    await showImageryTool(
+      baseMsg({ imagery: { ...imagery, tilejson_url: url } })
+    );
+
+    expect(showApiError).toHaveBeenCalledOnce();
+    expect(mapState.addLayer).not.toHaveBeenCalled();
+  });
+
+  it("does not claim the session expired when a public tiler returns 403", async () => {
+    mockFetch({ ok: false, status: 403 });
 
     await showImageryTool(baseMsg());
 
-    expect(showApiError).toHaveBeenCalledOnce();
+    expect(showApiError).not.toHaveBeenCalled();
     expect(mapState.addLayer).not.toHaveBeenCalled();
   });
 

--- a/app/store/chat-tools/__tests__/showImagery.test.ts
+++ b/app/store/chat-tools/__tests__/showImagery.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import type { Layer } from "@/app/store/layerManagerSlice";
+
+// Stateful mapStore mock: the handler reads layers back after mutating them
+// (to hide earlier captures and compute the reorder), so the mock must apply
+// the same semantics as the real slice.
+const mapState = {
+  layers: [] as Layer[],
+  addLayer: vi.fn((layer: Layer) => {
+    mapState.layers = [
+      ...mapState.layers.filter((l) => l.id !== layer.id),
+      { ...layer, opacity: layer.opacity ?? 1 },
+    ];
+  }),
+  setLayerVisibility: vi.fn((id: string, visible: boolean) => {
+    mapState.layers = mapState.layers.map((l) =>
+      l.id === id ? { ...l, visible } : l
+    );
+  }),
+  reorderLayers: vi.fn((ids: string[]) => {
+    mapState.layers = ids
+      .map((id) => mapState.layers.find((l) => l.id === id))
+      .filter((l): l is Layer => !!l);
+  }),
+};
+
+vi.mock("@/app/store/mapStore", () => ({
+  default: { getState: () => mapState },
+}));
+
+const showApiError = vi.fn();
+vi.mock("@/app/hooks/useErrorHandler", () => ({
+  showApiError: (...args: unknown[]) => showApiError(...args),
+}));
+
+import { showImageryTool } from "../showImagery";
+import type { ImageryInfo, StreamMessage } from "@/app/types/chat";
+
+const timestamp = new Date().toISOString();
+
+const imagery: ImageryInfo = {
+  tile_url: "https://tiles.example.com/{z}/{x}/{y}.png?url=s3",
+  tilejson_url: "https://tiles.example.com/tilejson.json?url=s3",
+  mosaic_id: "abc123",
+  item_count: 9,
+  date_start: "2026-06-12",
+  date_end: "2026-06-16",
+  target_date: "2026-06-15",
+  window_days: 30,
+  max_cloud_cover: 50,
+  aoi_names: ["Paracas National Reserve"],
+};
+
+const tileJson = {
+  bounds: [-77, -14.5, -76, -13.5] as [number, number, number, number],
+  minzoom: 8,
+  maxzoom: 14,
+};
+
+const baseMsg = (overrides: Partial<StreamMessage> = {}): StreamMessage => ({
+  type: "tool",
+  name: "show_imagery",
+  timestamp,
+  imagery,
+  ...overrides,
+});
+
+function mockFetch(response: Partial<Response> | Error) {
+  const fetchMock =
+    response instanceof Error
+      ? vi.fn().mockRejectedValue(response)
+      : vi.fn().mockResolvedValue({
+          ok: true,
+          status: 200,
+          json: async () => tileJson,
+          ...response,
+        });
+  vi.stubGlobal("fetch", fetchMock);
+  return fetchMock;
+}
+
+describe("showImageryTool", () => {
+  beforeEach(() => {
+    mapState.layers = [];
+    vi.clearAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("adds a raster layer keyed on the mosaic id with TileJSON tuning", async () => {
+    mockFetch({});
+
+    await showImageryTool(baseMsg());
+
+    expect(mapState.addLayer).toHaveBeenCalledOnce();
+    const layer = mapState.addLayer.mock.calls[0][0];
+    expect(layer).toMatchObject({
+      id: "imagery-abc123",
+      name: "Satellite Imagery (Jun 15, 2026)",
+      type: "raster",
+      visible: true,
+      tileUrl: imagery.tile_url,
+      minzoom: 8,
+      maxzoom: 14,
+      bounds: tileJson.bounds,
+      imagery,
+    });
+  });
+
+  it("requests the TileJSON without auth headers for non-API hosts", async () => {
+    const fetchMock = mockFetch({});
+
+    await showImageryTool(baseMsg());
+
+    expect(fetchMock).toHaveBeenCalledWith(imagery.tilejson_url, {
+      headers: {},
+    });
+  });
+
+  it("hides earlier captures and stacks the new one on top of them", async () => {
+    mockFetch({});
+    mapState.layers = [
+      { id: "dataset-4", name: "TCL", type: "raster", visible: true },
+      {
+        id: "imagery-old",
+        name: "Satellite Imagery",
+        type: "raster",
+        visible: true,
+        imagery: { ...imagery, mosaic_id: "old" },
+      },
+    ] as Layer[];
+
+    await showImageryTool(baseMsg());
+
+    const ids = mapState.layers.map((l) => l.id);
+    expect(ids).toEqual(["dataset-4", "imagery-abc123", "imagery-old"]);
+    const old = mapState.layers.find((l) => l.id === "imagery-old");
+    expect(old?.visible).toBe(false);
+    const dataset = mapState.layers.find((l) => l.id === "dataset-4");
+    expect(dataset?.visible).toBe(true);
+  });
+
+  it("re-running the same mosaic upserts instead of stacking", async () => {
+    mockFetch({});
+
+    await showImageryTool(baseMsg());
+    await showImageryTool(baseMsg());
+
+    expect(
+      mapState.layers.filter((l) => l.id === "imagery-abc123")
+    ).toHaveLength(1);
+    expect(mapState.layers[0].visible).toBe(true);
+  });
+
+  it("does nothing when the message carries no imagery", async () => {
+    const fetchMock = mockFetch({});
+
+    await showImageryTool(baseMsg({ imagery: undefined }));
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(mapState.addLayer).not.toHaveBeenCalled();
+  });
+
+  it("surfaces an auth error and adds no layer on 401", async () => {
+    mockFetch({ ok: false, status: 401 });
+
+    await showImageryTool(baseMsg());
+
+    expect(showApiError).toHaveBeenCalledOnce();
+    expect(mapState.addLayer).not.toHaveBeenCalled();
+  });
+
+  it("adds no layer and does not throw on a non-ok response", async () => {
+    mockFetch({ ok: false, status: 404 });
+
+    await expect(showImageryTool(baseMsg())).resolves.toBeUndefined();
+    expect(mapState.addLayer).not.toHaveBeenCalled();
+  });
+
+  it("adds no layer and does not throw when the fetch rejects", async () => {
+    mockFetch(new Error("network down"));
+
+    await expect(showImageryTool(baseMsg())).resolves.toBeUndefined();
+    expect(mapState.addLayer).not.toHaveBeenCalled();
+  });
+});

--- a/app/store/chat-tools/showImagery.ts
+++ b/app/store/chat-tools/showImagery.ts
@@ -1,0 +1,114 @@
+import { StreamMessage } from "@/app/types/chat";
+import useMapStore from "../mapStore";
+import { API_CONFIG } from "@/app/config/api";
+import { getAuthHeaders } from "@/app/lib/api-client";
+import { showApiError } from "@/app/hooks/useErrorHandler";
+import {
+  IMAGERY_ATTRIBUTION,
+  imageryLayerId,
+  imageryLayerTitle,
+  isImageryLayerId,
+} from "@/app/utils/imagery";
+
+interface TileJson {
+  bounds?: [number, number, number, number];
+  minzoom?: number;
+  maxzoom?: number;
+}
+
+/**
+ * Fetches a tiler resource. The backend emits absolute URLs pointing at
+ * whatever tiler it is configured to use — currently the public GFW tiles
+ * service, which needs no auth. If the tiler is ever the Zeno API itself,
+ * its routes require bearer auth, so attach it for API-origin URLs.
+ */
+function fetchTileJson(url: string): Promise<Response> {
+  const headers = url.startsWith(API_CONFIG.API_HOST) ? getAuthHeaders() : {};
+  return fetch(url, { headers });
+}
+
+/**
+ * Handles the show_imagery tool: renders the Sentinel-2 mosaic from the
+ * `imagery` agent-state entry as a raster layer.
+ *
+ * Each run adds a capture to the imagery legend group. The newest capture is
+ * shown and earlier ones are hidden (not removed) — the legend's per-capture
+ * toggles bring them back for comparison. Re-running an identical request
+ * yields the same mosaic_id and simply upserts the existing layer, which
+ * also makes thread replay idempotent.
+ *
+ * The TileJSON is fetched first for the mosaic's bounds and zoom range;
+ * without the range MapLibre would request tiles outside it and get 404s
+ * instead of overscaling. A failure to fetch it is a rare hard error
+ * (expired mosaic, malformed URL) and the layer is simply not shown.
+ */
+export async function showImageryTool(streamMessage: StreamMessage) {
+  const imagery = streamMessage.imagery;
+  if (!imagery) return;
+
+  const { addLayer, setLayerVisibility, reorderLayers } =
+    useMapStore.getState();
+
+  let tileJson: TileJson;
+  try {
+    const res = await fetchTileJson(imagery.tilejson_url);
+    if (res.status === 401 || res.status === 403) {
+      showApiError(
+        "Your session has expired. Please sign in again to view satellite imagery.",
+        { title: "Session Expired" }
+      );
+      return;
+    }
+    if (!res.ok) {
+      console.warn(
+        `Imagery mosaic unavailable (HTTP ${res.status}); not showing layer`
+      );
+      return;
+    }
+    tileJson = (await res.json()) as TileJson;
+  } catch (error) {
+    console.error("Failed to load imagery TileJSON:", error);
+    return;
+  }
+
+  const id = imageryLayerId(imagery.mosaic_id);
+
+  // Newest capture wins: hide earlier captures so the map shows the mosaic
+  // the agent just produced. They stay in the legend for toggling back.
+  useMapStore
+    .getState()
+    .layers.filter((l) => isImageryLayerId(l.id) && l.id !== id && l.visible)
+    .forEach((l) => setLayerVisibility(l.id, false));
+
+  addLayer({
+    id,
+    name: imageryLayerTitle(imagery.target_date),
+    type: "raster",
+    visible: true,
+    tileUrl: imagery.tile_url,
+    minzoom: tileJson.minzoom,
+    maxzoom: tileJson.maxzoom,
+    bounds: tileJson.bounds,
+    attribution: IMAGERY_ATTRIBUTION,
+    startDate: imagery.date_start,
+    endDate: imagery.date_end,
+    imagery,
+  });
+
+  // addLayer appends, which would leave the new mosaic underneath any
+  // earlier ones it overlaps. Reorder so the newest imagery layer sits at
+  // the top of the imagery group (which itself stays below dataset rasters —
+  // see DynamicTileLayers).
+  const layers = useMapStore.getState().layers;
+  const nonImageryIds = layers
+    .filter((l) => !isImageryLayerId(l.id))
+    .map((l) => l.id);
+  const olderImageryIds = layers
+    .filter((l) => isImageryLayerId(l.id) && l.id !== id)
+    .map((l) => l.id);
+  reorderLayers([...nonImageryIds, id, ...olderImageryIds]);
+
+  // No camera movement here: the viewport was already positioned by
+  // pick_aoi, and re-fitting to the mosaic bounds would yank the map
+  // away from wherever the user is looking.
+}

--- a/app/store/chat-tools/showImagery.ts
+++ b/app/store/chat-tools/showImagery.ts
@@ -21,10 +21,25 @@ interface TileJson {
  * whatever tiler it is configured to use — currently the public GFW tiles
  * service, which needs no auth. If the tiler is ever the Zeno API itself,
  * its routes require bearer auth, so attach it for API-origin URLs.
+ *
+ * Origins are compared rather than prefix-matched: `startsWith(API_HOST)` also
+ * matches `https://api.staging.globalnaturewatch.org.example.com`, which would
+ * hand that host the user's bearer token.
+ *
+ * Reports back whether the request went to our own API so the caller can tell
+ * an expired session from a third-party tiler refusing the request.
  */
-function fetchTileJson(url: string): Promise<Response> {
-  const headers = url.startsWith(API_CONFIG.API_HOST) ? getAuthHeaders() : {};
-  return fetch(url, { headers });
+async function fetchTileJson(
+  url: string
+): Promise<{ res: Response; sameOrigin: boolean }> {
+  let sameOrigin = false;
+  try {
+    sameOrigin = new URL(url).origin === new URL(API_CONFIG.API_HOST).origin;
+  } catch {
+    // Malformed URL — send no credentials and let fetch reject below.
+  }
+  const res = await fetch(url, { headers: sameOrigin ? getAuthHeaders() : {} });
+  return { res, sameOrigin };
 }
 
 /**
@@ -51,8 +66,11 @@ export async function showImageryTool(streamMessage: StreamMessage) {
 
   let tileJson: TileJson;
   try {
-    const res = await fetchTileJson(imagery.tilejson_url);
-    if (res.status === 401 || res.status === 403) {
+    const { res, sameOrigin } = await fetchTileJson(imagery.tilejson_url);
+    // Only an auth failure against our own API means the session lapsed. The
+    // public tiler also answers 401/403 for rate limits and expired mosaics,
+    // where telling the user to sign in again sends them down a dead end.
+    if (sameOrigin && (res.status === 401 || res.status === 403)) {
       showApiError(
         "Your session has expired. Please sign in again to view satellite imagery.",
         { title: "Session Expired" }

--- a/app/store/chatStore.ts
+++ b/app/store/chatStore.ts
@@ -386,8 +386,12 @@ async function processStreamMessage(
       );
       return;
     }
-    // Handling for show_imagery tool: render the Sentinel-2 mosaic on the map
-    else if (streamMessage.name === "show_imagery" && streamMessage.imagery) {
+    // Handling for show_imagery tool: render the Sentinel-2 mosaic on the map.
+    // Deliberately not gated on `streamMessage.imagery`: a result carrying no
+    // payload (no scenes matched, soft backend failure) still has to clear the
+    // updating flag, or the legend sits on "Updating mosaic…" until the turn's
+    // safety net fires. showImageryTool no-ops when the payload is missing.
+    else if (streamMessage.name === "show_imagery") {
       // Clear the flag in the same microtask that adds the capture, so the
       // legend swaps "Updating mosaic…" → capture in a single render.
       void Promise.resolve().then(async () => {

--- a/app/store/chatStore.ts
+++ b/app/store/chatStore.ts
@@ -32,6 +32,7 @@ import { generateInsightsTool } from "./chat-tools/generateInsights";
 import { pickAoiTool } from "./chat-tools/pickAoi";
 import { pickDatasetTool } from "./chat-tools/pickDataset";
 import { pullDataTool } from "./chat-tools/pullData";
+import { showImageryTool } from "./chat-tools/showImagery";
 import { queryClient } from "@/app/lib/query-client";
 import { dashboardKeys } from "@/src/features/dashboards/ui/dashboardQueries";
 import {
@@ -58,6 +59,10 @@ interface ChatState {
   // arriving. Distinct from isLoading (true for the whole request) so the
   // insight workspace loading state surfaces only when an insight is on the way.
   isGeneratingInsight: boolean;
+  // True only while the agent is actively building a mosaic — i.e. between
+  // the agent announcing a show_imagery tool call and that tool's result
+  // arriving. Drives the legend's "Updating mosaic…" state.
+  isImageryUpdating: boolean;
   abortController: AbortController | null;
   currentThreadId: string | null;
   toolSteps: ToolStepData[];
@@ -92,6 +97,7 @@ interface ChatActions {
   ) => Promise<{ isNew: boolean; id: string }>;
   setLoading: (loading: boolean) => void;
   setGeneratingInsight: (generating: boolean) => void;
+  setImageryUpdating: (updating: boolean) => void;
   generateNewThread: () => string;
   fetchThread: (
     threadId: string,
@@ -126,6 +132,7 @@ You can ask me about land cover change, forest loss, or biodiversity risks in pl
   ],
   isLoading: false,
   isGeneratingInsight: false,
+  isImageryUpdating: false,
   abortController: null,
   currentThreadId: null,
   toolSteps: [],
@@ -227,6 +234,9 @@ async function processStreamMessage(
     if (streamMessage.tool_calls?.includes("generate_insights")) {
       setGeneratingInsight(true);
     }
+    if (streamMessage.tool_calls?.includes("show_imagery")) {
+      useChatStore.getState().setImageryUpdating(true);
+    }
     return;
   }
   if (streamMessage.type === "error") {
@@ -234,6 +244,10 @@ async function processStreamMessage(
     // state so the workspace skeleton doesn't linger while the agent recovers.
     if (streamMessage.name === "generate_insights") {
       setGeneratingInsight(false);
+    }
+    // Likewise no mosaic is coming — clear the legend's updating state.
+    if (streamMessage.name === "show_imagery") {
+      useChatStore.getState().setImageryUpdating(false);
     }
     // Handle timeout errors specifically
     if (streamMessage.name === "timeout") {
@@ -275,6 +289,9 @@ async function processStreamMessage(
     // while the chart is computed.
     if (streamMessage.tool_calls?.includes("generate_insights")) {
       setGeneratingInsight(true);
+    }
+    if (streamMessage.tool_calls?.includes("show_imagery")) {
+      useChatStore.getState().setImageryUpdating(true);
     }
     const pending = getPendingTraceId();
     const traceToUse = streamMessage.trace_id || pending || undefined;
@@ -367,6 +384,17 @@ async function processStreamMessage(
       void Promise.resolve().then(() =>
         pullDataTool(streamMessage, addMessage)
       );
+      return;
+    }
+    // Handling for show_imagery tool: render the Sentinel-2 mosaic on the map
+    else if (streamMessage.name === "show_imagery" && streamMessage.imagery) {
+      // Clear the flag in the same microtask that adds the capture, so the
+      // legend swaps "Updating mosaic…" → capture in a single render.
+      void Promise.resolve().then(async () => {
+        // Non-blocking: TileJSON fetch shouldn't stall the stream
+        await showImageryTool(streamMessage);
+        useChatStore.getState().setImageryUpdating(false);
+      });
       return;
     }
   }
@@ -539,6 +567,7 @@ const useChatStore = create<ChatState & ChatActions>((set, get) => ({
     // Reset any stale insight-generating flag from a prior turn; it is set
     // true only once this turn's agent announces a generate_insights call.
     setGeneratingInsight(false);
+    get().setImageryUpdating(false);
 
     const ui_context = diffUiContext(uiContext, keys, get().lastSentContext);
     // Record what we're sending so the same context isn't re-announced next
@@ -762,9 +791,11 @@ const useChatStore = create<ChatState & ChatActions>((set, get) => ({
       attachToolStepsToLastUserMessage();
 
       setLoading(false);
-      // Safety net: clear the insight-generating flag in case generate_insights
-      // was announced but never produced a result (error, abort, timeout).
+      // Safety net: clear the tool-in-flight flags in case generate_insights /
+      // show_imagery was announced but never produced a result (error, abort,
+      // timeout).
       setGeneratingInsight(false);
+      get().setImageryUpdating(false);
 
       queryClient.invalidateQueries({ queryKey: ["threads"] });
       return { isNew: !currentThreadId, id: threadId };
@@ -775,6 +806,8 @@ const useChatStore = create<ChatState & ChatActions>((set, get) => ({
 
   setGeneratingInsight: (generating) =>
     set({ isGeneratingInsight: generating }),
+
+  setImageryUpdating: (updating) => set({ isImageryUpdating: updating }),
 
   cancelRequest: () => {
     const controller = get().abortController;
@@ -1052,6 +1085,7 @@ const useChatStore = create<ChatState & ChatActions>((set, get) => ({
 
       setLoading(false);
       setGeneratingInsight(false);
+      get().setImageryUpdating(false);
     }
   },
 }));

--- a/app/store/layerManagerSlice.ts
+++ b/app/store/layerManagerSlice.ts
@@ -1,6 +1,6 @@
 import { StateCreator } from "zustand";
 import { FeatureCollection, Feature } from "geojson";
-import type { AOISelection } from "@/app/types/chat";
+import type { AOISelection, ImageryInfo } from "@/app/types/chat";
 import type { VectorStyleSpec } from "@/app/constants/datasets";
 import type { MapState } from "./mapStore";
 
@@ -38,6 +38,15 @@ export interface Layer {
   parentLayerId?: string;
   // Data-driven fill/line paint spec for type:"vector" context layers
   vectorStyle?: VectorStyleSpec;
+  // Raster source tuning, derived from a mosaic's TileJSON. Without the zoom
+  // range MapLibre would request tiles outside the mosaic's range and get
+  // 404s instead of overscaling.
+  minzoom?: number;
+  maxzoom?: number;
+  bounds?: [number, number, number, number];
+  attribution?: string;
+  // Set when added from show_imagery (Sentinel-2 mosaic legend metadata)
+  imagery?: ImageryInfo;
 }
 
 // The two MVT renderers partition vector layers by whether they carry a

--- a/app/types/chat.ts
+++ b/app/types/chat.ts
@@ -165,6 +165,7 @@ export interface StreamMessage {
   suggested_datasets?: SuggestedDataset[];
   aoi?: object;
   aoi_selection?: AOISelection;
+  imagery?: ImageryInfo;
   insights?: object[];
   charts_data?: object[];
   codeact_parts?: CodeActPart[];
@@ -187,6 +188,32 @@ export interface StreamMessage {
   // tells the client to refetch the named resource.
   msg_type?: string;
   dashboard_id?: string;
+}
+
+// Sentinel-2 mosaic payload written to agent state by the show_imagery tool.
+// tile_url / tilejson_url are absolute URLs to the tiler the backend is
+// configured to use (currently the public GFW tiles service). mosaic_id is an
+// opaque recipe token, stable across reruns of the same request.
+export interface ImageryInfo {
+  tile_url: string;
+  tilejson_url: string;
+  mosaic_id: string;
+  // Scene count and acquired date range; optional because payloads written
+  // before wri/project-zeno#758 omitted them on mosaic cache hits.
+  item_count?: number;
+  date_start?: string;
+  date_end?: string;
+  // Observed cloud-cover stats across the mosaic's scenes (%), added by
+  // wri/project-zeno#758 — absent on older payloads.
+  mean_cloud_cover?: number;
+  min_cloud_cover?: number;
+  max_cloud_cover_observed?: number;
+  target_date: string;
+  aoi_names: string[];
+  // Search constraints used to build the mosaic. Absent on payloads created
+  // before these fields existed (replayed old threads).
+  window_days?: number;
+  max_cloud_cover?: number;
 }
 
 export interface AOI {
@@ -303,6 +330,7 @@ export interface LangChainUpdate {
   suggested_datasets?: SuggestedDataset[];
   aoi?: object;
   aoi_selection?: AOISelection;
+  imagery?: ImageryInfo;
   start_date?: string;
   end_date?: string;
   insights: object[];

--- a/app/utils/__tests__/imagery.test.ts
+++ b/app/utils/__tests__/imagery.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  captureMetaLabel,
+  formatCaptureDate,
+  imageryCloudNote,
+  imageryLayerId,
+  imageryLayerTitle,
+  imageryLegendInfo,
+  imageryLegendParams,
+  imageryThumbnailUrl,
+  isImageryLayerId,
+} from "@/app/utils/imagery";
+
+const fullMeta = {
+  item_count: 9,
+  date_start: "2026-06-12",
+  date_end: "2026-06-16",
+  target_date: "2026-06-15",
+  window_days: 30,
+  max_cloud_cover: 50,
+  aoi_names: ["Paracas National Reserve"],
+};
+
+describe("imageryLegendParams", () => {
+  it("builds DATES, WINDOW, CLOUD and AREA chips from full metadata", () => {
+    const params = imageryLegendParams(fullMeta);
+    expect(params).toEqual([
+      {
+        label: "DATES",
+        value: "Jun 12 – Jun 16, 2026",
+        maxValueWidth: "26ch",
+      },
+      { label: "WINDOW", value: "±30 days" },
+      { label: "CLOUD", value: "< 50%" },
+      { label: "AREA", value: "Paracas National Reserve" },
+    ]);
+  });
+
+  it("keeps the start year on a cross-year range", () => {
+    const params = imageryLegendParams({
+      date_start: "2025-12-28",
+      date_end: "2026-01-04",
+    });
+    expect(params[0].value).toBe("Dec 28, 2025 – Jan 4, 2026");
+  });
+
+  it("joins multiple AOI names into one AREA chip", () => {
+    const params = imageryLegendParams({ aoi_names: ["Peru", "Paracas"] });
+    expect(params).toEqual([{ label: "AREA", value: "Peru, Paracas" }]);
+  });
+
+  it("omits every chip whose metadata is missing", () => {
+    expect(imageryLegendParams({})).toEqual([]);
+    expect(imageryLegendParams({ date_start: "2026-06-12" })).toEqual([]);
+    expect(imageryLegendParams({ aoi_names: [] })).toEqual([]);
+  });
+
+  it("falls back to full dates when a bound is unparseable", () => {
+    const params = imageryLegendParams({
+      date_start: "not-a-date",
+      date_end: "2026-06-16",
+    });
+    expect(params[0].value).toBe("not-a-date – Jun 16, 2026");
+  });
+});
+
+describe("imageryLegendInfo", () => {
+  it("mentions scene count, target date and attribution", () => {
+    expect(imageryLegendInfo(fullMeta)).toBe(
+      "Sentinel-2 true-colour mosaic built from 9 scenes closest to Jun 15, 2026. Contains modified Copernicus Sentinel data."
+    );
+  });
+
+  it("singularises one scene and skips missing parts", () => {
+    expect(imageryLegendInfo({ item_count: 1 })).toBe(
+      "Sentinel-2 true-colour mosaic built from 1 scene. Contains modified Copernicus Sentinel data."
+    );
+    expect(imageryLegendInfo({})).toBe(
+      "Sentinel-2 true-colour mosaic. Contains modified Copernicus Sentinel data."
+    );
+  });
+
+  it("includes observed mean cloud cover when present", () => {
+    expect(imageryLegendInfo({ mean_cloud_cover: 12.4 })).toContain(
+      "Mean observed cloud cover 12%."
+    );
+  });
+});
+
+describe("imageryCloudNote", () => {
+  it("returns a note above the default cloud limit", () => {
+    expect(imageryCloudNote({ max_cloud_cover: 50 })).toBe(
+      "Searched with a loosened cloud-cover limit (50%) — imagery may contain clouds."
+    );
+  });
+
+  it("returns undefined at or below the default, or when unknown", () => {
+    expect(imageryCloudNote({ max_cloud_cover: 20 })).toBeUndefined();
+    expect(imageryCloudNote({ max_cloud_cover: 10 })).toBeUndefined();
+    expect(imageryCloudNote({})).toBeUndefined();
+  });
+});
+
+describe("captureMetaLabel", () => {
+  it("combines cloud limit and scene count", () => {
+    expect(captureMetaLabel(fullMeta)).toBe("cloud <50% · 9 scenes");
+    expect(captureMetaLabel({ item_count: 1 })).toBe("1 scene");
+    expect(captureMetaLabel({ max_cloud_cover: 20 })).toBe("cloud <20%");
+    expect(captureMetaLabel({})).toBe("");
+  });
+});
+
+describe("titles and ids", () => {
+  it("formats the layer title with the target date", () => {
+    expect(imageryLayerTitle("2026-06-15")).toBe(
+      "Satellite Imagery (Jun 15, 2026)"
+    );
+    expect(imageryLayerTitle()).toBe("Satellite Imagery");
+    expect(imageryLayerTitle("garbage")).toBe("Satellite Imagery (garbage)");
+  });
+
+  it("formats capture dates per the design", () => {
+    expect(formatCaptureDate("2026-06-15")).toBe("15 Jun 2026");
+    expect(formatCaptureDate("garbage")).toBe("garbage");
+  });
+
+  it("builds and recognises imagery layer ids", () => {
+    expect(imageryLayerId("abc123")).toBe("imagery-abc123");
+    expect(isImageryLayerId("imagery-abc123")).toBe(true);
+    expect(isImageryLayerId("dataset-4")).toBe(false);
+  });
+});
+
+describe("imageryThumbnailUrl", () => {
+  const template = "https://tiles.example.com/{z}/{x}/{y}.png?url=s3";
+
+  it("substitutes the centre tile at a zoom matching the extent", () => {
+    // 2°×2° extent centred on (0,0): zoom = ceil(log2(360/2)) = 8, centre
+    // tile of the 256×256 grid.
+    expect(imageryThumbnailUrl(template, [-1, -1, 1, 1])).toBe(
+      "https://tiles.example.com/8/128/128.png?url=s3"
+    );
+  });
+
+  it("clamps the zoom to the mosaic's range", () => {
+    const url = imageryThumbnailUrl(template, [-1, -1, 1, 1], 10, 14);
+    expect(url).toContain("/10/");
+    const wide = imageryThumbnailUrl(template, [-170, -60, 170, 60], 8, 14);
+    expect(wide).toContain("/8/");
+  });
+
+  it("returns undefined without bounds or with a degenerate extent", () => {
+    expect(imageryThumbnailUrl(template)).toBeUndefined();
+    expect(imageryThumbnailUrl(template, [10, 10, 10, 10])).toBeUndefined();
+  });
+});

--- a/app/utils/__tests__/imagery.test.ts
+++ b/app/utils/__tests__/imagery.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 
 import {
+  buildImageryGroup,
   captureMetaLabel,
   formatCaptureDate,
   imageryCloudNote,
@@ -11,6 +12,7 @@ import {
   imageryThumbnailUrl,
   isImageryLayerId,
 } from "@/app/utils/imagery";
+import type { Layer } from "@/app/store/layerManagerSlice";
 
 const fullMeta = {
   item_count: 9,
@@ -129,6 +131,87 @@ describe("titles and ids", () => {
     expect(imageryLayerId("abc123")).toBe("imagery-abc123");
     expect(isImageryLayerId("imagery-abc123")).toBe(true);
     expect(isImageryLayerId("dataset-4")).toBe(false);
+  });
+});
+
+describe("buildImageryGroup", () => {
+  const imageryLayer = (
+    id: string,
+    overrides: Partial<Layer> = {},
+    metaOverrides: Record<string, unknown> = {}
+  ): Layer =>
+    ({
+      id,
+      name: "Satellite Imagery",
+      type: "raster",
+      visible: true,
+      opacity: 0.8,
+      tileUrl: "https://tiles.example.com/{z}/{x}/{y}.png",
+      bounds: [-1, -1, 1, 1],
+      minzoom: 8,
+      maxzoom: 14,
+      imagery: { ...fullMeta, mosaic_id: id, ...metaOverrides },
+      ...overrides,
+    }) as Layer;
+
+  it("returns null when there are no captures and nothing updating", () => {
+    expect(buildImageryGroup([], false)).toBeNull();
+  });
+
+  it("builds the group from the newest (first) capture", () => {
+    const group = buildImageryGroup(
+      [
+        imageryLayer("imagery-new"),
+        imageryLayer(
+          "imagery-old",
+          { visible: false },
+          { target_date: "2026-05-15", aoi_names: ["Pacaya-Samiria"] }
+        ),
+      ],
+      false
+    );
+
+    expect(group).toMatchObject({
+      kind: "imagery",
+      id: "imagery-group",
+      title: "Satellite Imagery",
+      opacity: 80,
+      updating: false,
+      areaCount: 2,
+    });
+    expect(group?.params.map((p) => p.label)).toEqual([
+      "DATES",
+      "WINDOW",
+      "CLOUD",
+      "AREA",
+    ]);
+    expect(group?.captures).toHaveLength(2);
+    expect(group?.captures[0]).toMatchObject({
+      layerId: "imagery-new",
+      live: true,
+      visible: true,
+      dateLabel: "15 Jun 2026",
+      metaLabel: "cloud <50% · 9 scenes",
+    });
+    expect(group?.captures[1]).toMatchObject({
+      layerId: "imagery-old",
+      live: false,
+      visible: false,
+      areaLabel: "Pacaya-Samiria",
+    });
+    expect(group?.captures[0].thumbnailUrl).toContain("/8/128/128");
+  });
+
+  it("returns an updating stub when no capture has landed yet", () => {
+    const group = buildImageryGroup([], true);
+    expect(group).toMatchObject({
+      kind: "imagery",
+      updating: true,
+      captures: [],
+      params: [],
+      areaCount: 0,
+    });
+    expect(group?.info).toBeUndefined();
   });
 });
 

--- a/app/utils/imagery.ts
+++ b/app/utils/imagery.ts
@@ -1,7 +1,11 @@
 import { format, parseISO } from "date-fns";
 
 import type { ImageryInfo } from "@/app/types/chat";
-import type { LegendParam } from "@/app/components/legend/types";
+import type {
+  ImageryLegendGroup,
+  LegendParam,
+} from "@/app/components/legend/types";
+import type { Layer } from "@/app/store/layerManagerSlice";
 
 /**
  * Metadata driving an imagery legend entry — the ImageryState payload the
@@ -157,6 +161,56 @@ export function captureMetaLabel(meta: ImageryLegendMeta): string {
     parts.push(`${meta.item_count} scene${meta.item_count === 1 ? "" : "s"}`);
   }
   return parts.join(" · ");
+}
+
+/**
+ * Builds the single "Satellite Imagery" legend group from the imagery map
+ * layers (one per show_imagery capture, newest first in the layer array).
+ * Summary fields come from the newest (live) capture. Returns null when
+ * there is nothing to show. Shared by the explorer legend hook and the
+ * dashboard map-widget legend.
+ */
+export function buildImageryGroup(
+  imageryLayers: Layer[],
+  updating: boolean
+): ImageryLegendGroup | null {
+  if (imageryLayers.length === 0 && !updating) return null;
+
+  const live = imageryLayers[0];
+  const captures = imageryLayers.map((layer, index) => {
+    const imagery = layer.imagery!;
+    return {
+      layerId: layer.id,
+      areaLabel: imagery.aoi_names?.join(", ") || layer.name,
+      dateLabel: formatCaptureDate(imagery.target_date),
+      metaLabel: captureMetaLabel(imagery),
+      visible: layer.visible,
+      live: index === 0,
+      thumbnailUrl: layer.tileUrl
+        ? imageryThumbnailUrl(
+            layer.tileUrl,
+            layer.bounds,
+            layer.minzoom,
+            layer.maxzoom
+          )
+        : undefined,
+    };
+  });
+
+  return {
+    kind: "imagery",
+    id: IMAGERY_LEGEND_GROUP_ID,
+    title: IMAGERY_LAYER_NAME,
+    subtitle: IMAGERY_SUBTITLE,
+    opacity: (live?.opacity ?? 1) * 100,
+    params: live?.imagery ? imageryLegendParams(live.imagery) : [],
+    info: live?.imagery ? imageryLegendInfo(live.imagery) : undefined,
+    note: live?.imagery ? imageryCloudNote(live.imagery) : undefined,
+    captures,
+    areaCount: new Set(captures.map((c) => c.areaLabel)).size,
+    updating,
+    thumbnailUrl: captures[0]?.thumbnailUrl,
+  };
 }
 
 /**

--- a/app/utils/imagery.ts
+++ b/app/utils/imagery.ts
@@ -1,0 +1,210 @@
+import { format, parseISO } from "date-fns";
+
+import type { ImageryInfo } from "@/app/types/chat";
+import type { LegendParam } from "@/app/components/legend/types";
+
+/**
+ * Metadata driving an imagery legend entry — the ImageryState payload the
+ * show_imagery tool writes to agent state, whether carried on an explorer map
+ * layer or snapshotted into a dashboard map widget's config. Field names
+ * follow the wire format (snake_case) so both consumers can pass their
+ * payloads through unmapped.
+ *
+ * Everything is optional: payloads created before a field existed simply lack
+ * it (item_count / date_start / date_end were omitted on mosaic cache hits
+ * before wri/project-zeno#758). Builders below omit whatever is missing
+ * rather than failing.
+ */
+export type ImageryLegendMeta = Partial<
+  Pick<
+    ImageryInfo,
+    | "item_count"
+    | "date_start"
+    | "date_end"
+    | "mean_cloud_cover"
+    | "min_cloud_cover"
+    | "max_cloud_cover_observed"
+    | "target_date"
+    | "window_days"
+    | "max_cloud_cover"
+    | "aoi_names"
+  >
+>;
+
+export const IMAGERY_LAYER_ID_PREFIX = "imagery-";
+export const IMAGERY_LEGEND_GROUP_ID = "imagery-group";
+export const IMAGERY_LAYER_NAME = "Satellite Imagery";
+export const IMAGERY_SUBTITLE = "Sentinel-2 · True-colour";
+export const IMAGERY_ATTRIBUTION = "Contains modified Copernicus Sentinel data";
+
+// Backend default for show_imagery's max_cloud_cover; anything above it
+// means the agent loosened the search and clouds are expected.
+export const IMAGERY_DEFAULT_MAX_CLOUD_COVER = 20;
+
+export function imageryLayerId(mosaicId: string): string {
+  return `${IMAGERY_LAYER_ID_PREFIX}${mosaicId}`;
+}
+
+export function isImageryLayerId(id: string): boolean {
+  return id.startsWith(IMAGERY_LAYER_ID_PREFIX);
+}
+
+function formatImageryDate(isoDate: string): string {
+  try {
+    return format(parseISO(isoDate), "MMM d, yyyy");
+  } catch {
+    return isoDate;
+  }
+}
+
+// Compact acquired-date range, e.g. "May 28 – Jun 3, 2026": the start date's
+// year is elided within a single year so the chip survives the dashboard
+// legend's 300px width without truncating away the end date.
+function formatImageryDateRange(startIso: string, endIso: string): string {
+  try {
+    const start = parseISO(startIso);
+    const end = parseISO(endIso);
+    const startLabel =
+      format(start, "yyyy") === format(end, "yyyy")
+        ? format(start, "MMM d")
+        : format(start, "MMM d, yyyy");
+    return `${startLabel} – ${format(end, "MMM d, yyyy")}`;
+  } catch {
+    return `${formatImageryDate(startIso)} – ${formatImageryDate(endIso)}`;
+  }
+}
+
+/** Capture-row date per the Figma spec, e.g. "15 Jun 2026". */
+export function formatCaptureDate(isoDate: string): string {
+  try {
+    return format(parseISO(isoDate), "d MMM yyyy");
+  } catch {
+    return isoDate;
+  }
+}
+
+/** Legend/layer title, e.g. "Satellite Imagery (Jun 15, 2026)". */
+export function imageryLayerTitle(targetDate?: string): string {
+  if (!targetDate) return IMAGERY_LAYER_NAME;
+  return `${IMAGERY_LAYER_NAME} (${formatImageryDate(targetDate)})`;
+}
+
+/**
+ * The read-only chips under an imagery legend title. Each chip is omitted
+ * when its metadata is missing (pre-#758 cache hits, old payloads).
+ */
+export function imageryLegendParams(meta: ImageryLegendMeta): LegendParam[] {
+  const params: LegendParam[] = [];
+  if (meta.date_start && meta.date_end) {
+    params.push({
+      label: "DATES",
+      value: formatImageryDateRange(meta.date_start, meta.date_end),
+      // Wide enough for a cross-year range ("Dec 28, 2025 – Jan 4, 2026");
+      // the default 15ch would hide the end date behind an ellipsis.
+      maxValueWidth: "26ch",
+    });
+  }
+  if (meta.window_days !== undefined) {
+    params.push({ label: "WINDOW", value: `±${meta.window_days} days` });
+  }
+  if (meta.max_cloud_cover !== undefined) {
+    params.push({ label: "CLOUD", value: `< ${meta.max_cloud_cover}%` });
+  }
+  if (meta.aoi_names && meta.aoi_names.length > 0) {
+    params.push({ label: "AREA", value: meta.aoi_names.join(", ") });
+  }
+  return params;
+}
+
+/** The info-popover sentence for an imagery legend entry. */
+export function imageryLegendInfo(meta: ImageryLegendMeta): string {
+  const scenes =
+    meta.item_count !== undefined
+      ? ` built from ${meta.item_count} scene${meta.item_count === 1 ? "" : "s"}`
+      : "";
+  const closest = meta.target_date
+    ? ` closest to ${formatImageryDate(meta.target_date)}`
+    : "";
+  const observed =
+    meta.mean_cloud_cover !== undefined
+      ? ` Mean observed cloud cover ${Math.round(meta.mean_cloud_cover)}%.`
+      : "";
+  return `Sentinel-2 true-colour mosaic${scenes}${closest}.${observed} ${IMAGERY_ATTRIBUTION}.`;
+}
+
+/**
+ * A cautionary note shown when the search ran above the default cloud-cover
+ * limit — partly obscured imagery is then expected and shouldn't read as a
+ * rendering bug. Undefined when the default (or a stricter) limit applied.
+ */
+export function imageryCloudNote(meta: ImageryLegendMeta): string | undefined {
+  if (
+    meta.max_cloud_cover === undefined ||
+    meta.max_cloud_cover <= IMAGERY_DEFAULT_MAX_CLOUD_COVER
+  ) {
+    return undefined;
+  }
+  return `Searched with a loosened cloud-cover limit (${meta.max_cloud_cover}%) — imagery may contain clouds.`;
+}
+
+/** Capture-row meta line, e.g. "cloud <50% · 9 scenes". */
+export function captureMetaLabel(meta: ImageryLegendMeta): string {
+  const parts: string[] = [];
+  if (meta.max_cloud_cover !== undefined) {
+    parts.push(`cloud <${meta.max_cloud_cover}%`);
+  }
+  if (meta.item_count !== undefined) {
+    parts.push(`${meta.item_count} scene${meta.item_count === 1 ? "" : "s"}`);
+  }
+  return parts.join(" · ");
+}
+
+/**
+ * A single-tile preview URL for a mosaic, used as the legend/card thumbnail.
+ * Picks the zoom whose tile is just smaller than the mosaic's extent (so the
+ * preview is filled with imagery rather than empty margins), clamped to the
+ * mosaic's zoom range, and takes the tile at the extent's centre.
+ */
+export function imageryThumbnailUrl(
+  tileUrl: string,
+  bounds?: [number, number, number, number],
+  minzoom = 0,
+  maxzoom = 22
+): string | undefined {
+  if (!bounds) return undefined;
+  const [west, south, east, north] = bounds;
+  const crossesDateline = west > east;
+  const lonSpan = crossesDateline ? 360 - west + east : east - west;
+  const latSpan = north - south;
+  const maxSpan = Math.max(lonSpan, latSpan);
+  if (!(maxSpan > 0)) return undefined;
+
+  const zoom = Math.min(
+    Math.max(Math.ceil(Math.log2(360 / maxSpan)), minzoom),
+    maxzoom
+  );
+
+  let lonCenter = west + lonSpan / 2;
+  if (lonCenter > 180) lonCenter -= 360;
+  const latCenter = (south + north) / 2;
+
+  const n = 2 ** zoom;
+  const x = Math.min(Math.floor(((lonCenter + 180) / 360) * n), n - 1);
+  const latRad = (latCenter * Math.PI) / 180;
+  const y = Math.min(
+    Math.max(
+      Math.floor(
+        ((1 - Math.log(Math.tan(latRad) + 1 / Math.cos(latRad)) / Math.PI) /
+          2) *
+          n
+      ),
+      0
+    ),
+    n - 1
+  );
+
+  return tileUrl
+    .replace("{z}", String(zoom))
+    .replace("{x}", String(x))
+    .replace("{y}", String(y));
+}


### PR DESCRIPTION
Re-implements `feat/sentinel-2-visualization` against current develop (the old branch was 379 commits behind) and adds the Satellite Imagery legend from the Phase 3 Figma designs ([section 1453-4494](https://www.figma.com/design/a4jBBuwr0FQfKTY3l8aOKM/-Global-Nature-Watch--Phase-3?node-id=1453-4494)). First PR of a stack — `feat/imagery-chat-card` (chat data card) and `feat/imagery-dashboard` (dashboard legend + full-width widgets) branch off this one.

## Stream + map core

- `ImageryInfo` on `StreamMessage`/`LangChainUpdate` and passthrough in `parse-stream-message.ts`. Includes the observed cloud-cover stats being added by wri/project-zeno#758 — **every** metadata field is optional so pre-#758 cache-hit payloads and replayed old threads degrade gracefully.
- `show_imagery` dispatch in `chatStore` → new `app/store/chat-tools/showImagery.ts`: fetches the mosaic TileJSON for bounds/zoom range (without it MapLibre 404s outside z8–14 instead of overscaling), then upserts a raster layer keyed `imagery-<mosaic_id>` — identical reruns and thread replay are idempotent.
- **Newest capture wins**: a new capture hides (not removes) earlier ones; the legend's per-capture toggles bring them back for comparison.
- Imagery mosaics are opaque and basemap-like, so they always render at the bottom of the raster stack; dataset/context overlays stay visible above them (`DynamicTileLayers`).
- `isImageryUpdating` flag driven by the agent's `tool_calls` announcement (same pattern as `isGeneratingInsight`), cleared on result/error/abort.
- `tool-display.ts` entry for the reasoning timeline.

## Legend (Figma nodes 1473:7971 / 1473:8288 / 1473:8197)

- One "Satellite Imagery" group entry for all captures: IMAGERY badge, mosaic-tile thumbnail (a real tile at a zoom fitted to the mosaic extent), "Sentinel-2 · True-colour" subtitle, DATES/WINDOW/CLOUD/AREA chips, and a note when the search ran above the default 20% cloud limit.
- Collapsed-by-default captures list ("N captures · M areas") grouped by area: per-capture thumbnail, date, `cloud <50% · 9 scenes` meta, visibility toggle, LIVE badge on the newest capture.
- "Updating mosaic…" body (skeleton + spinner strip) while the agent rebuilds, per the update-in-place design.
- Header controls act on the whole group: opacity and ✕ fan out to all capture layers.
- Chip/info/note builders live in `app/utils/imagery.ts` so the dashboard legend (stacked PR) reuses them unmapped — field names follow the wire format.
- Drive-by fix: legend drag-reorder now expands entries to their underlying map layers (imagery captures, context sub-layers) instead of passing only root ids to `reorderLayers`, which silently **drops** unlisted layers.

## Decisions / deviations from the mock-ups

- Capture rows say "9 **scenes**" where the mock-up says "tiles" — `item_count` counts STAC scenes.
- The **Edit** link on chips is deferred: an edit-parameters interaction doesn't exist for any layer type yet (the design shows it on tree-cover-loss chips too). Re-runs go through chat; the updating display state is included.
- The "Satellite Imagery" input context chip and the sources footer are marked FUTURE STATE in Figma and excluded.
- The old branch's hardcoded `ff: "experimental"` and map-wide `transformRequest` are gone: develop's agent-profile pipeline already routes `ff`, and tiles now come from the public GFW tiles service (no bearer auth needed).

## Test plan

- [x] `pnpm test` — 672 passing; new suites for the imagery builders (`imagery.test.ts`), the handler (`showImagery.test.ts`, incl. replay idempotency, visibility policy, 401/404/network failure paths), the legend component (`ImageryLegendEntry.test.tsx`), and an `imagery` passthrough case in `parse-stream-message.test.ts`. The only failures are the 4 pre-existing `NewDashboardScreen.test.tsx` ones on develop.
- [x] `pnpm typecheck`, `pnpm lint`, `pnpm build` all green.
- [ ] In-browser QA against a local backend on the experimental profile: `show_imagery` → layer + legend states (default / expanded / updating / stacking with datasets), thread replay, capture toggles.

## Related

- Backend: wri/project-zeno#758 (mosaic build metadata — the field set here matches its shape; confirming that unblocks its draft)
- Supersedes the closed #593 prototype's shared-builder approach (its `imageryLegend.ts` was ported into `app/utils/imagery.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01W7qknvqmraXN47UXxVF1A1
