### PR TITLE
Read colors from the backend dataset catalog registry (phase 1+2)

### DIFF
--- a/app/components/legend/__tests__/applyPaletteOverride.test.ts
+++ b/app/components/legend/__tests__/applyPaletteOverride.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "vitest";
+
+import { applyPaletteOverride } from "../applyPaletteOverride";
+import type { DatasetLegendConfig } from "@/app/constants/datasets";
+import type { DatasetPalette } from "@/app/schemas/api/datasets/get";
+
+function makeLegend(
+  type: DatasetLegendConfig["type"],
+  items: DatasetLegendConfig["items"]
+): DatasetLegendConfig {
+  return {
+    title: "Test dataset",
+    color: "#000000",
+    items,
+    type,
+    info: "",
+    note: "",
+  };
+}
+
+function makePalette(overrides: Partial<DatasetPalette> = {}): DatasetPalette {
+  return {
+    dataset_id: 1,
+    dataset_name: "Test dataset",
+    categories: [],
+    series_color: null,
+    divergent_colors: null,
+    legend_categories: true,
+    ...overrides,
+  };
+}
+
+const GRADIENT_ITEMS = [
+  { label: "Low", color: "#eeeeee" },
+  { label: "High", color: "#111111" },
+];
+
+describe("applyPaletteOverride", () => {
+  it("returns the static legend unchanged when no palette has loaded", () => {
+    const legend = makeLegend("categorical", GRADIENT_ITEMS);
+    expect(applyPaletteOverride(legend, undefined)).toBe(legend);
+  });
+
+  it("replaces categorical items with the registry categories", () => {
+    const legend = makeLegend("categorical", [
+      { label: "Stale", color: "#ffffff" },
+    ]);
+    const result = applyPaletteOverride(
+      legend,
+      makePalette({
+        categories: [
+          { slug: "natural", label_en: "Natural", color: "#4CAF50" },
+          { slug: "non_natural", label_en: "Non-natural", color: "#9E9E9E" },
+        ],
+      })
+    );
+
+    expect(result.items).toEqual([
+      { label: "Natural", color: "#4CAF50" },
+      { label: "Non-natural", color: "#9E9E9E" },
+    ]);
+  });
+
+  it("applies the series color to symbol legends without expanding categories", () => {
+    const legend = makeLegend("symbol", [{ label: "Loss", color: "#ffffff" }]);
+    const result = applyPaletteOverride(
+      legend,
+      makePalette({ series_color: "#ABCDEF" })
+    );
+
+    expect(result.color).toBe("#ABCDEF");
+    expect(result.items).toEqual([{ label: "Loss", color: "#ABCDEF" }]);
+  });
+
+  it("keeps hand-curated items when legend_categories is false", () => {
+    const legend = makeLegend("categorical", [
+      { label: "Natural", color: "#4CAF50" },
+      { label: "Everything else", color: "#9E9E9E" },
+    ]);
+    const result = applyPaletteOverride(
+      legend,
+      makePalette({
+        legend_categories: false,
+        categories: [
+          { slug: "natural", label_en: "Natural", color: "#4CAF50" },
+          { slug: "cropland", label_en: "Cropland", color: "#fff183" },
+        ],
+      })
+    );
+
+    expect(result.items).toEqual(legend.items);
+  });
+
+  // Gradient legends read items[0]/items[last] as the min/max endpoints, so a
+  // category list or a flattened series color would render nonsense there.
+  it.each(["sequential", "divergent"] as const)(
+    "leaves %s gradient legends untouched",
+    (type) => {
+      const legend = makeLegend(type, GRADIENT_ITEMS);
+      const palette = makePalette({
+        series_color: "#ABCDEF",
+        categories: [{ slug: "a", label_en: "A", color: "#123456" }],
+      });
+
+      expect(applyPaletteOverride(legend, palette)).toBe(legend);
+    }
+  );
+});

--- a/app/components/legend/applyPaletteOverride.ts
+++ b/app/components/legend/applyPaletteOverride.ts
@@ -1,0 +1,54 @@
+import type { DatasetLegendConfig } from "@/app/constants/datasets";
+import type { DatasetPalette } from "@/app/schemas/api/datasets/get";
+
+/**
+ * Legend types whose `items` are a flat list of discrete swatches, and so can
+ * safely be swapped for the registry's category list or flattened to a single
+ * series color. Gradient legends ("sequential", "divergent") read `items` as
+ * ordered min→max stops — renderLegendSymbology takes the first and last
+ * labels as the endpoints — so either override would render nonsense there.
+ * Listing the safe types (rather than excluding the unsafe ones) means a new
+ * legend type is left untouched until it is explicitly opted in.
+ */
+const OVERRIDABLE_LEGEND_TYPES: ReadonlySet<DatasetLegendConfig["type"]> =
+  new Set(["symbol", "categorical"]);
+
+/**
+ * Overrides a dataset's hardcoded legend colors with the backend-owned
+ * palette (see docs/insight-chart-colors-plan.md in project-zeno), so the
+ * map legend is guaranteed to match the colors used in generated charts.
+ *
+ * Falls back to the static legend when no backend palette is available yet
+ * (e.g. still loading) — this is a progressive enhancement, not a hard
+ * dependency. Datasets with `legend_categories: false` (e.g. SBTN Natural
+ * Lands, which intentionally collapses its non-natural classes into one
+ * legend row) keep their hand-curated static `items` too; only their series
+ * color comes from the registry.
+ */
+export function applyPaletteOverride(
+  legend: DatasetLegendConfig,
+  palette?: DatasetPalette
+): DatasetLegendConfig {
+  if (!palette || !OVERRIDABLE_LEGEND_TYPES.has(legend.type)) return legend;
+
+  if (palette.categories.length > 0 && palette.legend_categories) {
+    return {
+      ...legend,
+      items: palette.categories.map((category) => ({
+        label: category.label_en,
+        color: category.color,
+      })),
+    };
+  }
+
+  if (palette.series_color) {
+    const seriesColor = palette.series_color;
+    return {
+      ...legend,
+      color: seriesColor,
+      items: legend.items?.map((item) => ({ ...item, color: seriesColor })),
+    };
+  }
+
+  return legend;
+}

--- a/app/components/legend/useLegendHook.tsx
+++ b/app/components/legend/useLegendHook.tsx
@@ -27,48 +27,7 @@ import {
   IMAGERY_LEGEND_GROUP_ID,
 } from "@/app/utils/imagery";
 import { useDatasetsCatalog } from "@/app/hooks/useDatasetsCatalog";
-import type { DatasetPalette } from "@/app/schemas/api/datasets/get";
-
-/**
- * Overrides a dataset's hardcoded legend colors with the backend-owned
- * palette (see docs/insight-chart-colors-plan.md in project-zeno), so the
- * map legend is guaranteed to match the colors used in generated charts.
- * Falls back to the static legend when no backend palette is available yet
- * (e.g. still loading) — this is a progressive enhancement, not a hard
- * dependency. Divergent (raster gradient) legends are left untouched: that
- * continuous colormap isn't the same shape as the registry's simple
- * positive/negative chart color pair. Datasets with `legend_categories:
- * false` (e.g. SBTN Natural Lands, which intentionally collapses its
- * non-natural classes into one legend row) keep their hand-curated static
- * `items` untouched too — only their chart colors come from the registry.
- */
-function applyPaletteOverride(
-  legend: DatasetLegendConfig,
-  palette?: DatasetPalette
-): DatasetLegendConfig {
-  if (!palette || legend.type === "divergent") return legend;
-
-  if (palette.categories.length > 0 && palette.legend_categories) {
-    return {
-      ...legend,
-      items: palette.categories.map((category) => ({
-        label: category.label_en,
-        color: category.color,
-      })),
-    };
-  }
-
-  if (palette.series_color) {
-    const seriesColor = palette.series_color;
-    return {
-      ...legend,
-      color: seriesColor,
-      items: legend.items?.map((item) => ({ ...item, color: seriesColor })),
-    };
-  }
-
-  return legend;
-}
+import { applyPaletteOverride } from "@/app/components/legend/applyPaletteOverride";
 
 // Maps internal parameter keys to the badge label shown in the legend.
 const PARAMETER_LABELS: Record<string, string> = {

--- a/app/components/legend/useLegendHook.tsx
+++ b/app/components/legend/useLegendHook.tsx
@@ -26,6 +26,49 @@ import {
   buildImageryGroup,
   IMAGERY_LEGEND_GROUP_ID,
 } from "@/app/utils/imagery";
+import { useDatasetsCatalog } from "@/app/hooks/useDatasetsCatalog";
+import type { DatasetPalette } from "@/app/schemas/api/datasets/get";
+
+/**
+ * Overrides a dataset's hardcoded legend colors with the backend-owned
+ * palette (see docs/insight-chart-colors-plan.md in project-zeno), so the
+ * map legend is guaranteed to match the colors used in generated charts.
+ * Falls back to the static legend when no backend palette is available yet
+ * (e.g. still loading) — this is a progressive enhancement, not a hard
+ * dependency. Divergent (raster gradient) legends are left untouched: that
+ * continuous colormap isn't the same shape as the registry's simple
+ * positive/negative chart color pair. Datasets with `legend_categories:
+ * false` (e.g. SBTN Natural Lands, which intentionally collapses its
+ * non-natural classes into one legend row) keep their hand-curated static
+ * `items` untouched too — only their chart colors come from the registry.
+ */
+function applyPaletteOverride(
+  legend: DatasetLegendConfig,
+  palette?: DatasetPalette
+): DatasetLegendConfig {
+  if (!palette || legend.type === "divergent") return legend;
+
+  if (palette.categories.length > 0 && palette.legend_categories) {
+    return {
+      ...legend,
+      items: palette.categories.map((category) => ({
+        label: category.label_en,
+        color: category.color,
+      })),
+    };
+  }
+
+  if (palette.series_color) {
+    const seriesColor = palette.series_color;
+    return {
+      ...legend,
+      color: seriesColor,
+      items: legend.items?.map((item) => ({ ...item, color: seriesColor })),
+    };
+  }
+
+  return legend;
+}
 
 // Maps internal parameter keys to the badge label shown in the legend.
 const PARAMETER_LABELS: Record<string, string> = {
@@ -106,6 +149,7 @@ export interface LegendAoi {
 
 export function useLegendHook() {
   const [layers, setLayers] = useState<LegendEntry[]>([]);
+  const { palettesByDatasetId } = useDatasetsCatalog();
 
   const {
     layers: managedLayers,
@@ -165,7 +209,11 @@ export function useLegendHook() {
         );
         if (!relatedDataset?.legend) continue;
 
-        const { title, info, note } = relatedDataset.legend;
+        const legend = applyPaletteOverride(
+          relatedDataset.legend,
+          palettesByDatasetId[relatedDataset.dataset_id]
+        );
+        const { title, info, note } = legend;
 
         const yearParam = buildYearParam(layer.startDate, layer.endDate);
         const params = buildParams(layer.parameters ?? {}, yearParam);
@@ -177,7 +225,7 @@ export function useLegendHook() {
           info,
           params: params.length > 0 ? params : undefined,
           contextLayer: contextLayerByParentId.get(layer.id),
-          symbology: renderLegendSymbology(relatedDataset.legend),
+          symbology: renderLegendSymbology(legend),
           children: note ? <Text fontSize="xs">{note}</Text> : undefined,
         });
       }
@@ -192,7 +240,7 @@ export function useLegendHook() {
     };
 
     setLayers(buildEntries());
-  }, [managedLayers, isImageryUpdating]);
+  }, [managedLayers, isImageryUpdating, palettesByDatasetId]);
 
   // One chip per visible area layer, using the selection name as the label.
   // The visible layer IS the scope — removing the chip removes the layer.

--- a/app/components/widgets/ChartWidget.tsx
+++ b/app/components/widgets/ChartWidget.tsx
@@ -315,36 +315,41 @@ export default function ChartWidget({
   expanded = false,
   fitYAxis = false,
 }: ChartWidgetProps) {
-  const { data, xAxis, yAxis, type, seriesFields } = widget;
+  const {
+    data,
+    xAxis,
+    yAxis,
+    type,
+    seriesFields,
+    datasetName,
+    colorMap,
+    seriesColor,
+    divergentColors,
+  } = widget;
   const ChartTypeWrapper = chartWrappers[type as ChartType];
 
+  // Depends on the individual fields rather than `widget`: callers rebuild the
+  // widget object on render (see chartsToWidgets), but these values come
+  // straight off the fetched chart and keep a stable identity.
   const { data: formattedData, series } = useMemo(
     () =>
       xAxis
-        ? formatChartData(
-            data,
-            type,
-            xAxis,
-            yAxis,
-            widget.datasetName,
-            seriesFields,
-            {
-              colorMap: widget.colorMap,
-              seriesColor: widget.seriesColor,
-              divergentColors: widget.divergentColors,
-            }
-          )
+        ? formatChartData(data, type, xAxis, yAxis, datasetName, seriesFields, {
+            colorMap,
+            seriesColor,
+            divergentColors,
+          })
         : { data: [], series: [] },
     [
       data,
       type,
       xAxis,
       yAxis,
-      widget.datasetName,
+      datasetName,
       seriesFields,
-      widget.colorMap,
-      widget.seriesColor,
-      widget.divergentColors,
+      colorMap,
+      seriesColor,
+      divergentColors,
     ]
   );
 

--- a/app/components/widgets/ChartWidget.tsx
+++ b/app/components/widgets/ChartWidget.tsx
@@ -327,10 +327,25 @@ export default function ChartWidget({
             xAxis,
             yAxis,
             widget.datasetName,
-            seriesFields
+            seriesFields,
+            {
+              colorMap: widget.colorMap,
+              seriesColor: widget.seriesColor,
+              divergentColors: widget.divergentColors,
+            }
           )
         : { data: [], series: [] },
-    [data, type, xAxis, yAxis, widget.datasetName, seriesFields]
+    [
+      data,
+      type,
+      xAxis,
+      yAxis,
+      widget.datasetName,
+      seriesFields,
+      widget.colorMap,
+      widget.seriesColor,
+      widget.divergentColors,
+    ]
   );
 
   // Humanize series labels that are raw column keys (snake_case or the

--- a/app/hooks/useDatasetsCatalog.ts
+++ b/app/hooks/useDatasetsCatalog.ts
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { apiFetch } from "@/app/lib/api-client";
 import {
@@ -34,10 +35,17 @@ export function useDatasetsCatalog() {
     retry: 1,
   });
 
-  const palettesByDatasetId: Record<number, DatasetPalette> = {};
-  for (const palette of data?.datasets ?? []) {
-    palettesByDatasetId[palette.dataset_id] = palette;
-  }
+  // Keep a stable object reference across renders when `data` hasn't
+  // changed — this is consumed as a useEffect dependency in useLegendHook,
+  // and a freshly-built object every render there causes an infinite
+  // render loop (the effect never sees a stable dependency).
+  const palettesByDatasetId = useMemo(() => {
+    const map: Record<number, DatasetPalette> = {};
+    for (const palette of data?.datasets ?? []) {
+      map[palette.dataset_id] = palette;
+    }
+    return map;
+  }, [data]);
 
   return { palettesByDatasetId, isLoading, error };
 }

--- a/app/hooks/useDatasetsCatalog.ts
+++ b/app/hooks/useDatasetsCatalog.ts
@@ -1,0 +1,43 @@
+import { useQuery } from "@tanstack/react-query";
+import { apiFetch } from "@/app/lib/api-client";
+import {
+  DatasetCatalogResponseSchema,
+  type DatasetCatalogResponse,
+  type DatasetPalette,
+} from "@/app/schemas/api/datasets/get";
+
+async function fetchDatasetsCatalog(): Promise<DatasetCatalogResponse> {
+  const res = await apiFetch("/api/datasets/catalog");
+
+  if (!res.ok) {
+    throw new Error(`Failed to fetch dataset catalog: ${res.statusText}`);
+  }
+
+  const data = await res.json();
+  return DatasetCatalogResponseSchema.parse(data);
+}
+
+/**
+ * The canonical color registry for dataset categories, series colors, and
+ * divergent colors — backend-owned (see docs/insight-chart-colors-plan.md
+ * in project-zeno) so charts and map legends are guaranteed to agree.
+ *
+ * Static, backend-deployment-scoped data: cached indefinitely for the
+ * session, never refetched on window focus.
+ */
+export function useDatasetsCatalog() {
+  const { data, isLoading, error } = useQuery<DatasetCatalogResponse>({
+    queryKey: ["datasets-catalog"],
+    queryFn: fetchDatasetsCatalog,
+    staleTime: Infinity,
+    refetchOnWindowFocus: false,
+    retry: 1,
+  });
+
+  const palettesByDatasetId: Record<number, DatasetPalette> = {};
+  for (const palette of data?.datasets ?? []) {
+    palettesByDatasetId[palette.dataset_id] = palette;
+  }
+
+  return { palettesByDatasetId, isLoading, error };
+}

--- a/app/schemas/api/datasets/get.ts
+++ b/app/schemas/api/datasets/get.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import type { DivergentColors } from "@/app/types/chartColors";
 
 export const DatasetPaletteCategorySchema = z.object({
   slug: z.string(),
@@ -6,10 +7,12 @@ export const DatasetPaletteCategorySchema = z.object({
   color: z.string(),
 });
 
+// `satisfies` keeps this schema pinned to the shared DivergentColors shape:
+// the two must not drift, since chart and legend colors are the same registry.
 export const DatasetDivergentColorsSchema = z.object({
   positive: z.string(),
   negative: z.string(),
-});
+}) satisfies z.ZodType<DivergentColors>;
 
 export const DatasetPaletteSchema = z.object({
   dataset_id: z.number(),
@@ -33,9 +36,6 @@ export const DatasetCatalogResponseSchema = z.object({
 
 export type DatasetPaletteCategory = z.infer<
   typeof DatasetPaletteCategorySchema
->;
-export type DatasetDivergentColors = z.infer<
-  typeof DatasetDivergentColorsSchema
 >;
 export type DatasetPalette = z.infer<typeof DatasetPaletteSchema>;
 export type DatasetCatalogResponse = z.infer<

--- a/app/schemas/api/datasets/get.ts
+++ b/app/schemas/api/datasets/get.ts
@@ -1,0 +1,43 @@
+import { z } from "zod";
+
+export const DatasetPaletteCategorySchema = z.object({
+  slug: z.string(),
+  label_en: z.string(),
+  color: z.string(),
+});
+
+export const DatasetDivergentColorsSchema = z.object({
+  positive: z.string(),
+  negative: z.string(),
+});
+
+export const DatasetPaletteSchema = z.object({
+  dataset_id: z.number(),
+  dataset_name: z.string(),
+  categories: z.array(DatasetPaletteCategorySchema),
+  series_color: z.string().nullable(),
+  divergent_colors: DatasetDivergentColorsSchema.nullable(),
+  /**
+   * False for datasets whose map legend intentionally curates/collapses
+   * categories that are less relevant at a glance (e.g. SBTN Natural Lands
+   * groups all non-natural classes into one legend row). Chart colors still
+   * cover every category regardless — this only controls whether a legend
+   * should be expanded to the full category list.
+   */
+  legend_categories: z.boolean(),
+});
+
+export const DatasetCatalogResponseSchema = z.object({
+  datasets: z.array(DatasetPaletteSchema),
+});
+
+export type DatasetPaletteCategory = z.infer<
+  typeof DatasetPaletteCategorySchema
+>;
+export type DatasetDivergentColors = z.infer<
+  typeof DatasetDivergentColorsSchema
+>;
+export type DatasetPalette = z.infer<typeof DatasetPaletteSchema>;
+export type DatasetCatalogResponse = z.infer<
+  typeof DatasetCatalogResponseSchema
+>;

--- a/app/store/chat-tools/generateInsights.ts
+++ b/app/store/chat-tools/generateInsights.ts
@@ -20,6 +20,9 @@ interface ChartData {
   yAxis: string;
   seriesFields?: string[];
   series_fields?: string[];
+  colorMap?: Record<string, string>;
+  seriesColor?: string;
+  divergentColors?: { positive: string; negative: string };
 }
 
 function getSeriesFields(chart: ChartData): string[] | undefined {
@@ -113,6 +116,11 @@ export function generateInsightsTool(
           yAxis: chart.yAxis,
           ...(seriesFields ? { seriesFields } : {}),
           ...(datasetName ? { datasetName } : {}),
+          ...(chart.colorMap ? { colorMap: chart.colorMap } : {}),
+          ...(chart.seriesColor ? { seriesColor: chart.seriesColor } : {}),
+          ...(chart.divergentColors
+            ? { divergentColors: chart.divergentColors }
+            : {}),
           generation: {
             codeact_parts: streamMessage.codeact_parts,
             source_urls: streamMessage.source_urls,

--- a/app/store/chat-tools/generateInsights.ts
+++ b/app/store/chat-tools/generateInsights.ts
@@ -9,8 +9,10 @@ import useMapStore from "../mapStore";
 import { isAreaLayer } from "../layerManagerSlice";
 import useInsightStore from "../insightStore";
 import useChatStore from "../chatStore";
+import type { ChartColorFields } from "@/app/types/chartColors";
+import { pickChartColors } from "@/app/utils/pickChartColors";
 
-interface ChartData {
+interface ChartData extends ChartColorFields {
   id: string;
   title: string;
   type: "line" | "bar" | "table";
@@ -20,9 +22,6 @@ interface ChartData {
   yAxis: string;
   seriesFields?: string[];
   series_fields?: string[];
-  colorMap?: Record<string, string>;
-  seriesColor?: string;
-  divergentColors?: { positive: string; negative: string };
 }
 
 function getSeriesFields(chart: ChartData): string[] | undefined {
@@ -116,11 +115,7 @@ export function generateInsightsTool(
           yAxis: chart.yAxis,
           ...(seriesFields ? { seriesFields } : {}),
           ...(datasetName ? { datasetName } : {}),
-          ...(chart.colorMap ? { colorMap: chart.colorMap } : {}),
-          ...(chart.seriesColor ? { seriesColor: chart.seriesColor } : {}),
-          ...(chart.divergentColors
-            ? { divergentColors: chart.divergentColors }
-            : {}),
+          ...pickChartColors(chart),
           generation: {
             codeact_parts: streamMessage.codeact_parts,
             source_urls: streamMessage.source_urls,

--- a/app/types/chartColors.ts
+++ b/app/types/chartColors.ts
@@ -1,0 +1,24 @@
+/**
+ * Positive/negative color pair for divergent (signed-value) charts and the
+ * dataset legends that share those semantics.
+ */
+export interface DivergentColors {
+  positive: string;
+  negative: string;
+}
+
+/**
+ * Backend-resolved chart colors (phase 2 of the color registry — see
+ * docs/insight-chart-colors-plan.md in project-zeno): category slug → hex,
+ * a single-series color, and the divergent pair.
+ *
+ * Every field is optional; when one is absent the local
+ * `app/config/chartColorMappings.ts` config applies (pre-migration insights,
+ * or a category with no registry entry). Mixed into `InsightWidget` and read
+ * by `formatChartData`, so the shape has a single home.
+ */
+export interface ChartColorFields {
+  colorMap?: Record<string, string>;
+  seriesColor?: string;
+  divergentColors?: DivergentColors;
+}

--- a/app/types/chat.ts
+++ b/app/types/chat.ts
@@ -1,5 +1,6 @@
 import { FeatureCollection } from "geojson";
 import type { BlogArticle } from "@/app/schemas/api/blogs/get";
+import type { ChartColorFields } from "@/app/types/chartColors";
 
 export type { BlogArticle };
 
@@ -58,8 +59,9 @@ export interface ChatMessage {
   suppressFooter?: boolean; // Non-terminal segment of a [Chart uuid] split — no footer, tight spacing
 }
 
-// Widget types for insights
-export interface InsightWidget {
+// Widget types for insights. Extends ChartColorFields with the backend color
+// registry's resolution for this chart (absent for pre-migration insights).
+export interface InsightWidget extends ChartColorFields {
   id?: string; // backend chart UUID, used to resolve [Chart <id>] references in text
   type:
     | "line"
@@ -89,13 +91,6 @@ export interface InsightWidget {
   // one analysis share it; it is the handle for REST widget adds
   // (POST /api/dashboards/:id/widgets).
   insightId?: string;
-  // Backend color registry resolution (phase 2) — category slug -> hex,
-  // single-series color, and positive/negative colors. Falls back to the
-  // local chartColorMappings.ts config when absent (pre-migration insights,
-  // or a category with no registry entry).
-  colorMap?: Record<string, string>;
-  seriesColor?: string;
-  divergentColors?: { positive: string; negative: string };
 }
 
 // Parameters the agent used to produce an insight (read-only transparency)

--- a/app/types/chat.ts
+++ b/app/types/chat.ts
@@ -89,6 +89,13 @@ export interface InsightWidget {
   // one analysis share it; it is the handle for REST widget adds
   // (POST /api/dashboards/:id/widgets).
   insightId?: string;
+  // Backend color registry resolution (phase 2) — category slug -> hex,
+  // single-series color, and positive/negative colors. Falls back to the
+  // local chartColorMappings.ts config when absent (pre-migration insights,
+  // or a category with no registry entry).
+  colorMap?: Record<string, string>;
+  seriesColor?: string;
+  divergentColors?: { positive: string; negative: string };
 }
 
 // Parameters the agent used to produce an insight (read-only transparency)

--- a/app/utils/__tests__/formatCharts.test.ts
+++ b/app/utils/__tests__/formatCharts.test.ts
@@ -198,4 +198,101 @@ describe("formatChartData", () => {
     const logging = result.series.find((s) => s.name === "Logging");
     expect(logging?.color).toBe("#52A44E");
   });
+
+  describe("backend color overrides (phase 2)", () => {
+    it("prefers the backend colorMap over the local mapping for pie charts, keyed by slug", () => {
+      const data = [
+        { driver: "Tala", driver__slug: "logging", area_ha: 100 },
+        { driver: "Incendio", driver__slug: "wildfire", area_ha: 50 },
+      ];
+      const result = formatChartData(
+        data,
+        "pie",
+        "driver",
+        "area_ha",
+        undefined,
+        undefined,
+        {
+          colorMap: { logging: "#111111", wildfire: "#222222" },
+        }
+      );
+      const logging = result.series.find((s) => s.name === "Tala");
+      const wildfire = result.series.find((s) => s.name === "Incendio");
+      expect(logging?.color).toBe("#111111");
+      expect(wildfire?.color).toBe("#222222");
+    });
+
+    it("falls back to the row value as the slug when no __slug column is present", () => {
+      const data = [{ category: "agriculture", value: 10 }];
+      const result = formatChartData(
+        data,
+        "pie",
+        "category",
+        "value",
+        undefined,
+        undefined,
+        {
+          colorMap: { agriculture: "#333333" },
+        }
+      );
+      expect(result.data[0].color).toBe("#333333");
+    });
+
+    it("builds pie colors from the backend colorMap when there is no local palette for the field", () => {
+      const data = [
+        { class: "Natural", class__slug: "natural", value: 10 },
+        { class: "Non-natural", class__slug: "non_natural", value: 5 },
+      ];
+      const result = formatChartData(
+        data,
+        "pie",
+        "class",
+        "value",
+        undefined,
+        undefined,
+        {
+          colorMap: { natural: "#4CAF50", non_natural: "#9E9E9E" },
+        }
+      );
+      expect(result.series).toEqual([
+        { name: "Natural", color: "#4CAF50" },
+        { name: "Non-natural", color: "#9E9E9E" },
+      ]);
+    });
+
+    it("prefers backend seriesColor over the local DATASET_SERIES_COLORS map", () => {
+      const data = [
+        { country: "Brazil", area_ha: 100 },
+        { country: "Peru", area_ha: 50 },
+      ];
+      const result = formatChartData(
+        data,
+        "bar",
+        "country",
+        "area_ha",
+        "Tree cover loss",
+        undefined,
+        { seriesColor: "#ABCDEF" }
+      );
+      expect(result.series[0].color).toBe("#ABCDEF");
+    });
+
+    it("prefers backend divergentColors over the local DATASET_DIVERGENT_COLORS map", () => {
+      const data = [
+        { country: "Brazil", net_flux_tCO2e: -450 },
+        { country: "Indonesia", net_flux_tCO2e: 320 },
+      ];
+      const result = formatChartData(
+        data,
+        "bar",
+        "country",
+        "net_flux_tCO2e",
+        "Forest greenhouse gas net flux (2001-2024)",
+        undefined,
+        { divergentColors: { positive: "#00FF00", negative: "#FF0000" } }
+      );
+      expect(result.data[0]._barColor).toBe("#FF0000");
+      expect(result.data[1]._barColor).toBe("#00FF00");
+    });
+  });
 });

--- a/app/utils/formatCharts.tsx
+++ b/app/utils/formatCharts.tsx
@@ -3,6 +3,7 @@ import CHART_COLOR_MAPPING, {
   DATASET_SERIES_COLORS,
   DATASET_DIVERGENT_COLORS,
 } from "@/app/config/chartColorMappings";
+import type { ChartColorFields } from "@/app/types/chartColors";
 
 interface InputData {
   [key: string]: unknown | unknown;
@@ -23,19 +24,6 @@ interface ChartSeries {
 // see src/agent/subagents/analyst/charts/color_resolver.py. `colorMap` below
 // is keyed by that slug, not by the (possibly translated) display value.
 const SLUG_COLUMN_SUFFIX = "__slug";
-
-/**
- * Backend-resolved chart colors (phase 2 of the color registry — see
- * docs/insight-chart-colors-plan.md in the backend repo). When present,
- * these take precedence over the local `chartColorMappings.ts` config, which
- * remains the fallback for pre-migration insights or categories with no
- * registry entry.
- */
-export interface ChartColorOverrides {
-  colorMap?: Record<string, string>;
-  seriesColor?: string;
-  divergentColors?: { positive: string; negative: string };
-}
 
 function isNumericValue(value: unknown): boolean {
   if (value === null || value === undefined || value === "") return false;
@@ -120,6 +108,10 @@ function filterChartDataColumns(
  * @param xAxis The key to use for the x-axis.
  * @param yAxis The key to use for the y-axis (required for scatter charts).
  * @param seriesFields Explicit metric columns for multi-series charts.
+ * @param colorOverrides Backend-resolved colors (phase 2 of the color
+ *   registry). When present they take precedence over the local
+ *   `chartColorMappings.ts` config, which remains the fallback for
+ *   pre-migration insights and categories with no registry entry.
  * @returns An object containing the transformed `data` and `series` arrays.
  */
 export default function formatChartData(
@@ -138,7 +130,7 @@ export default function formatChartData(
   yAxis?: string,
   datasetName?: string,
   seriesFields?: string[],
-  colorOverrides?: ChartColorOverrides
+  colorOverrides?: ChartColorFields
 ): { data: ChartData[]; series: ChartSeries[] } {
   const empty = { data: [], series: [] };
 
@@ -167,7 +159,7 @@ export default function formatChartData(
   const xAxisKey = xAxis || keys[0]; //identify dataset
   const valueKeys = resolveValueKeys(keys, xAxisKey, yAxis, seriesFields);
   // The pie branch resolves per-row colors off this sibling slug column (see
-  // ChartColorOverrides) — keep it even though it's not an axis/value column,
+  // SLUG_COLUMN_SUFFIX) — keep it even though it's not an axis/value column,
   // or scoping below would silently discard it.
   const xAxisSlugKey = `${xAxisKey}${SLUG_COLUMN_SUFFIX}`;
   // Scatter needs a third (name/label) column beyond x and y, so scoping to
@@ -196,9 +188,6 @@ export default function formatChartData(
   const chartRows = scopedData as InputData[];
 
   const defaultColors = getChartColors();
-  const chartColors = chartRows.map(
-    (_, index) => defaultColors[index % defaultColors.length]
-  );
 
   // --- Logic for PIE charts ---
   if (type === "pie") {
@@ -209,44 +198,25 @@ export default function formatChartData(
 
     const backendColorMap = colorOverrides?.colorMap;
     const colorPalette = CHART_COLOR_MAPPING[xAxisKey];
+    const paletteByValue = colorPalette
+      ? new Map(colorPalette.map((item) => [item.value, item.color]))
+      : undefined;
 
-    const slugFor = (item: InputData): string | undefined =>
-      backendColorMap
-        ? String(item[`${xAxisKey}${SLUG_COLUMN_SUFFIX}`] ?? item[xAxisKey])
-        : undefined;
-
-    let pieChartColors: string[] = [];
-
-    if (colorPalette) {
-      const valueToColorMap = new Map(
-        colorPalette.map((item) => [item.value, item.color])
+    // Precedence per row: backend registry (keyed by the untranslated slug,
+    // falling back to the display value) → local palette → default rotation.
+    const pieChartColors = chartRows.map((item, index) => {
+      const slug = String(item[xAxisSlugKey] ?? item[xAxisKey]);
+      return (
+        backendColorMap?.[slug] ||
+        paletteByValue?.get(String(item[xAxisKey])) ||
+        defaultColors[index % defaultColors.length]
       );
-      pieChartColors = chartRows.map((item, index) => {
-        const slug = slugFor(item);
-        const backendColor = slug ? backendColorMap![slug] : undefined;
-        const key = String(item[xAxisKey]);
-        return (
-          backendColor ||
-          valueToColorMap.get(key) ||
-          defaultColors[index % defaultColors.length]
-        );
-      });
-    } else if (backendColorMap) {
-      pieChartColors = chartRows.map((item, index) => {
-        const slug = slugFor(item);
-        return (
-          (slug && backendColorMap[slug]) ||
-          defaultColors[index % defaultColors.length]
-        );
-      });
-    } else {
-      pieChartColors = chartColors;
-    }
+    });
 
     // For Pie charts, we need to add a color to each data point.
     const transformedData = chartRows.map((item, index) => ({
       ...item,
-      color: pieChartColors[index % pieChartColors.length],
+      color: pieChartColors[index],
     })) as ChartData[];
 
     let series: ChartSeries[];
@@ -267,22 +237,16 @@ export default function formatChartData(
         series.push({ name: label, color: pieChartColors[index] });
       });
     } else if (colorPalette) {
-      // Create a map for quick color lookup
-      const valueToColorMap = new Map(
-        colorPalette.map((item) => [item.value, item.color])
+      // Order the legend by the local palette, keeping only the values that
+      // actually appear in the data.
+      const presentValues = new Set(
+        transformedData.map((item) => item[xAxisKey])
       );
-
-      // Create a map for the original data values for sorting
-      const dataValueMap = new Map(
-        transformedData.map((item) => [item[xAxisKey], item])
-      );
-
-      // Sort the series based on the order in colorPalette
       series = colorPalette
-        .filter((paletteItem) => dataValueMap.has(paletteItem.value)) // Ensure the item exists in the data
+        .filter((paletteItem) => presentValues.has(paletteItem.value))
         .map((paletteItem) => ({
           name: paletteItem.value,
-          color: valueToColorMap.get(paletteItem.value) || "#000000", // Fallback color
+          color: paletteItem.color,
         }));
     } else {
       // Fallback to default series generation if no color palette is defined

--- a/app/utils/formatCharts.tsx
+++ b/app/utils/formatCharts.tsx
@@ -18,6 +18,25 @@ interface ChartSeries {
   stackId?: string;
 }
 
+// Sibling column the backend attaches next to a categorical column (e.g.
+// "driver__slug" next to "driver") carrying a stable, untranslated slug —
+// see src/agent/subagents/analyst/charts/color_resolver.py. `colorMap` below
+// is keyed by that slug, not by the (possibly translated) display value.
+const SLUG_COLUMN_SUFFIX = "__slug";
+
+/**
+ * Backend-resolved chart colors (phase 2 of the color registry — see
+ * docs/insight-chart-colors-plan.md in the backend repo). When present,
+ * these take precedence over the local `chartColorMappings.ts` config, which
+ * remains the fallback for pre-migration insights or categories with no
+ * registry entry.
+ */
+export interface ChartColorOverrides {
+  colorMap?: Record<string, string>;
+  seriesColor?: string;
+  divergentColors?: { positive: string; negative: string };
+}
+
 function isNumericValue(value: unknown): boolean {
   if (value === null || value === undefined || value === "") return false;
   if (typeof value === "number") return Number.isFinite(value);
@@ -118,7 +137,8 @@ export default function formatChartData(
   xAxis?: string,
   yAxis?: string,
   datasetName?: string,
-  seriesFields?: string[]
+  seriesFields?: string[],
+  colorOverrides?: ChartColorOverrides
 ): { data: ChartData[]; series: ChartSeries[] } {
   const empty = { data: [], series: [] };
 
@@ -146,6 +166,10 @@ export default function formatChartData(
 
   const xAxisKey = xAxis || keys[0]; //identify dataset
   const valueKeys = resolveValueKeys(keys, xAxisKey, yAxis, seriesFields);
+  // The pie branch resolves per-row colors off this sibling slug column (see
+  // ChartColorOverrides) — keep it even though it's not an axis/value column,
+  // or scoping below would silently discard it.
+  const xAxisSlugKey = `${xAxisKey}${SLUG_COLUMN_SUFFIX}`;
   // Scatter needs a third (name/label) column beyond x and y, so scoping to
   // [xAxis, yAxis] would discard it and leave the chart unable to render.
   const shouldScopeColumns =
@@ -153,7 +177,11 @@ export default function formatChartData(
     (Boolean(seriesFields?.length) ||
       (Boolean(yAxis) && type !== "grouped-bar"));
   const scopedData = shouldScopeColumns
-    ? filterChartDataColumns(data, [xAxisKey, ...valueKeys])
+    ? filterChartDataColumns(data, [
+        xAxisKey,
+        ...valueKeys,
+        ...(keys.includes(xAxisSlugKey) ? [xAxisSlugKey] : []),
+      ])
     : data;
   const scopedFirstRow = scopedData[0];
   if (
@@ -179,7 +207,14 @@ export default function formatChartData(
       return { data: [], series: [] };
     }
 
+    const backendColorMap = colorOverrides?.colorMap;
     const colorPalette = CHART_COLOR_MAPPING[xAxisKey];
+
+    const slugFor = (item: InputData): string | undefined =>
+      backendColorMap
+        ? String(item[`${xAxisKey}${SLUG_COLUMN_SUFFIX}`] ?? item[xAxisKey])
+        : undefined;
+
     let pieChartColors: string[] = [];
 
     if (colorPalette) {
@@ -187,9 +222,20 @@ export default function formatChartData(
         colorPalette.map((item) => [item.value, item.color])
       );
       pieChartColors = chartRows.map((item, index) => {
+        const slug = slugFor(item);
+        const backendColor = slug ? backendColorMap![slug] : undefined;
         const key = String(item[xAxisKey]);
         return (
+          backendColor ||
           valueToColorMap.get(key) ||
+          defaultColors[index % defaultColors.length]
+        );
+      });
+    } else if (backendColorMap) {
+      pieChartColors = chartRows.map((item, index) => {
+        const slug = slugFor(item);
+        return (
+          (slug && backendColorMap[slug]) ||
           defaultColors[index % defaultColors.length]
         );
       });
@@ -205,7 +251,22 @@ export default function formatChartData(
 
     let series: ChartSeries[];
 
-    if (colorPalette) {
+    if (backendColorMap) {
+      // Backend-resolved colors win outright (they're already computed into
+      // pieChartColors above, per-row, via the __slug column) — build the
+      // legend from first-seen row order, de-duplicated by display label.
+      // colorMap has no inherent ordering, unlike the local
+      // CHART_COLOR_MAPPING array, and a row's translated label may not
+      // match the local palette's English `value` even when one exists.
+      const seen = new Set<string>();
+      series = [];
+      chartRows.forEach((item, index) => {
+        const label = String(item[xAxisKey]);
+        if (seen.has(label)) return;
+        seen.add(label);
+        series.push({ name: label, color: pieChartColors[index] });
+      });
+    } else if (colorPalette) {
       // Create a map for quick color lookup
       const valueToColorMap = new Map(
         colorPalette.map((item) => [item.value, item.color])
@@ -258,9 +319,9 @@ export default function formatChartData(
       name: item[nameKey],
     }));
 
-    const datasetColor = datasetName
-      ? DATASET_SERIES_COLORS[datasetName]
-      : undefined;
+    const datasetColor =
+      colorOverrides?.seriesColor ??
+      (datasetName ? DATASET_SERIES_COLORS[datasetName] : undefined);
     const series: ChartSeries[] = [
       {
         name: nameKey, // The series name can be derived from the label key
@@ -289,12 +350,12 @@ export default function formatChartData(
     }
 
     // Single series
-    const divergent = datasetName
-      ? DATASET_DIVERGENT_COLORS[datasetName]
-      : undefined;
-    const datasetColor = datasetName
-      ? DATASET_SERIES_COLORS[datasetName]
-      : undefined;
+    const divergent =
+      colorOverrides?.divergentColors ??
+      (datasetName ? DATASET_DIVERGENT_COLORS[datasetName] : undefined);
+    const datasetColor =
+      colorOverrides?.seriesColor ??
+      (datasetName ? DATASET_SERIES_COLORS[datasetName] : undefined);
 
     // For bar charts with divergent colors, add per-bar _barColor based on value sign
     if (type === "bar" && divergent && chartValueKeys.length === 1) {

--- a/app/utils/pickChartColors.ts
+++ b/app/utils/pickChartColors.ts
@@ -1,0 +1,26 @@
+import type {
+  ChartColorFields,
+  DivergentColors,
+} from "@/app/types/chartColors";
+
+/** Transport shape of the color fields: the backend sends `null`, not absent. */
+interface RawChartColors {
+  colorMap?: Record<string, string> | null;
+  seriesColor?: string | null;
+  divergentColors?: DivergentColors | null;
+}
+
+/**
+ * Narrows a transport-shaped chart to the `ChartColorFields` mixin, omitting
+ * empty fields entirely rather than carrying `null`/`undefined` through — so a
+ * missing registry entry falls through to the local color config downstream.
+ */
+export function pickChartColors(source: RawChartColors): ChartColorFields {
+  return {
+    ...(source.colorMap ? { colorMap: source.colorMap } : {}),
+    ...(source.seriesColor ? { seriesColor: source.seriesColor } : {}),
+    ...(source.divergentColors
+      ? { divergentColors: source.divergentColors }
+      : {}),
+  };
+}

--- a/src/entities/insight/lib/charts-to-widgets.ts
+++ b/src/entities/insight/lib/charts-to-widgets.ts
@@ -10,6 +10,9 @@ import type { AnalysisParams, InsightWidget } from "@/app/types/chat";
  * widget in the batch.
  *
  * Unknown chart types fall back to "bar" so a bad type never blanks the widget.
+ *
+ * colorMap/seriesColor/divergentColors are carried through — they drive
+ * ChartWidget's backend-color precedence (see formatCharts.tsx).
  */
 const ALLOWED_TYPES = new Set<InsightWidget["type"]>([
   "line",
@@ -39,5 +42,10 @@ export function chartsToWidgets(
     yAxis: chart.yAxis,
     seriesFields: chart.seriesFields,
     analysisParams,
+    ...(chart.colorMap ? { colorMap: chart.colorMap } : {}),
+    ...(chart.seriesColor ? { seriesColor: chart.seriesColor } : {}),
+    ...(chart.divergentColors
+      ? { divergentColors: chart.divergentColors }
+      : {}),
   }));
 }

--- a/src/entities/insight/lib/charts-to-widgets.ts
+++ b/src/entities/insight/lib/charts-to-widgets.ts
@@ -1,19 +1,7 @@
 import type { Chart } from "../model/chart";
 import type { AnalysisParams, InsightWidget } from "@/app/types/chat";
+import { pickChartColors } from "@/app/utils/pickChartColors";
 
-/**
- * Presentation ACL: maps insight charts to the shared `InsightWidget` view model.
- *
- * The single convergence point for every insight acquisition path — the direct
- * analysis LRO and the browse/history list both map through here, never at the
- * transport (ADR 0008). `analysisParams`, when supplied, is attached to every
- * widget in the batch.
- *
- * Unknown chart types fall back to "bar" so a bad type never blanks the widget.
- *
- * colorMap/seriesColor/divergentColors are carried through — they drive
- * ChartWidget's backend-color precedence (see formatCharts.tsx).
- */
 const ALLOWED_TYPES = new Set<InsightWidget["type"]>([
   "line",
   "bar",
@@ -26,6 +14,19 @@ const ALLOWED_TYPES = new Set<InsightWidget["type"]>([
   "scatter",
 ]);
 
+/**
+ * Presentation ACL: maps insight charts to the shared `InsightWidget` view model.
+ *
+ * The single convergence point for every insight acquisition path — the direct
+ * analysis LRO and the browse/history list both map through here, never at the
+ * transport (ADR 0008). `analysisParams`, when supplied, is attached to every
+ * widget in the batch.
+ *
+ * Unknown chart types fall back to "bar" so a bad type never blanks the widget.
+ *
+ * The registry color fields are carried through — they drive ChartWidget's
+ * backend-color precedence (see formatCharts.tsx).
+ */
 export function chartsToWidgets(
   charts: Chart[],
   analysisParams?: AnalysisParams
@@ -42,10 +43,6 @@ export function chartsToWidgets(
     yAxis: chart.yAxis,
     seriesFields: chart.seriesFields,
     analysisParams,
-    ...(chart.colorMap ? { colorMap: chart.colorMap } : {}),
-    ...(chart.seriesColor ? { seriesColor: chart.seriesColor } : {}),
-    ...(chart.divergentColors
-      ? { divergentColors: chart.divergentColors }
-      : {}),
+    ...pickChartColors(chart),
   }));
 }

--- a/src/entities/insight/model/chart.ts
+++ b/src/entities/insight/model/chart.ts
@@ -19,4 +19,10 @@ export interface Chart {
   seriesFields: string[];
   /** Maps to InsightChartResponse.chart_data */
   data: Record<string, unknown>[];
+  /** Maps to InsightChartResponse.color_map */
+  colorMap?: Record<string, string>;
+  /** Maps to InsightChartResponse.series_color */
+  seriesColor?: string | null;
+  /** Maps to InsightChartResponse.divergent_colors */
+  divergentColors?: { positive: string; negative: string } | null;
 }

--- a/src/entities/insight/model/chart.ts
+++ b/src/entities/insight/model/chart.ts
@@ -1,3 +1,5 @@
+import type { DivergentColors } from "@/app/types/chartColors";
+
 /** A single chart produced by an analysis. Mirrors the API's InsightChartResponse. */
 export interface Chart {
   id: string;
@@ -24,5 +26,5 @@ export interface Chart {
   /** Maps to InsightChartResponse.series_color */
   seriesColor?: string | null;
   /** Maps to InsightChartResponse.divergent_colors */
-  divergentColors?: { positive: string; negative: string } | null;
+  divergentColors?: DivergentColors | null;
 }

--- a/src/features/analysis/api/rest-analysis-gateway.ts
+++ b/src/features/analysis/api/rest-analysis-gateway.ts
@@ -34,6 +34,9 @@ interface RawChart {
   group_field?: string;
   series_fields?: string[];
   chart_data: Record<string, unknown>[];
+  color_map?: Record<string, string>;
+  series_color?: string | null;
+  divergent_colors?: { positive: string; negative: string } | null;
 }
 
 interface RawInsightResponse {
@@ -210,6 +213,9 @@ export class RestAnalysisGateway implements AnalysisGateway {
           groupField: c.group_field ?? "",
           seriesFields: c.series_fields ?? [],
           data: c.chart_data,
+          colorMap: c.color_map,
+          seriesColor: c.series_color,
+          divergentColors: c.divergent_colors,
         })
       ),
     };

--- a/src/features/analysis/api/rest-analysis-gateway.ts
+++ b/src/features/analysis/api/rest-analysis-gateway.ts
@@ -8,6 +8,7 @@ import type {
 import type { AnalysisSelection } from "../model/analysis-selection";
 import type { AnalysisResult } from "../model/analysis-result";
 import type { Chart } from "@/src/entities/insight";
+import type { DivergentColors } from "@/app/types/chartColors";
 import { AnalysisError } from "../model/analysis-error";
 
 // ── Raw API shapes (anti-corruption layer — never leave this file) ─────────────
@@ -36,7 +37,7 @@ interface RawChart {
   chart_data: Record<string, unknown>[];
   color_map?: Record<string, string>;
   series_color?: string | null;
-  divergent_colors?: { positive: string; negative: string } | null;
+  divergent_colors?: DivergentColors | null;
 }
 
 interface RawInsightResponse {


### PR DESCRIPTION
## Summary

Replaces #615, rebuilt clean off current `develop`. #615's branch had drifted to include unrelated commits (the Amazon.ia marketing page, header contrast fix, dependency-security bumps) picked up from a stale base — those are already on `develop` via their own PRs (#569/#576/#586), so this PR is just the three insight-chart-colors commits, cherry-picked and re-resolved against current `develop`.

Backend counterpart: wri/project-zeno#771 (phase 1, merged) and wri/project-zeno#773 (phase 2).

## Changes

- **Phase 1** — map legend colors read from the backend's `GET /api/datasets/catalog` registry (`useDatasetsCatalog`, `useLegendHook`'s `applyPaletteOverride`) instead of the hardcoded `constants/datasets.ts`, fixing a color-drift bug between that file and `chartColorMappings.ts`. SBTN Natural Lands keeps its curated collapsed legend; the GHG net-flux continuous gradient legend is untouched.
- Fix for an infinite render loop in `useDatasetsCatalog` (unmemoized `palettesByDatasetId` object identity was retriggering the legend-building effect every render).
- **Phase 2** — chart colors (`ChartWidget`/`formatChartData`) now prefer `colorMap`/`seriesColor`/`divergentColors` carried on each chart from the backend color resolver, falling back to the local `chartColorMappings.ts` config when absent (pre-migration insights, or an unregistered category). Threaded through both acquisition paths: the chat-stream path (`generateInsights.ts`) and the analysis-LRO path (`rest-analysis-gateway.ts` → `src/entities/insight`'s `chartsToWidgets`, which is where this logic now lives after the `develop`-side FSD refactor moved it out of the now-removed `analysis-result-to-widgets.ts`).

## Test plan

- [x] `pnpm typecheck` / `pnpm lint` / `pnpm format:check` — clean
- [x] `pnpm test app/utils/__tests__/formatCharts.test.ts src/entities/insight` — 37 passed