### PR TITLE
Send live map viewport + visible insights in view_context

### DIFF
--- a/app/store/__tests__/chatStore.test.ts
+++ b/app/store/__tests__/chatStore.test.ts
@@ -23,10 +23,13 @@ import useChatStore from "../chatStore";
 import useViewContextStore from "../viewContextStore";
 import useAuthStore from "../authStore";
 import useAgentProfileStore from "../agentProfileStore";
+import useMapStore from "../mapStore";
+import useInsightStore from "../insightStore";
 import { apiFetch } from "@/app/lib/api-client";
 import type {
   AnalyseSuggestion,
   ViewAnalysisSuggestion,
+  InsightWidget,
 } from "@/app/types/chat";
 
 // Error that mimics a fetch/stream abort: `name === "AbortError"` is what
@@ -174,6 +177,45 @@ describe("chatStore view_context", () => {
     await useChatStore.getState().sendMessage("hello");
 
     expect(sentBody()).not.toHaveProperty("view_context");
+  });
+
+  it("enriches the map surface with live viewport + visible insights", async () => {
+    useViewContextStore.getState().setViewContext({ page: "map" });
+    useInsightStore.getState().addInsights([
+      {
+        type: "bar",
+        title: "t",
+        description: "d",
+        data: [],
+        xAxis: "x",
+        yAxis: "y",
+        insightId: "i1",
+      } as InsightWidget,
+    ]);
+    useMapStore.setState({
+      mapRef: {
+        getMap: () => ({
+          getBounds: () => ({
+            getWest: () => -73.9876,
+            getSouth: () => 40.7661,
+            getEast: () => -73.9397,
+            getNorth: () => 40.8002,
+          }),
+          getZoom: () => 5,
+        }),
+      } as unknown as ReturnType<typeof useMapStore.getState>["mapRef"],
+    });
+
+    await useChatStore.getState().sendMessage("what's in this chart?");
+
+    expect(sentBody().view_context).toEqual({
+      page: "map",
+      viewport: { bbox: [-73.9876, 40.7661, -73.9397, 40.8002], zoom: 5 },
+      visible_insights: ["i1"],
+    });
+
+    useMapStore.setState({ mapRef: null });
+    useInsightStore.getState().clearInsights();
   });
 });
 

--- a/app/store/chatStore.ts
+++ b/app/store/chatStore.ts
@@ -22,6 +22,7 @@ import {
   emptyContextKeys,
   type ContextKeys,
 } from "@/app/utils/messageContext";
+import { enrichMapViewContext } from "@/app/utils/viewContext";
 import { readDataStream } from "@/app/lib/read-data-stream";
 import { parseStreamMessage } from "@/app/lib/parse-stream-message";
 import { buildInsightChatMessages } from "@/app/lib/insight-chat-messages";
@@ -581,7 +582,11 @@ const useChatStore = create<ChatState & ChatActions>((set, get) => ({
     // Send the agent profile as `ff` only when a profile is selected and the
     // user type is allowed to use feature flags (else the backend 403s).
     const userType = useAuthStore.getState().userType;
-    const viewContext = useViewContextStore.getState().viewContext;
+    const viewContext = enrichMapViewContext(
+      useViewContextStore.getState().viewContext,
+      useMapStore.getState().mapRef,
+      useInsightStore.getState().insights
+    );
     // The dashboard agent tools live in the backend's experimental profile, so
     // default to it whenever the dashboards feature is active — either on a
     // dashboard surface or with the ?ff=dashboard gate open — letting a single

--- a/app/store/viewContextStore.ts
+++ b/app/store/viewContextStore.ts
@@ -15,7 +15,14 @@ import { create } from "zustand";
  * its own on mount.
  */
 export type ViewContext =
-  | { page: "map" }
+  | {
+      page: "map";
+      // Live map extent + on-map insights aren't tracked here reactively —
+      // they're computed fresh at send time (see enrichMapViewContext) the
+      // same way `ui_context` is, so this store only ever holds `page`.
+      viewport?: { bbox: [number, number, number, number]; zoom: number };
+      visible_insights?: string[];
+    }
   | { page: "dashboard"; dashboard_id: string; dashboard_name?: string };
 
 interface ViewContextState {

--- a/app/utils/__tests__/viewContext.test.ts
+++ b/app/utils/__tests__/viewContext.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from "vitest";
+import type { MapRef } from "react-map-gl/maplibre";
+
+import { enrichMapViewContext } from "../viewContext";
+import type { InsightWidget } from "@/app/types/chat";
+
+function fakeMapRef(bounds: {
+  west: number;
+  south: number;
+  east: number;
+  north: number;
+  zoom: number;
+}): MapRef {
+  const map = {
+    getBounds: () => ({
+      getWest: () => bounds.west,
+      getSouth: () => bounds.south,
+      getEast: () => bounds.east,
+      getNorth: () => bounds.north,
+    }),
+    getZoom: () => bounds.zoom,
+  };
+  return { getMap: () => map } as unknown as MapRef;
+}
+
+function insight(insightId?: string): InsightWidget {
+  return {
+    type: "bar",
+    title: "t",
+    description: "d",
+    data: [],
+    xAxis: "x",
+    yAxis: "y",
+    ...(insightId ? { insightId } : {}),
+  };
+}
+
+describe("enrichMapViewContext", () => {
+  it("passes through null unchanged", () => {
+    expect(enrichMapViewContext(null, null, [])).toBeNull();
+  });
+
+  it("passes through non-map pages unchanged", () => {
+    const base = {
+      page: "dashboard" as const,
+      dashboard_id: "d1",
+      dashboard_name: "Paraná",
+    };
+    expect(enrichMapViewContext(base, null, [insight("i1")])).toEqual(base);
+  });
+
+  it("adds no viewport/visible_insights when mapRef is absent and no insights are shown", () => {
+    expect(enrichMapViewContext({ page: "map" }, null, [])).toEqual({
+      page: "map",
+    });
+  });
+
+  it("adds a rounded viewport bbox + zoom from the live map", () => {
+    const mapRef = fakeMapRef({
+      west: -73.98764321,
+      south: 40.76614321,
+      east: -73.93974321,
+      north: 40.80024321,
+      zoom: 5.678,
+    });
+
+    const result = enrichMapViewContext({ page: "map" }, mapRef, []);
+
+    expect(result).toEqual({
+      page: "map",
+      viewport: {
+        bbox: [-73.9876, 40.7661, -73.9397, 40.8002],
+        zoom: 5.68,
+      },
+    });
+  });
+
+  it("adds deduplicated visible_insights from on-map insight widgets", () => {
+    const result = enrichMapViewContext({ page: "map" }, null, [
+      insight("i1"),
+      insight("i2"),
+      insight("i1"),
+      insight(undefined),
+    ]);
+
+    expect(result).toEqual({
+      page: "map",
+      visible_insights: ["i1", "i2"],
+    });
+  });
+
+  it("omits visible_insights when no shown insight has a persisted insightId", () => {
+    const result = enrichMapViewContext({ page: "map" }, null, [
+      insight(undefined),
+      insight(undefined),
+    ]);
+
+    expect(result).toEqual({ page: "map" });
+  });
+});

--- a/app/utils/viewContext.ts
+++ b/app/utils/viewContext.ts
@@ -1,0 +1,61 @@
+import { MapRef } from "react-map-gl/maplibre";
+
+import type { InsightWidget } from "@/app/types/chat";
+import type { ViewContext } from "@/app/store/viewContextStore";
+
+// Keep the payload compact — the backend only echoes these back to the agent
+// as reasoning context, not for precise geometry.
+const round = (n: number, decimals: number): number => {
+  const factor = 10 ** decimals;
+  return Math.round(n * factor) / factor;
+};
+
+type Viewport = NonNullable<Extract<ViewContext, { page: "map" }>["viewport"]>;
+
+function buildViewport(mapRef: MapRef | null): Viewport | undefined {
+  const map = mapRef?.getMap();
+  if (!map) return undefined;
+  const bounds = map.getBounds();
+  return {
+    bbox: [
+      round(bounds.getWest(), 4),
+      round(bounds.getSouth(), 4),
+      round(bounds.getEast(), 4),
+      round(bounds.getNorth(), 4),
+    ],
+    zoom: round(map.getZoom(), 2),
+  };
+}
+
+function buildVisibleInsights(insights: InsightWidget[]): string[] | undefined {
+  const ids = Array.from(
+    new Set(
+      insights
+        .map((widget) => widget.insightId)
+        .filter((id): id is string => Boolean(id))
+    )
+  );
+  return ids.length > 0 ? ids : undefined;
+}
+
+// Extend the ambient `view_context` with map-only fields that are computed
+// live at send time rather than tracked reactively in viewContextStore — the
+// current map extent and which insights are shown on the map right now, read
+// fresh from mapStore/insightStore for every request (same approach as
+// `ui_context` in messageContext.ts).
+export function enrichMapViewContext(
+  base: ViewContext | null,
+  mapRef: MapRef | null,
+  insights: InsightWidget[]
+): ViewContext | null {
+  if (!base || base.page !== "map") return base;
+
+  const viewport = buildViewport(mapRef);
+  const visible_insights = buildVisibleInsights(insights);
+
+  return {
+    ...base,
+    ...(viewport && { viewport }),
+    ...(visible_insights && { visible_insights }),
+  };
+}


### PR DESCRIPTION
## Summary
Backend counterpart to wri/project-zeno#781.

The backend's `inspect_view_context` tool already understands `viewport` and `visible_insights` on `view_context` — including loading full chart data/summaries for on-screen insight ids — but the frontend's `ViewContext` only ever sent `page`/`dashboard_id`/`dashboard_name`. So the chart-data inspection work only ever reached insights hosted on a dashboard, never an insight the user has open directly on the map.

- `ViewContext`'s map variant now carries optional `viewport` (`{bbox, zoom}`) and `visible_insights` (deduped insight ids).
- Both are computed live at send time in `enrichMapViewContext` (`app/utils/viewContext.ts`) from the live `mapRef` bounds/zoom and `useInsightStore`'s on-map insight widgets — mirroring how `ui_context` is derived fresh per request rather than tracked reactively in a store.
- `visible_insights` is built from each widget's persisted `insightId` (the backend-loadable insight UUID), not the per-chart `id`, and only insights that have one are included.

## Test plan
- [x] `vitest run app/utils/__tests__/viewContext.test.ts app/store/__tests__/chatStore.test.ts` — 31 passed
- [x] `tsc --noEmit` — clean
- [x] pre-push hooks (prettier check, typecheck) passed