### PR TITLE
HOTFIX: correct Bezos Earth Fund attribution on the Amazon.ia page

### DIFF
--- a/app/amazonia/sections/Partners.tsx
+++ b/app/amazonia/sections/Partners.tsx
@@ -54,7 +54,7 @@ export default function Partners() {
             lineHeight="1.7"
             color="whiteAlpha.800"
           >
-            Amazon.ia is launching in 2026 with a seed grant from the{" "}
+            Amazon.ia is launching in 2026 with founding support from the{" "}
             <Text as="span" color="white" fontWeight="500">
               Bezos Earth Fund
             </Text>


### PR DESCRIPTION
Corrects the funder attribution on the live `/amazonia` page from "a seed grant" to "founding support".

```diff
- Amazon.ia is launching in 2026 with a seed grant from the Bezos Earth Fund
+ Amazon.ia is launching in 2026 with founding support from the Bezos Earth Fund
```

### Why this is going straight to `main`

The copy edit already exists on `develop` as 05f0255d (27 Jul, labelled HOTFIX), but the Amazon.ia page was cherry-picked to `main` separately in #576, so the correction never reached the live page. `main` has been serving the old wording since.

It would eventually arrive via the release PR (#620), but that is currently blocked behind #604, and funder attribution language shouldn't wait on the release train.

This is a cherry-pick of the original commit, so authorship and the tie back to 05f0255d are preserved.

### Side benefit

`Partners.tsx` currently conflicts between `develop` and `main` (add/add — the page exists on both branches under different SHAs). Once this lands, the file is byte-identical on both sides and that conflict disappears, taking #620 from two conflicts down to one (`pnpm-lock.yaml`). Verified with `git merge-tree`.

### Test plan

- [x] `pnpm format:check`
- [x] `pnpm typecheck` (pre-push hook)
- [ ] Confirm the wording on `/amazonia` after deploy
- [ ] Comms/legal sign-off on "founding support" as the correct phrasing