### PR TITLE
fix(chat): read dataset suggestions from the generic nudge key

### DIFF
--- a/app/lib/__tests__/parse-stream-message.test.ts
+++ b/app/lib/__tests__/parse-stream-message.test.ts
@@ -173,6 +173,61 @@ describe("parseStreamMessage — tool response_metadata write signals", () => {
   });
 });
 
+describe("parseStreamMessage — dataset_choice nudge → suggested_datasets", () => {
+  it("extracts nudge.data as suggested_datasets when the nudge type is dataset_choice", () => {
+    const suggested = [
+      {
+        dataset_id: 4,
+        dataset_name: "TCL Fires",
+        reason: "Annual fire series.",
+      },
+      { dataset_id: 7, dataset_name: "DIST Alerts", reason: "Daily alerts." },
+    ];
+    const update = {
+      ...toolUpdate("pick_dataset"),
+      nudge: {
+        type: "dataset_choice",
+        options: ["TCL Fires", "DIST Alerts"],
+        data: suggested,
+      },
+    } as unknown as LangChainUpdate;
+
+    const msg = parseStreamMessage(update, "tools", TS);
+    expect(msg?.suggested_datasets).toEqual(suggested);
+  });
+
+  it("ignores nudge data for other nudge types (e.g. aoi_choice)", () => {
+    const update = {
+      ...toolUpdate("pick_aoi"),
+      nudge: {
+        type: "aoi_choice",
+        options: ["Georgia, USA", "Georgia (country)"],
+        data: [{ name: "Georgia, USA" }, { name: "Georgia (country)" }],
+      },
+    } as unknown as LangChainUpdate;
+
+    const msg = parseStreamMessage(update, "tools", TS);
+    expect(msg?.suggested_datasets).toBeUndefined();
+  });
+
+  it("falls back to the legacy suggested_datasets field when there is no nudge", () => {
+    const suggested = [
+      {
+        dataset_id: 4,
+        dataset_name: "TCL Fires",
+        reason: "Annual fire series.",
+      },
+    ];
+    const update = {
+      ...toolUpdate("pick_dataset"),
+      suggested_datasets: suggested,
+    } as unknown as LangChainUpdate;
+
+    const msg = parseStreamMessage(update, "tools", TS);
+    expect(msg?.suggested_datasets).toEqual(suggested);
+  });
+});
+
 describe("parseStreamMessage — tool error classification", () => {
   it("classifies a status=error tool message as an error", () => {
     const update = toolUpdate("create_dashboard");

--- a/app/lib/parse-stream-message.ts
+++ b/app/lib/parse-stream-message.ts
@@ -85,7 +85,15 @@ export function parseStreamMessage(
       name: kwargs.name,
       content: typeof content === "string" ? content : String(content),
       dataset: langChainMessage.dataset || undefined,
-      suggested_datasets: langChainMessage.suggested_datasets || undefined,
+      // Prefer the generic nudge's dataset_choice data (wri/project-zeno#770);
+      // fall back to the legacy field for threads paused mid-disambiguation
+      // before that migration.
+      suggested_datasets:
+        (langChainMessage.nudge?.type === "dataset_choice"
+          ? langChainMessage.nudge.data
+          : undefined) ||
+        langChainMessage.suggested_datasets ||
+        undefined,
       insights: langChainMessage.insights || [],
       charts_data: langChainMessage.charts_data || [],
       insight_id: langChainMessage.insight_id || undefined,

--- a/app/types/chat.ts
+++ b/app/types/chat.ts
@@ -334,6 +334,11 @@ export interface LangChainResponse {
 export interface LangChainUpdate {
   dataset: object;
   suggested_datasets?: SuggestedDataset[];
+  // Generic nudge state key, replacing suggested_datasets above
+  // (wri/project-zeno#770). For "dataset_choice", `data` carries the same
+  // per-option shape suggested_datasets used to carry — kept narrow here
+  // since only that one nudge type is consumed on the frontend today.
+  nudge?: { type: string; options: string[]; data?: SuggestedDataset[] };
   aoi?: object;
   aoi_selection?: AOISelection;
   imagery?: ImageryInfo;


### PR DESCRIPTION
## Summary

The backend generalized `pick_dataset`'s `suggested_datasets` state field into a generic `nudge` key (wri/project-zeno#770), dropping the structured per-option dataset metadata in the process. A follow-up commit on that same PR (`90dc3f1`, "Add richer per-option data to dataset_choice and aoi_choice nudges") restored it as `nudge.data`, carrying the exact same per-option shape `suggested_datasets` used to.

This PR is the minimal frontend change to match: it maps `nudge.data` back onto `suggested_datasets` at the wire-parsing boundary (`parseStreamMessage`) when `nudge.type === "dataset_choice"`, with a fallback to the legacy field for threads paused mid-disambiguation before the backend migration. Everything downstream — `pickDatasetTool`, `chatStore`'s nudge buffering, `DatasetNudge.tsx`'s instant map-layer pick, `ChatInput`'s placeholder copy — is untouched and keeps working exactly as before.

Deliberately **not** building out a generic nudge UI/model (no handling for `aoi_choice` or other nudge types) — this only restores the existing dataset-suggestion nudge against the new backend contract.

Depends on wri/project-zeno#770.

## Test plan

- [x] `pnpm typecheck` / `pnpm lint` / `pnpm format:check` / `pnpm build` all pass
- [x] `pnpm test` — full suite (741 tests) passes
- [x] Added coverage in `parse-stream-message.test.ts` for: extracting `nudge.data` as `suggested_datasets` on `dataset_choice`, ignoring other nudge types (e.g. `aoi_choice`), and the legacy-field fallback
