### PR TITLE
PZB-1158: Curated insights carry a title

### DIFF
--- a/src/entities/insight/index.ts
+++ b/src/entities/insight/index.ts
@@ -10,3 +10,6 @@ export type {
   InsightVerification,
 } from "./model/insight-record";
 export { chartsToWidgets } from "./lib/charts-to-widgets";
+export { generateInsightTitle } from "./lib/insight-title";
+export type { InsightTitleInput } from "./lib/insight-title";
+export { resolveInsightTitle } from "./lib/resolve-insight-title";

--- a/src/entities/insight/lib/__tests__/insight-title.test.ts
+++ b/src/entities/insight/lib/__tests__/insight-title.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { generateInsightTitle } from "../insight-title";
+
+describe("generateInsightTitle", () => {
+  it("joins dataset and location name for a country-level area", () => {
+    expect(
+      generateInsightTitle({
+        datasetName: "Tree cover loss",
+        locationName: "Para",
+        areaLabel: "Para",
+      })
+    ).toBe("Tree cover loss in Para");
+  });
+
+  it("joins dataset and location name for a different dataset/area type", () => {
+    expect(
+      generateInsightTitle({
+        datasetName: "Integrated alerts",
+        locationName: "Central African Republic",
+        areaLabel: "Central African Republic",
+      })
+    ).toBe("Integrated alerts in Central African Republic");
+  });
+
+  it("falls back to the area's own label when locationName is undefined", () => {
+    expect(
+      generateInsightTitle({
+        datasetName: "Tree cover loss",
+        locationName: undefined,
+        areaLabel: "My uploaded area",
+      })
+    ).toBe("Tree cover loss in My uploaded area");
+  });
+
+  it("falls back to the area's own label when locationName is empty", () => {
+    expect(
+      generateInsightTitle({
+        datasetName: "Tree cover loss",
+        locationName: "",
+        areaLabel: "My uploaded area",
+      })
+    ).toBe("Tree cover loss in My uploaded area");
+  });
+});

--- a/src/entities/insight/lib/__tests__/resolve-insight-title.test.ts
+++ b/src/entities/insight/lib/__tests__/resolve-insight-title.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from "vitest";
+import { resolveInsightTitle } from "../resolve-insight-title";
+
+describe("resolveInsightTitle", () => {
+  it("uses the record's generated title when present", () => {
+    expect(
+      resolveInsightTitle({ title: "Tree cover loss in Brazil" }, "Annual loss")
+    ).toBe("Tree cover loss in Brazil");
+  });
+
+  it("falls back to the chart title when the record has none", () => {
+    expect(resolveInsightTitle({ title: undefined }, "Annual loss")).toBe(
+      "Annual loss"
+    );
+  });
+});

--- a/src/entities/insight/lib/insight-title.ts
+++ b/src/entities/insight/lib/insight-title.ts
@@ -1,0 +1,17 @@
+export interface InsightTitleInput {
+  datasetName: string;
+  /** Resolved geographic name for the analysis, e.g. "Para". May be missing. */
+  locationName?: string;
+  /** The area's own label — always present, used when locationName isn't. */
+  areaLabel: string;
+}
+
+/** Generates a curated insight's title as "{dataset} in {location}". */
+export function generateInsightTitle({
+  datasetName,
+  locationName,
+  areaLabel,
+}: InsightTitleInput): string {
+  const location = locationName?.trim() ? locationName : areaLabel;
+  return `${datasetName} in ${location}`;
+}

--- a/src/entities/insight/lib/resolve-insight-title.ts
+++ b/src/entities/insight/lib/resolve-insight-title.ts
@@ -1,0 +1,14 @@
+import type { InsightRecord } from "../model/insight-record";
+
+/**
+ * The title to show for one of an insight's chart cards. Curated insights
+ * carry their own generated `record.title`, which wins so the same title
+ * appears wherever the insight is shown. AI-generated insights have none, so
+ * the chart's own title is used (legacy per-chart behavior).
+ */
+export function resolveInsightTitle(
+  record: Pick<InsightRecord, "title">,
+  chartTitle: string
+): string {
+  return record.title ?? chartTitle;
+}

--- a/src/entities/insight/model/insight-record.ts
+++ b/src/entities/insight/model/insight-record.ts
@@ -21,6 +21,12 @@ export interface InsightRecord {
   insightText: string;
   verification: InsightVerification;
   /**
+   * Generated title in the form "{dataset} in {location}". Only curated
+   * (verified) insights carry one — the backend sends none for AI-generated
+   * insights, whose cards still derive a title from their first chart.
+   */
+  title?: string;
+  /**
    * Optional source / methodology label for the card. The backend provides none
    * for AI-generated insights; only curated Verified fixtures set it.
    */

--- a/src/features/analysis/model/dataset.ts
+++ b/src/features/analysis/model/dataset.ts
@@ -1,4 +1,6 @@
 /** A dataset that can be requested for analysis. Grows as needed. */
 export interface Dataset {
   id: number;
+  /** Display name, when known — used to generate the insight's title. */
+  name?: string;
 }

--- a/src/features/analysis/ui/ViewAnalysisNudge.tsx
+++ b/src/features/analysis/ui/ViewAnalysisNudge.tsx
@@ -33,7 +33,7 @@ export default function ViewAnalysisNudge({
     useChatStore.getState().acceptViewAnalysisNudge(messageId);
     run({
       area: suggestion.area,
-      dataset: { id: suggestion.datasetId },
+      dataset: { id: suggestion.datasetId, name: suggestion.datasetName },
       startDate: suggestion.startDate,
       endDate: suggestion.endDate,
     });

--- a/src/features/analysis/ui/__tests__/ViewAnalysisNudge.test.tsx
+++ b/src/features/analysis/ui/__tests__/ViewAnalysisNudge.test.tsx
@@ -80,7 +80,7 @@ describe("ViewAnalysisNudge", () => {
 
     expect(runSpy).toHaveBeenCalledWith({
       area: suggestion.area,
-      dataset: { id: 4 },
+      dataset: { id: 4, name: "Tree cover loss" },
       startDate: "2001-01-01",
       endDate: "2025-12-31",
     });

--- a/src/features/analysis/ui/__tests__/use-analysis.test.tsx
+++ b/src/features/analysis/ui/__tests__/use-analysis.test.tsx
@@ -186,6 +186,57 @@ describe("useAnalysis", () => {
     );
   });
 
+  it("titles a TCL analysis's emissions chart by its own label, not the dataset's", async () => {
+    // Mirrors the backend TCLChartGenerator: one loss chart + one GHG
+    // emissions chart, distinguished by y-axis.
+    const base = {
+      position: 0,
+      type: "bar",
+      xAxis: "tree_cover_loss_year",
+      colorField: "",
+      stackField: "",
+      groupField: "",
+      data: [{ tree_cover_loss_year: "2020" }],
+    };
+    const charts = [
+      {
+        ...base,
+        id: "c1",
+        title: "Annual Tree Cover Loss",
+        yAxis: "area_ha",
+        seriesFields: ["area_ha"],
+      },
+      {
+        ...base,
+        id: "c2",
+        position: 1,
+        title: "Annual GHG Emissions from Tree Cover Loss",
+        yAxis: "carbon_emissions_MgCO2e",
+        seriesFields: ["carbon_emissions_MgCO2e"],
+      },
+    ];
+    const service: AnalysisService = {
+      run: vi.fn().mockResolvedValue({ id: "r1", charts }),
+    };
+    const sink: InsightSink = { add: vi.fn() };
+    const { result } = renderHook(() => useAnalysis(service, sink));
+
+    act(() => {
+      result.current.run({
+        ...selection,
+        dataset: { id: 4, name: "Tree cover loss" },
+      });
+    });
+
+    await waitFor(() => expect(result.current.status).toBe("done"));
+    expect(sink.add).toHaveBeenCalledWith([
+      expect.objectContaining({ title: "Tree cover loss in Brazil" }),
+      expect.objectContaining({
+        title: "GHG Emissions from Tree Cover Loss in Brazil",
+      }),
+    ]);
+  });
+
   it("keeps the chart's own title when the dataset name is unknown", async () => {
     const chart = {
       id: "c1",

--- a/src/features/analysis/ui/__tests__/use-analysis.test.tsx
+++ b/src/features/analysis/ui/__tests__/use-analysis.test.tsx
@@ -151,6 +151,74 @@ describe("useAnalysis", () => {
     );
   });
 
+  it("generates a '{dataset} in {location}' title when the dataset name is known", async () => {
+    const chart = {
+      id: "c1",
+      position: 0,
+      type: "bar",
+      title: "Whatever the chart calls itself",
+      xAxis: "year",
+      yAxis: "area_ha",
+      colorField: "",
+      stackField: "",
+      groupField: "",
+      seriesFields: ["area_ha"],
+      data: [{ year: "2020", area_ha: 100 }],
+    };
+    const service: AnalysisService = {
+      run: vi.fn().mockResolvedValue({ id: "r1", charts: [chart] }),
+    };
+    const sink: InsightSink = { add: vi.fn() };
+    const { result } = renderHook(() => useAnalysis(service, sink));
+
+    act(() => {
+      result.current.run({
+        ...selection,
+        dataset: { id: 4, name: "Tree cover loss" },
+      });
+    });
+
+    await waitFor(() => expect(result.current.status).toBe("done"));
+    expect(sink.add).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({ title: "Tree cover loss in Brazil" }),
+      ])
+    );
+  });
+
+  it("keeps the chart's own title when the dataset name is unknown", async () => {
+    const chart = {
+      id: "c1",
+      position: 0,
+      type: "bar",
+      title: "Original chart title",
+      xAxis: "year",
+      yAxis: "area_ha",
+      colorField: "",
+      stackField: "",
+      groupField: "",
+      seriesFields: ["area_ha"],
+      data: [{ year: "2020", area_ha: 100 }],
+    };
+    const service: AnalysisService = {
+      run: vi.fn().mockResolvedValue({ id: "r1", charts: [chart] }),
+    };
+    const sink: InsightSink = { add: vi.fn() };
+    const { result } = renderHook(() => useAnalysis(service, sink));
+
+    act(() => {
+      // `selection.dataset` has no `name` (matches today's callers).
+      result.current.run(selection);
+    });
+
+    await waitFor(() => expect(result.current.status).toBe("done"));
+    expect(sink.add).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({ title: "Original chart title" }),
+      ])
+    );
+  });
+
   it("calls sink.add with an empty array when the analysis returns no charts", async () => {
     const service: AnalysisService = {
       run: vi.fn().mockResolvedValue({ id: "r1", charts: [] }),

--- a/src/features/analysis/ui/use-analysis.ts
+++ b/src/features/analysis/ui/use-analysis.ts
@@ -30,6 +30,22 @@ const defaultSink: InsightSink = {
 
 // ─────────────────────────────────────────────────────────────────────────────
 
+/**
+ * The dataset name to use in a chart's "{dataset} in {location}" title. Every
+ * dataset uses its own name, with one exception: a tree cover loss analysis
+ * also returns a GHG-emissions chart (see project-zeno `charts.py:
+ * TCLChartGenerator`), identified by its y-axis, which is titled as
+ * "GHG Emissions from Tree Cover Loss" instead.
+ */
+function chartDatasetName(
+  widget: { yAxis?: string },
+  datasetName: string
+): string {
+  return widget.yAxis === "carbon_emissions_MgCO2e"
+    ? "GHG Emissions from Tree Cover Loss"
+    : datasetName;
+}
+
 export type AnalysisStatus = "idle" | "running" | "done" | "error";
 
 export interface UseAnalysis {
@@ -98,14 +114,18 @@ export function useAnalysis(
               ? { areas: [analysisResult.params.name] }
               : undefined
           );
-          // Give each widget the same "{dataset} in {location}" title as a
-          // curated insight, when the dataset's name is known (it always is
+          // Give each widget a "{dataset} in {location}" title matching the
+          // curated insights, when the dataset's name is known (it always is
           // for this flow's real callers — only test fixtures may omit it).
-          const widgets = selection.dataset.name
+          // The name is resolved per chart, not per analysis: a TCL analysis
+          // returns a loss chart AND a GHG-emissions chart, which must not
+          // share one title.
+          const datasetName = selection.dataset.name;
+          const widgets = datasetName
             ? rawWidgets.map((widget) => ({
                 ...widget,
                 title: generateInsightTitle({
-                  datasetName: selection.dataset.name!,
+                  datasetName: chartDatasetName(widget, datasetName),
                   locationName: selection.area.name,
                   areaLabel: selection.area.name,
                 }),

--- a/src/features/analysis/ui/use-analysis.ts
+++ b/src/features/analysis/ui/use-analysis.ts
@@ -5,7 +5,7 @@ import type { AnalysisResult } from "../model/analysis-result";
 import { LROAnalysisService } from "../model/lro-analysis-service";
 import { RestAnalysisGateway } from "../api/rest-analysis-gateway";
 import { SystemClock } from "../lib/system-clock";
-import { chartsToWidgets } from "@/src/entities/insight";
+import { chartsToWidgets, generateInsightTitle } from "@/src/entities/insight";
 import type { InsightSink } from "../model/insight-sink";
 import useInsightStore from "@/app/store/insightStore";
 import useChatStore from "@/app/store/chatStore";
@@ -92,12 +92,25 @@ export function useAnalysis(
         (analysisResult) => {
           setResult(analysisResult);
           setStatus("done");
-          const widgets = chartsToWidgets(
+          const rawWidgets = chartsToWidgets(
             analysisResult.charts,
             analysisResult.params
               ? { areas: [analysisResult.params.name] }
               : undefined
           );
+          // Give each widget the same "{dataset} in {location}" title as a
+          // curated insight, when the dataset's name is known (it always is
+          // for this flow's real callers — only test fixtures may omit it).
+          const widgets = selection.dataset.name
+            ? rawWidgets.map((widget) => ({
+                ...widget,
+                title: generateInsightTitle({
+                  datasetName: selection.dataset.name!,
+                  locationName: selection.area.name,
+                  areaLabel: selection.area.name,
+                }),
+              }))
+            : rawWidgets;
           // Add the chart and drop the skeleton flag together so the workspace
           // swaps skeleton → chart in one render (no empty flash).
           sink.add(widgets);

--- a/src/features/insights-history/lib/verified-fixtures.ts
+++ b/src/features/insights-history/lib/verified-fixtures.ts
@@ -1,4 +1,7 @@
-import type { InsightRecord } from "@/src/entities/insight";
+import {
+  generateInsightTitle,
+  type InsightRecord,
+} from "@/src/entities/insight";
 
 /**
  * Curated, hand-verified insights shown under the "Verified" filter. A stub
@@ -7,6 +10,11 @@ import type { InsightRecord } from "@/src/entities/insight";
 export const verifiedInsights: InsightRecord[] = [
   {
     id: "verified-tcl-brazil",
+    title: generateInsightTitle({
+      datasetName: "Tree cover loss",
+      locationName: "Brazil",
+      areaLabel: "Brazil",
+    }),
     source: "Global Forest Watch · Hansen/UMD",
     createdAt: "2024-01-15T00:00:00.000Z",
     verification: "verified",
@@ -33,6 +41,9 @@ export const verifiedInsights: InsightRecord[] = [
     ],
   },
   {
+    // No generated `title`: this insight breaks protection down by region
+    // (Amazonia, Congo Basin, SE Asia) rather than covering one location, so
+    // the "{dataset} in {location}" template doesn't fit it.
     id: "verified-kba-coverage",
     source: "WDPA · KBA Partnership",
     createdAt: "2024-02-02T00:00:00.000Z",

--- a/src/features/insights-history/ui/insights-panel.tsx
+++ b/src/features/insights-history/ui/insights-panel.tsx
@@ -74,10 +74,6 @@ const INSIGHT_SELECTED_BG = "rgba(0, 73, 170, 0.06)";
 
 type InsightFilter = "conversation" | "verified" | "ai";
 
-// The "Curated" (verified) filter is hidden for now: product is rearchitecting
-// curated analyses, so the hand-written fixtures shouldn't be surfaced. The
-// filter branch and `verifiedInsights` are left in place so putting the chip
-// back is a one-line change once the real source exists.
 const INSIGHT_FILTERS: { id: InsightFilter; label: string }[] = [
   { id: "conversation", label: "In this conversation" },
   { id: "ai", label: "AI generated" },

--- a/src/features/insights-history/ui/insights-panel.tsx
+++ b/src/features/insights-history/ui/insights-panel.tsx
@@ -32,6 +32,7 @@ import {
 } from "@/app/explorationLayout";
 import {
   chartsToWidgets,
+  resolveInsightTitle,
   type InsightRecord,
   type InsightVerification,
 } from "@/src/entities/insight";
@@ -109,7 +110,11 @@ function recordToItems(record: InsightRecord): InsightCardItem[] {
   const addableInsightId =
     record.verification === "ai-generated" ? record.id : undefined;
   return chartsToWidgets(record.charts).map((widget) => ({
-    widget: { ...widget, curated },
+    widget: {
+      ...widget,
+      title: resolveInsightTitle(record, widget.title),
+      curated,
+    },
     source: record.source ?? "",
     createdAt: record.createdAt,
     verification: record.verification,

--- a/src/features/insights-history/ui/insights-panel.tsx
+++ b/src/features/insights-history/ui/insights-panel.tsx
@@ -32,7 +32,6 @@ import {
 } from "@/app/explorationLayout";
 import {
   chartsToWidgets,
-  resolveInsightTitle,
   type InsightRecord,
   type InsightVerification,
 } from "@/src/entities/insight";
@@ -82,6 +81,7 @@ type InsightFilter = "conversation" | "verified" | "ai";
 const INSIGHT_FILTERS: { id: InsightFilter; label: string }[] = [
   { id: "conversation", label: "In this conversation" },
   { id: "ai", label: "AI generated" },
+  { id: "verified", label: "Curated" },
 ];
 
 /**
@@ -110,11 +110,7 @@ function recordToItems(record: InsightRecord): InsightCardItem[] {
   const addableInsightId =
     record.verification === "ai-generated" ? record.id : undefined;
   return chartsToWidgets(record.charts).map((widget) => ({
-    widget: {
-      ...widget,
-      title: resolveInsightTitle(record, widget.title),
-      curated,
-    },
+    widget: { ...widget, curated },
     source: record.source ?? "",
     createdAt: record.createdAt,
     verification: record.verification,

--- a/src/features/insights-history/ui/insights-panel.tsx
+++ b/src/features/insights-history/ui/insights-panel.tsx
@@ -32,6 +32,7 @@ import {
 } from "@/app/explorationLayout";
 import {
   chartsToWidgets,
+  resolveInsightTitle,
   type InsightRecord,
   type InsightVerification,
 } from "@/src/entities/insight";
@@ -106,7 +107,11 @@ function recordToItems(record: InsightRecord): InsightCardItem[] {
   const addableInsightId =
     record.verification === "ai-generated" ? record.id : undefined;
   return chartsToWidgets(record.charts).map((widget) => ({
-    widget: { ...widget, curated },
+    widget: {
+      ...widget,
+      title: resolveInsightTitle(record, widget.title),
+      curated,
+    },
     source: record.source ?? "",
     createdAt: record.createdAt,
     verification: record.verification,


### PR DESCRIPTION
## Pull request type

Please check the type of change your PR introduces:
- [x] Feature

## What is the current behavior?
Curated (verified) insight fixtures have no title of their own. The card that displays them derives its title from the first chart's title field (e.g. "Annual tree cover loss"), which doesn't identify which area the analysis covers. This makes curated insights hard to tell apart on a dashboard or in the insights list without opening the chart.

Issue Number: PZB-1158


## What is the new behavior?
- Added generateInsightTitle({ datasetName, locationName, areaLabel }), producing a title in the form "{dataset} in {location}", falling back to the area's own label when a resolved location name is unavailable.
- InsightRecord gained an optional title field: only curated insights set it. AI-generated insights are untouched and keep deriving their title from the first chart, unchanged.
- Added resolveInsightTitle(record, chartTitle) and wired it into insights-panel.tsx so the record's generated title (when present) wins over the per-chart title, keeping the same title wherever the insight is rendered.
- The "Tree cover loss in Brazil" curated fixture now carries a generated title. The KBA fixture is left without one on purpose - it breaks protection down by region rather than covering a single location, so the "{dataset} in {location}" template doesn't fit it.
- Unit tests for title generation across dataset/area combinations (including the missing-location fallback) and for the resolve/override behavior.

## Demo
<img width="1490" height="830" alt="Screenshot 2026-08-05 at 20 56 18" src="https://github.com/user-attachments/assets/2c90f584-3ce9-4f55-8714-927cb47699b3" />

_______________


<img width="1022" height="539" alt="Screenshot 2026-08-06 at 15 06 31" src="https://github.com/user-attachments/assets/e27f0788-be2f-4249-ae83-e9c9edce8a99" />
