### PR TITLE
feat(dashboards): add the "Suggested modules" row to dashboard pages

### DIFF
--- a/app/components/ChatInput.tsx
+++ b/app/components/ChatInput.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import {
   Button,
   Flex,
@@ -85,7 +85,24 @@ export default function ChatInput({
     toggleAreasPanel,
     insightsPanelOpen,
     toggleInsightsPanel,
+    chatInputFocusToken,
   } = useSidebarStore();
+
+  // Focus on request from outside (e.g. a dashboard's "Describe your own"
+  // suggested module) — skip the initial mount so the textarea isn't
+  // stolen-focused on every page load.
+  const hasMountedRef = useRef(false);
+  useEffect(() => {
+    if (!hasMountedRef.current) {
+      hasMountedRef.current = true;
+      return;
+    }
+    if (isMobile) {
+      onInputModalOpen();
+    }
+    focusEl?.focus();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [chatInputFocusToken]);
 
   const excludedLayerIds = useChatStore((s) => s.excludedContextLayerIds);
   const excludedSet = new Set(excludedLayerIds);

--- a/app/store/__tests__/sidebarStore.test.ts
+++ b/app/store/__tests__/sidebarStore.test.ts
@@ -97,3 +97,17 @@ describe("sidebarStore — catalog column panels", () => {
     expect(state.insightsPanelOpen).toBe(false);
   });
 });
+
+describe("sidebarStore — chat input focus requests", () => {
+  it("increments the focus token on each request", () => {
+    const before = useSidebarStore.getState().chatInputFocusToken;
+
+    useSidebarStore.getState().requestChatInputFocus();
+    expect(useSidebarStore.getState().chatInputFocusToken).toBe(before + 1);
+
+    // A second request bumps it again, even though nothing else changed —
+    // ChatInput's effect keys off the token changing, not a boolean flag.
+    useSidebarStore.getState().requestChatInputFocus();
+    expect(useSidebarStore.getState().chatInputFocusToken).toBe(before + 2);
+  });
+});

--- a/app/store/sidebarStore.ts
+++ b/app/store/sidebarStore.ts
@@ -42,6 +42,14 @@ interface SidebarState {
   insightsPanelOpen: boolean;
   setInsightsPanelOpen: (open: boolean) => void;
   toggleInsightsPanel: () => void;
+  /**
+   * Incremented each time something outside ChatInput (e.g. the dashboard's
+   * "Describe your own" suggested module) wants the chat textarea focused.
+   * A counter rather than a boolean so repeated requests each retrigger the
+   * effect even if the textarea never lost focus in between.
+   */
+  chatInputFocusToken: number;
+  requestChatInputFocus: () => void;
 }
 
 function updateThreadInCache(
@@ -109,6 +117,12 @@ const useSidebarStore = create<SidebarState>(() => ({
           }
         : { areasPanelOpen: false };
     }),
+  chatInputFocusToken: 0,
+  requestChatInputFocus: () =>
+    useSidebarStore.setState((state) => ({
+      chatInputFocusToken: state.chatInputFocusToken + 1,
+    })),
+
   insightsPanelOpen: false,
   setInsightsPanelOpen: (open) =>
     useSidebarStore.setState(

--- a/src/features/dashboards/__tests__/dashboards.test.ts
+++ b/src/features/dashboards/__tests__/dashboards.test.ts
@@ -1,5 +1,11 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
+vi.mock("@/app/lib/api-client", () => ({
+  apiFetch: vi.fn(),
+}));
+
+import { apiFetch } from "@/app/lib/api-client";
+import { addTextWidget } from "../api/dashboards";
 import {
   AoiSearchResponseSchema,
   DashboardListResponseSchema,
@@ -108,5 +114,21 @@ describe("dashboard date helpers", () => {
   it("uses a neutral updated label for invalid or future timestamps", () => {
     expect(updatedLabel("not-a-date")).toBe("Updated recently");
     expect(updatedLabel("2999-01-01T00:00:00Z")).toBe("Updated recently");
+  });
+});
+
+describe("addTextWidget", () => {
+  it("sends config.text as a string, per the backend's validate_text_config", async () => {
+    vi.mocked(apiFetch).mockResolvedValue(
+      new Response(JSON.stringify({}), { status: 200 })
+    );
+
+    await addTextWidget("d1");
+
+    expect(apiFetch).toHaveBeenCalledWith("/api/dashboards/d1/widgets", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ widget_type: "text", config: { text: "" } }),
+    });
   });
 });

--- a/src/features/dashboards/api/dashboards.ts
+++ b/src/features/dashboards/api/dashboards.ts
@@ -113,6 +113,21 @@ export async function addInsightWidget(
   });
 }
 
+// Adds a blank note (the "Text block" suggested module) — an empty
+// `widget_type: "text"` widget the owner fills in afterwards via
+// DashboardTextWidgetCard's pencil. Mirrors addInsightWidget: the backend
+// assigns id/position, so callers refetch rather than read the response.
+// The backend's `validate_text_config` requires `config.text` to be a
+// string (any string, including empty) — an empty string still renders as
+// a blank note client-side (`widgetText` treats a blank string as "no text").
+export async function addTextWidget(dashboardId: string): Promise<void> {
+  await readJson<unknown>(`/api/dashboards/${dashboardId}/widgets`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ widget_type: "text", config: { text: "" } }),
+  });
+}
+
 export async function deleteWidget(
   dashboardId: string,
   widgetId: string

--- a/src/features/dashboards/lib/__tests__/suggested-modules.test.ts
+++ b/src/features/dashboards/lib/__tests__/suggested-modules.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+
+import { SUGGESTED_PROMPT_MODULES } from "../suggested-modules";
+
+describe("SUGGESTED_PROMPT_MODULES", () => {
+  it("gives every card a unique id", () => {
+    const ids = SUGGESTED_PROMPT_MODULES.map((m) => m.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("gives every card a non-empty label, icon, and prompt", () => {
+    for (const card of SUGGESTED_PROMPT_MODULES) {
+      expect(card.label.trim()).not.toBe("");
+      expect(card.icon).toBeTruthy();
+      expect(card.prompt.trim()).not.toBe("");
+    }
+  });
+
+  it("scopes every prompt to the current area, per the chat pipeline's ui_context", () => {
+    for (const card of SUGGESTED_PROMPT_MODULES) {
+      expect(card.prompt.toLowerCase()).toContain("this area");
+    }
+  });
+
+  it("has every analysis card ask for a text block and a map alongside the analysis", () => {
+    const analysisCards = SUGGESTED_PROMPT_MODULES.filter(
+      (m) => m.kind === "analysis"
+    );
+    expect(analysisCards.length).toBeGreaterThan(0);
+    for (const card of analysisCards) {
+      const prompt = card.prompt.toLowerCase();
+      expect(prompt).toContain("text block");
+      expect(prompt).toContain("map");
+    }
+  });
+
+  it("keeps the satellite imagery card a plain content add, not an analysis", () => {
+    const imagery = SUGGESTED_PROMPT_MODULES.find(
+      (m) => m.id === "recent-satellite-imagery"
+    );
+    expect(imagery?.kind).toBe("action");
+  });
+});

--- a/src/features/dashboards/lib/__tests__/suggested-modules.test.ts
+++ b/src/features/dashboards/lib/__tests__/suggested-modules.test.ts
@@ -16,8 +16,14 @@ describe("SUGGESTED_PROMPT_MODULES", () => {
     }
   });
 
-  it("scopes every prompt to the current area, per the chat pipeline's ui_context", () => {
-    for (const card of SUGGESTED_PROMPT_MODULES) {
+  it("scopes every analysis prompt to the current area, per the chat pipeline's ui_context", () => {
+    // Action cards vary: satellite imagery needs an area, summarising the
+    // dashboard's existing content doesn't — only analysis cards require it.
+    const analysisCards = SUGGESTED_PROMPT_MODULES.filter(
+      (m) => m.kind === "analysis"
+    );
+    expect(analysisCards.length).toBeGreaterThan(0);
+    for (const card of analysisCards) {
       expect(card.prompt.toLowerCase()).toContain("this area");
     }
   });
@@ -39,5 +45,13 @@ describe("SUGGESTED_PROMPT_MODULES", () => {
       (m) => m.id === "recent-satellite-imagery"
     );
     expect(imagery?.kind).toBe("action");
+  });
+
+  it("has the dashboard-summary card ask for a text block, but not a fresh analysis", () => {
+    const summary = SUGGESTED_PROMPT_MODULES.find(
+      (m) => m.id === "summarise-dashboard"
+    );
+    expect(summary?.kind).toBe("action");
+    expect(summary?.prompt.toLowerCase()).toContain("text block");
   });
 });

--- a/src/features/dashboards/lib/suggested-modules.ts
+++ b/src/features/dashboards/lib/suggested-modules.ts
@@ -3,6 +3,7 @@ import {
   GlobeIcon,
   GrainsIcon,
   LogIcon,
+  NotepadIcon,
   SirenIcon,
   SplitHorizontalIcon,
   type Icon,
@@ -16,8 +17,9 @@ import {
  * until a real backend source exists for more than tree cover loss.
  *
  * `kind` distinguishes the cards that ask the agent to run an analysis
- * (chart + text block + map, all added to the dashboard) from the one that's
- * a plain content add with no analysis framing (satellite imagery).
+ * (chart + text block + map, all added to the dashboard) from the ones that
+ * are a plain content add with no analysis framing (satellite imagery,
+ * summarising the dashboard's existing content).
  */
 export interface SuggestedPromptModule {
   id: string;
@@ -73,6 +75,14 @@ export const SUGGESTED_PROMPT_MODULES: SuggestedPromptModule[] = [
     label: "Recent satellite imagery",
     icon: GlobeIcon,
     prompt: "Add a recent satellite imagery map of this area to the dashboard.",
+    kind: "action",
+  },
+  {
+    id: "summarise-dashboard",
+    label: "Summarise the dashboard",
+    icon: NotepadIcon,
+    prompt:
+      "Summarize what this dashboard currently shows and add the summary to the dashboard as a text block.",
     kind: "action",
   },
 ];

--- a/src/features/dashboards/lib/suggested-modules.ts
+++ b/src/features/dashboards/lib/suggested-modules.ts
@@ -1,0 +1,78 @@
+import {
+  ChartPieSliceIcon,
+  GlobeIcon,
+  GrainsIcon,
+  LogIcon,
+  SirenIcon,
+  SplitHorizontalIcon,
+  type Icon,
+} from "@phosphor-icons/react";
+
+/**
+ * One of the lime cards in the "Suggested modules" row (Figma node
+ * 1475:4879). Each just injects a canned prompt into the existing chat
+ * pipeline — the same MVP approach as `runAnalysis`/`DashboardChatNudges`:
+ * generative now, with a curated/deterministic swap deliberately deferred
+ * until a real backend source exists for more than tree cover loss.
+ *
+ * `kind` distinguishes the cards that ask the agent to run an analysis
+ * (chart + text block + map, all added to the dashboard) from the one that's
+ * a plain content add with no analysis framing (satellite imagery).
+ */
+export interface SuggestedPromptModule {
+  id: string;
+  label: string;
+  icon: Icon;
+  prompt: string;
+  kind: "analysis" | "action";
+}
+
+export const SUGGESTED_PROMPT_MODULES: SuggestedPromptModule[] = [
+  {
+    id: "tree-cover-loss",
+    label: "Tree cover loss analysis",
+    icon: LogIcon,
+    prompt:
+      "Analyse recent tree cover loss in this area, then add the analysis, a text block summarizing the insight, and a map to the dashboard.",
+    kind: "analysis",
+  },
+  {
+    id: "deforestation-alerts",
+    label: "Monitor disturbance alerts",
+    icon: SirenIcon,
+    prompt:
+      "Analyse recent alerts in this area, then add the analysis, a text block summarizing the insight, and a map to the dashboard.",
+    kind: "analysis",
+  },
+  {
+    id: "land-cover-distribution",
+    label: "Land cover distribution",
+    icon: ChartPieSliceIcon,
+    prompt:
+      "Analyse land cover distribution in this area, then add the analysis, a text block summarizing the insight, and a map to the dashboard.",
+    kind: "analysis",
+  },
+  {
+    id: "grassland-extent",
+    label: "Grassland extent analysis",
+    icon: GrainsIcon,
+    prompt:
+      "Analyse grassland extent in this area, then add the analysis, a text block summarizing the insight, and a map to the dashboard.",
+    kind: "analysis",
+  },
+  {
+    id: "compare-regions",
+    label: "Compare to other regions",
+    icon: SplitHorizontalIcon,
+    prompt:
+      "Compare this area to another region — start by asking me which area(s) to compare against — then add the comparison, a text block summarizing the insight, and a map to the dashboard.",
+    kind: "analysis",
+  },
+  {
+    id: "recent-satellite-imagery",
+    label: "Recent satellite imagery",
+    icon: GlobeIcon,
+    prompt: "Add a recent satellite imagery map of this area to the dashboard.",
+    kind: "action",
+  },
+];

--- a/src/features/dashboards/ui/DashboardDetailPage.tsx
+++ b/src/features/dashboards/ui/DashboardDetailPage.tsx
@@ -2,8 +2,7 @@
 
 import { useParams } from "next/navigation";
 import { useEffect } from "react";
-import { Box, Container, Flex, Heading, Spinner, Text } from "@chakra-ui/react";
-import { SquaresFourIcon } from "@phosphor-icons/react";
+import { Box, Container, Flex, Spinner, Text } from "@chakra-ui/react";
 
 import ChatPanel from "@/app/ChatPanel";
 import { getDashboardContentLeftPx } from "@/app/explorationLayout";
@@ -16,6 +15,7 @@ import { useDashboard } from "./dashboardQueries";
 import DashboardBreadcrumb from "./DashboardBreadcrumb";
 import DashboardHeader from "./DashboardHeader";
 import DashboardPinnedHeader from "./DashboardPinnedHeader";
+import DashboardSuggestedModules from "./DashboardSuggestedModules";
 import DashboardWidgetsGrid from "./DashboardWidgetsGrid";
 import { HERO_BAND_PROPS } from "./heroGrid";
 
@@ -134,33 +134,13 @@ export default function DashboardDetailPage() {
                 <DashboardHeader dashboard={dashboard} isOwner={isOwner} />
               </Box>
 
-              {dashboard.widgets.length > 0 ? (
+              {dashboard.widgets.length > 0 && (
                 <DashboardWidgetsGrid dashboard={dashboard} />
-              ) : (
-                <Flex
-                  minH="320px"
-                  align="center"
-                  justify="center"
-                  borderWidth="1px"
-                  borderStyle="dashed"
-                  borderColor="border"
-                  borderRadius="sm"
-                  bg="white"
-                  px={6}
-                  textAlign="center"
-                >
-                  <Box maxW="md">
-                    <SquaresFourIcon size={32} color="#656E7B" />
-                    <Heading as="h2" size="md" mt={4} mb={2}>
-                      This dashboard is empty
-                    </Heading>
-                    <Text color="fg.muted">
-                      Ask the AI assistant to analyse this area — insights it
-                      adds to the dashboard will appear here.
-                    </Text>
-                  </Box>
-                </Flex>
               )}
+              <DashboardSuggestedModules
+                dashboardId={dashboard.id}
+                isOwner={isOwner}
+              />
             </Box>
           )}
         </Flex>

--- a/src/features/dashboards/ui/DashboardSuggestedModules.tsx
+++ b/src/features/dashboards/ui/DashboardSuggestedModules.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import { Box, Flex, Text } from "@chakra-ui/react";
+import { SparkleIcon, TextTIcon, type Icon } from "@phosphor-icons/react";
+
+import { toaster } from "@/app/components/ui/toaster";
+import useChatStore from "@/app/store/chatStore";
+import useSidebarStore from "@/app/store/sidebarStore";
+import { SUGGESTED_PROMPT_MODULES } from "../lib/suggested-modules";
+import { useAddTextWidget } from "./dashboardQueries";
+
+const CARD_WIDTH_PX = 168;
+const CARD_HEIGHT_PX = 100;
+const ANALYSIS_CARD_BG = "#F7FBD9";
+const ANALYSIS_CARD_BORDER = "#C3D16F";
+const NEUTRAL_CARD_BG = "#F4F5F6";
+const NEUTRAL_CARD_BORDER = "#C2C7D0";
+const CARD_LABEL_COLOR = "#0049AA";
+
+function ModuleCard({
+  icon: IconComponent,
+  label,
+  bg,
+  borderColor,
+  disabled,
+  onClick,
+}: {
+  icon: Icon;
+  label: string;
+  bg: string;
+  borderColor: string;
+  disabled?: boolean;
+  onClick: () => void;
+}) {
+  return (
+    <Flex
+      as="button"
+      aria-disabled={disabled}
+      onClick={disabled ? undefined : onClick}
+      direction="column"
+      align="center"
+      justify="center"
+      gap={2}
+      w={`${CARD_WIDTH_PX}px`}
+      h={`${CARD_HEIGHT_PX}px`}
+      px={5}
+      flexShrink={0}
+      bg={bg}
+      borderWidth="1px"
+      borderStyle="dashed"
+      borderColor={borderColor}
+      borderRadius="sm"
+      color={CARD_LABEL_COLOR}
+      opacity={disabled ? 0.5 : 1}
+      cursor={disabled ? "not-allowed" : "pointer"}
+      transition="border-color 0.15s ease"
+      _hover={disabled ? undefined : { borderColor: CARD_LABEL_COLOR }}
+    >
+      <IconComponent size={24} />
+      <Text fontSize="sm" textAlign="center" lineHeight="1.2">
+        {label}
+      </Text>
+    </Flex>
+  );
+}
+
+/**
+ * The "Suggested modules" row (Figma node 1475:4879), rendered below the
+ * widget grid on every dashboard. The lime cards (SUGGESTED_PROMPT_MODULES)
+ * inject a canned prompt into the existing chat pipeline — same MVP approach
+ * as `runAnalysis`/`DashboardChatNudges` (see suggested-modules.ts). "Text
+ * block" adds an empty note widget directly, no chat round-trip. "Describe
+ * your own" just focuses the chat textarea, whose placeholder already reads
+ * "Or describe what you want to explore…" once the thread is empty.
+ */
+export default function DashboardSuggestedModules({
+  dashboardId,
+  isOwner,
+}: {
+  dashboardId: string;
+  isOwner: boolean;
+}) {
+  const sendMessage = useChatStore((s) => s.sendMessage);
+  const requestChatInputFocus = useSidebarStore((s) => s.requestChatInputFocus);
+  const addTextWidget = useAddTextWidget(dashboardId);
+
+  return (
+    <Flex direction="column" gap={5} mt={8}>
+      <Flex align="center" gap={3}>
+        <Box flex={1} h="1px" bg="#E0E2E5" />
+        <Text fontSize="xs" fontStyle="italic" color="#656E7B" flexShrink={0}>
+          Suggested modules
+        </Text>
+        <Box flex={1} h="1px" bg="#E0E2E5" />
+      </Flex>
+      <Flex wrap="wrap" gap="20px">
+        {SUGGESTED_PROMPT_MODULES.map((card) => (
+          <ModuleCard
+            key={card.id}
+            icon={card.icon}
+            label={card.label}
+            bg={ANALYSIS_CARD_BG}
+            borderColor={ANALYSIS_CARD_BORDER}
+            onClick={() => void sendMessage(card.prompt)}
+          />
+        ))}
+        {isOwner && (
+          <ModuleCard
+            icon={TextTIcon}
+            label="Text block"
+            bg={NEUTRAL_CARD_BG}
+            borderColor={NEUTRAL_CARD_BORDER}
+            disabled={addTextWidget.isPending}
+            onClick={() =>
+              addTextWidget.mutate(undefined, {
+                onError: (error) =>
+                  toaster.create({
+                    title: "Couldn't add text block",
+                    description:
+                      error instanceof Error
+                        ? error.message
+                        : "Please try again.",
+                    type: "error",
+                    duration: 4000,
+                  }),
+              })
+            }
+          />
+        )}
+        <ModuleCard
+          icon={SparkleIcon}
+          label="Describe your own"
+          bg={NEUTRAL_CARD_BG}
+          borderColor={NEUTRAL_CARD_BORDER}
+          onClick={requestChatInputFocus}
+        />
+      </Flex>
+    </Flex>
+  );
+}

--- a/src/features/dashboards/ui/DashboardSuggestedModules.tsx
+++ b/src/features/dashboards/ui/DashboardSuggestedModules.tsx
@@ -4,6 +4,7 @@ import { Box, Flex, Text } from "@chakra-ui/react";
 import { SparkleIcon, TextTIcon, type Icon } from "@phosphor-icons/react";
 
 import { toaster } from "@/app/components/ui/toaster";
+import { usePromptQuota } from "@/app/hooks/usePromptQuota";
 import useChatStore from "@/app/store/chatStore";
 import useSidebarStore from "@/app/store/sidebarStore";
 import { SUGGESTED_PROMPT_MODULES } from "../lib/suggested-modules";
@@ -77,6 +78,10 @@ function ModuleCard({
  * block" adds an empty note widget directly, no chat round-trip. "Describe
  * your own" just focuses the chat textarea, whose placeholder already reads
  * "Or describe what you want to explore…" once the thread is empty.
+ *
+ * Every card here writes to the dashboard — the prompts all end in "…add it
+ * to the dashboard" — so the whole row is owner-only, and the cards that go
+ * through the chat honour the same gates ChatInput's submitPrompt does.
  */
 export default function DashboardSuggestedModules({
   dashboardId,
@@ -86,11 +91,33 @@ export default function DashboardSuggestedModules({
   isOwner: boolean;
 }) {
   const sendMessage = useChatStore((s) => s.sendMessage);
+  const isStreaming = useChatStore((s) => s.isLoading);
+  const { promptsExhausted } = usePromptQuota();
   const requestChatInputFocus = useSidebarStore((s) => s.requestChatInputFocus);
   const addTextWidget = useAddTextWidget(dashboardId);
 
+  // These cards are a second entry point into sendMessage, so they need the
+  // guards submitPrompt applies to the textarea (ChatInput's `disabled` is the
+  // same two conditions). Sending while a turn streams would clear the live
+  // turn's tool steps and overwrite its abort controller in the store, leaving
+  // the first request running but uncancellable; sending with no prompts left
+  // just earns a generic "service unavailable". "Describe your own" is gated
+  // too — under either condition the textarea it focuses is itself disabled.
+  const chatDisabled = isStreaming || promptsExhausted;
+
+  if (!isOwner) return null;
+
   return (
-    <Flex direction="column" gap={5} mt={8}>
+    // The chat panel this row drives is desktop-only for now (see the
+    // ChatPanel mount in DashboardDetailPage), so on mobile every card but
+    // "Text block" would post into a panel the user cannot see. Drop the row
+    // until the mobile bottom sheet lands.
+    <Flex
+      direction="column"
+      gap={5}
+      mt={8}
+      display={{ base: "none", md: "flex" }}
+    >
       <Flex align="center" gap={3}>
         <Box flex={1} h="1px" bg="#E0E2E5" />
         <Text fontSize="xs" fontStyle="italic" color="#656E7B" flexShrink={0}>
@@ -106,37 +133,37 @@ export default function DashboardSuggestedModules({
             label={card.label}
             bg={ANALYSIS_CARD_BG}
             borderColor={ANALYSIS_CARD_BORDER}
+            disabled={chatDisabled}
             onClick={() => void sendMessage(card.prompt)}
           />
         ))}
-        {isOwner && (
-          <ModuleCard
-            icon={TextTIcon}
-            label="Text block"
-            bg={NEUTRAL_CARD_BG}
-            borderColor={NEUTRAL_CARD_BORDER}
-            disabled={addTextWidget.isPending}
-            onClick={() =>
-              addTextWidget.mutate(undefined, {
-                onError: (error) =>
-                  toaster.create({
-                    title: "Couldn't add text block",
-                    description:
-                      error instanceof Error
-                        ? error.message
-                        : "Please try again.",
-                    type: "error",
-                    duration: 4000,
-                  }),
-              })
-            }
-          />
-        )}
+        <ModuleCard
+          icon={TextTIcon}
+          label="Text block"
+          bg={NEUTRAL_CARD_BG}
+          borderColor={NEUTRAL_CARD_BORDER}
+          disabled={addTextWidget.isPending}
+          onClick={() =>
+            addTextWidget.mutate(undefined, {
+              onError: (error) =>
+                toaster.create({
+                  title: "Couldn't add text block",
+                  description:
+                    error instanceof Error
+                      ? error.message
+                      : "Please try again.",
+                  type: "error",
+                  duration: 4000,
+                }),
+            })
+          }
+        />
         <ModuleCard
           icon={SparkleIcon}
           label="Describe your own via the chat"
           bg={NEUTRAL_CARD_BG}
           borderColor={NEUTRAL_CARD_BORDER}
+          disabled={chatDisabled}
           onClick={requestChatInputFocus}
         />
       </Flex>

--- a/src/features/dashboards/ui/DashboardSuggestedModules.tsx
+++ b/src/features/dashboards/ui/DashboardSuggestedModules.tsx
@@ -9,7 +9,12 @@ import useSidebarStore from "@/app/store/sidebarStore";
 import { SUGGESTED_PROMPT_MODULES } from "../lib/suggested-modules";
 import { useAddTextWidget } from "./dashboardQueries";
 
-const CARD_WIDTH_PX = 168;
+// Cards grow to fill each row (flexGrow, capped at CARD_MAX_WIDTH_PX) rather
+// than staying pinned to their minimum width — a fixed width left a ragged
+// gap on the right of a row whenever the container was wider than an exact
+// multiple of (card + gap), including on a short last row.
+const CARD_MIN_WIDTH_PX = 168;
+const CARD_MAX_WIDTH_PX = 280;
 const CARD_HEIGHT_PX = 100;
 const ANALYSIS_CARD_BG = "#F7FBD9";
 const ANALYSIS_CARD_BORDER = "#C3D16F";
@@ -41,10 +46,12 @@ function ModuleCard({
       align="center"
       justify="center"
       gap={2}
-      w={`${CARD_WIDTH_PX}px`}
+      flexBasis={`${CARD_MIN_WIDTH_PX}px`}
+      flexGrow={1}
+      flexShrink={0}
+      maxW={`${CARD_MAX_WIDTH_PX}px`}
       h={`${CARD_HEIGHT_PX}px`}
       px={5}
-      flexShrink={0}
       bg={bg}
       borderWidth="1px"
       borderStyle="dashed"
@@ -129,7 +136,7 @@ export default function DashboardSuggestedModules({
         )}
         <ModuleCard
           icon={SparkleIcon}
-          label="Describe your own"
+          label="Describe your own via the chat"
           bg={NEUTRAL_CARD_BG}
           borderColor={NEUTRAL_CARD_BORDER}
           onClick={requestChatInputFocus}

--- a/src/features/dashboards/ui/DashboardSuggestedModules.tsx
+++ b/src/features/dashboards/ui/DashboardSuggestedModules.tsx
@@ -9,12 +9,12 @@ import useSidebarStore from "@/app/store/sidebarStore";
 import { SUGGESTED_PROMPT_MODULES } from "../lib/suggested-modules";
 import { useAddTextWidget } from "./dashboardQueries";
 
-// Cards grow to fill each row (flexGrow, capped at CARD_MAX_WIDTH_PX) rather
-// than staying pinned to their minimum width — a fixed width left a ragged
-// gap on the right of a row whenever the container was wider than an exact
-// multiple of (card + gap), including on a short last row.
-const CARD_MIN_WIDTH_PX = 168;
-const CARD_MAX_WIDTH_PX = 280;
+// Fixed width for every card — deliberately not flex-grow. Rows pack as
+// many as fit and wrap; a short last row leaves empty space rather than
+// stretching its cards, so a card is always the same size regardless of how
+// many others share its row or which surface (populated dashboard vs. the
+// empty-state hero) is rendering it.
+const CARD_WIDTH_PX = 168;
 const CARD_HEIGHT_PX = 100;
 const ANALYSIS_CARD_BG = "#F7FBD9";
 const ANALYSIS_CARD_BORDER = "#C3D16F";
@@ -46,10 +46,8 @@ function ModuleCard({
       align="center"
       justify="center"
       gap={2}
-      flexBasis={`${CARD_MIN_WIDTH_PX}px`}
-      flexGrow={1}
+      w={`${CARD_WIDTH_PX}px`}
       flexShrink={0}
-      maxW={`${CARD_MAX_WIDTH_PX}px`}
       h={`${CARD_HEIGHT_PX}px`}
       px={5}
       bg={bg}

--- a/src/features/dashboards/ui/__tests__/DashboardSuggestedModules.test.tsx
+++ b/src/features/dashboards/ui/__tests__/DashboardSuggestedModules.test.tsx
@@ -20,6 +20,7 @@ import { addTextWidget } from "../../api/dashboards";
 import { toaster } from "@/app/components/ui/toaster";
 import { SUGGESTED_PROMPT_MODULES } from "../../lib/suggested-modules";
 import DashboardSuggestedModules from "../DashboardSuggestedModules";
+import useAuthStore from "@/app/store/authStore";
 import useChatStore from "@/app/store/chatStore";
 import useSidebarStore from "@/app/store/sidebarStore";
 
@@ -41,8 +42,9 @@ const renderModules = (isOwner: boolean) => {
 describe("DashboardSuggestedModules", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    useChatStore.setState({ sendMessage: sendSpy });
+    useChatStore.setState({ sendMessage: sendSpy, isLoading: false });
     useSidebarStore.setState({ chatInputFocusToken: 0 });
+    useAuthStore.setState({ usedPrompts: 0, totalPrompts: 10 });
   });
 
   it("sends each prompt card's canned prompt as a chat message", () => {
@@ -85,10 +87,65 @@ describe("DashboardSuggestedModules", () => {
     );
   });
 
-  it("hides 'Text block' for a viewer who doesn't own the dashboard", () => {
+  it("renders nothing for a viewer who doesn't own the dashboard", () => {
     renderModules(false);
 
+    // Every card writes to the dashboard — the prompts all ask the agent to
+    // add the result to it — so a viewer gets no row at all, not just the
+    // "Text block" card hidden.
+    expect(screen.queryByText("Suggested modules")).toBeNull();
     expect(screen.queryByRole("button", { name: "Text block" })).toBeNull();
+    for (const card of SUGGESTED_PROMPT_MODULES) {
+      expect(screen.queryByRole("button", { name: card.label })).toBeNull();
+    }
+  });
+
+  it("won't send a prompt while a chat turn is still streaming", () => {
+    useChatStore.setState({ isLoading: true });
+    renderModules(true);
+
+    for (const card of SUGGESTED_PROMPT_MODULES) {
+      fireEvent.click(screen.getByRole("button", { name: card.label }));
+    }
+    fireEvent.click(
+      screen.getByRole("button", { name: "Describe your own via the chat" })
+    );
+
+    // A concurrent send clears the in-flight turn's tool steps and overwrites
+    // its abort controller, orphaning the running request.
+    expect(sendSpy).not.toHaveBeenCalled();
+    expect(useSidebarStore.getState().chatInputFocusToken).toBe(0);
+    expect(
+      screen
+        .getByRole("button", { name: SUGGESTED_PROMPT_MODULES[0].label })
+        .getAttribute("aria-disabled")
+    ).toBe("true");
+  });
+
+  it("won't send a prompt once the prompt quota is spent", () => {
+    useAuthStore.setState({ usedPrompts: 10, totalPrompts: 10 });
+    renderModules(true);
+
+    fireEvent.click(
+      screen.getByRole("button", { name: SUGGESTED_PROMPT_MODULES[0].label })
+    );
+    fireEvent.click(
+      screen.getByRole("button", { name: "Describe your own via the chat" })
+    );
+
+    expect(sendSpy).not.toHaveBeenCalled();
+    expect(useSidebarStore.getState().chatInputFocusToken).toBe(0);
+  });
+
+  it("still allows adding a text block while a chat turn streams", () => {
+    // The note is a direct POST, not a chat round-trip, so the chat gates
+    // don't apply to it.
+    useChatStore.setState({ isLoading: true });
+    renderModules(true);
+
+    fireEvent.click(screen.getByRole("button", { name: "Text block" }));
+
+    return waitFor(() => expect(addTextWidget).toHaveBeenCalledWith("d1"));
   });
 
   it("requests chat input focus on 'Describe your own via the chat'", () => {

--- a/src/features/dashboards/ui/__tests__/DashboardSuggestedModules.test.tsx
+++ b/src/features/dashboards/ui/__tests__/DashboardSuggestedModules.test.tsx
@@ -1,0 +1,101 @@
+// @vitest-environment happy-dom
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// The chatStore import chain reaches the Chakra toaster (.tsx) — stub it so the
+// test environment can parse the module boundary.
+vi.mock("@/app/components/ui/toaster", () => ({
+  toaster: { create: vi.fn() },
+  Toaster: () => null,
+}));
+
+vi.mock("../../api/dashboards", async (importOriginal) => ({
+  ...(await importOriginal<object>()),
+  addTextWidget: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { addTextWidget } from "../../api/dashboards";
+import { toaster } from "@/app/components/ui/toaster";
+import { SUGGESTED_PROMPT_MODULES } from "../../lib/suggested-modules";
+import DashboardSuggestedModules from "../DashboardSuggestedModules";
+import useChatStore from "@/app/store/chatStore";
+import useSidebarStore from "@/app/store/sidebarStore";
+
+const sendSpy = vi.fn().mockResolvedValue({ isNew: false, id: "t1" });
+
+const renderModules = (isOwner: boolean) => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <ChakraProvider value={defaultSystem}>
+        <DashboardSuggestedModules dashboardId="d1" isOwner={isOwner} />
+      </ChakraProvider>
+    </QueryClientProvider>
+  );
+};
+
+describe("DashboardSuggestedModules", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useChatStore.setState({ sendMessage: sendSpy });
+    useSidebarStore.setState({ chatInputFocusToken: 0 });
+  });
+
+  it("sends each prompt card's canned prompt as a chat message", () => {
+    renderModules(true);
+
+    for (const card of SUGGESTED_PROMPT_MODULES) {
+      fireEvent.click(screen.getByRole("button", { name: card.label }));
+    }
+
+    expect(sendSpy).toHaveBeenCalledTimes(SUGGESTED_PROMPT_MODULES.length);
+    for (const card of SUGGESTED_PROMPT_MODULES) {
+      expect(sendSpy).toHaveBeenCalledWith(card.prompt);
+    }
+  });
+
+  it("adds a blank text widget on 'Text block' for the owner", async () => {
+    renderModules(true);
+
+    fireEvent.click(screen.getByRole("button", { name: "Text block" }));
+
+    await waitFor(() => expect(addTextWidget).toHaveBeenCalledWith("d1"));
+  });
+
+  it("surfaces an error toast when adding the text widget fails", async () => {
+    vi.mocked(addTextWidget).mockRejectedValueOnce(
+      new Error("config.text: field required")
+    );
+    renderModules(true);
+
+    fireEvent.click(screen.getByRole("button", { name: "Text block" }));
+
+    await waitFor(() =>
+      expect(toaster.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "Couldn't add text block",
+          description: "config.text: field required",
+          type: "error",
+        })
+      )
+    );
+  });
+
+  it("hides 'Text block' for a viewer who doesn't own the dashboard", () => {
+    renderModules(false);
+
+    expect(screen.queryByRole("button", { name: "Text block" })).toBeNull();
+  });
+
+  it("requests chat input focus on 'Describe your own'", () => {
+    renderModules(true);
+
+    fireEvent.click(screen.getByRole("button", { name: "Describe your own" }));
+
+    expect(useSidebarStore.getState().chatInputFocusToken).toBe(1);
+  });
+});

--- a/src/features/dashboards/ui/__tests__/DashboardSuggestedModules.test.tsx
+++ b/src/features/dashboards/ui/__tests__/DashboardSuggestedModules.test.tsx
@@ -91,10 +91,12 @@ describe("DashboardSuggestedModules", () => {
     expect(screen.queryByRole("button", { name: "Text block" })).toBeNull();
   });
 
-  it("requests chat input focus on 'Describe your own'", () => {
+  it("requests chat input focus on 'Describe your own via the chat'", () => {
     renderModules(true);
 
-    fireEvent.click(screen.getByRole("button", { name: "Describe your own" }));
+    fireEvent.click(
+      screen.getByRole("button", { name: "Describe your own via the chat" })
+    );
 
     expect(useSidebarStore.getState().chatInputFocusToken).toBe(1);
   });

--- a/src/features/dashboards/ui/dashboardQueries.ts
+++ b/src/features/dashboards/ui/dashboardQueries.ts
@@ -8,6 +8,7 @@ import {
 import { searchAois } from "../api/aois";
 import {
   addInsightWidget,
+  addTextWidget,
   createDashboard,
   createDashboardPayloadFromAoi,
   deleteDashboard,
@@ -195,6 +196,22 @@ export function useAddInsightWidget(dashboardId: string) {
     // the refetch reflects the new widget — so without this the button/switch
     // re-enables the instant the POST resolves, and a fast second click would
     // re-POST the same insight and create a duplicate widget.
+    onSettled: () =>
+      queryClient.invalidateQueries({
+        queryKey: dashboardKeys.detail(dashboardId),
+      }),
+  });
+}
+
+// "Text block" suggested module — adds a blank note widget directly, no chat
+// round-trip. Not optimistic for the same reason as useAddInsightWidget: the
+// server assigns the widget id/position, so the button stays disabled-safe
+// only once the refetch actually reflects the new card.
+export function useAddTextWidget(dashboardId: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: () => addTextWidget(dashboardId),
     onSettled: () =>
       queryClient.invalidateQueries({
         queryKey: dashboardKeys.detail(dashboardId),


### PR DESCRIPTION
## Summary

- Adds the Figma "Suggested modules" section below the widget grid on every dashboard (always visible, not just the empty state).
- Five lime analysis cards — tree cover loss, deforestation alerts, land cover distribution, grassland extent, region comparison — each inject a canned prompt into the existing chat pipeline asking the agent to add the analysis, a text block, and a map to the dashboard. Same MVP approach already used by `runAnalysis`/`DashboardChatNudges` (generative now; a curated/deterministic swap is deliberately deferred).
- A sixth card, "Recent satellite imagery," just adds imagery with no analysis framing.
- "Text block" creates a blank note widget directly (no chat round-trip); gated to the dashboard owner.
- "Describe your own" focuses the chat textarea, whose placeholder already reads "Or describe what you want to explore…" once the thread is empty.

<img width="952" height="785" alt="Screenshot 2026-08-13 at 12 45 25 PM" src="https://github.com/user-attachments/assets/e331491f-6545-4ca6-8b4f-66bcf696db77" />

## Supporting plumbing

- `addTextWidget` (`api/dashboards.ts`) + `useAddTextWidget` (`dashboardQueries.ts`) create a blank `widget_type: "text"` widget via the existing `POST /widgets` endpoint, mirroring `addInsightWidget`.
- Traced a bug against the `project-zeno` backend source: `validate_text_config` in `src/api/schemas.py` requires `config.text` to be a string for any text-widget create. The request now sends `config: { text: "" }` — an empty string satisfies that check and still renders as an empty note client-side (`widgetText()` treats a blank string as "no text").
- `sidebarStore.chatInputFocusToken` + a `ChatInput` effect let UI outside the component request focus on the chat textarea — nothing could do this before.

## Test plan

- [x] `pnpm format:check && pnpm lint && pnpm typecheck && pnpm build` all pass
- [x] `pnpm test` passes (865/865), including new tests for `useAddTextWidget`, the `addTextWidget` request body, the canned-prompt data, the `sidebarStore` focus token, and click-through behavior of every card
- [x] Verified live in an isolated worktree + mock backend: all 8 cards render, "Text block" adds a real widget, "Describe your own" focuses the textarea, an analysis card sends its prompt and gets a reply
- [ ] Manual smoke test against the real staging backend (the text-block fix above was found via backend source, not live-tested against staging — worth a quick click-through before merge)