### PR TITLE
feat(dashboards): give a freshly created dashboard its own empty state

### DIFF
--- a/src/features/dashboards/__tests__/dashboards.test.ts
+++ b/src/features/dashboards/__tests__/dashboards.test.ts
@@ -16,7 +16,11 @@ import {
   sourceLabel,
   subtypeLabel,
 } from "../lib/aoi";
-import { updatedLabel, wasJustCreated } from "../lib/dates";
+import {
+  justCreatedMsRemaining,
+  updatedLabel,
+  wasJustCreated,
+} from "../lib/dates";
 
 describe("dashboard schemas", () => {
   it("parses AOI search results returned by the staging API", () => {
@@ -131,6 +135,23 @@ describe("dashboard date helpers", () => {
     const now = new Date("2026-08-13T12:00:00Z").getTime();
     expect(wasJustCreated("not-a-date", now)).toBe(false);
     expect(wasJustCreated("2026-08-13T12:01:00Z", now)).toBe(false);
+  });
+
+  it("reports how much of the just-created window remains", () => {
+    const now = new Date("2026-08-13T12:00:00Z").getTime();
+    expect(justCreatedMsRemaining("2026-08-13T11:59:00Z", now)).toBe(
+      9 * 60 * 1000
+    );
+    expect(justCreatedMsRemaining("2026-08-13T12:00:00Z", now)).toBe(
+      10 * 60 * 1000
+    );
+  });
+
+  it("reports zero remaining for expired, invalid, or future timestamps", () => {
+    const now = new Date("2026-08-13T12:00:00Z").getTime();
+    expect(justCreatedMsRemaining("2026-08-13T11:50:00Z", now)).toBe(0);
+    expect(justCreatedMsRemaining("not-a-date", now)).toBe(0);
+    expect(justCreatedMsRemaining("2026-08-13T12:01:00Z", now)).toBe(0);
   });
 });
 

--- a/src/features/dashboards/__tests__/dashboards.test.ts
+++ b/src/features/dashboards/__tests__/dashboards.test.ts
@@ -16,7 +16,7 @@ import {
   sourceLabel,
   subtypeLabel,
 } from "../lib/aoi";
-import { updatedLabel } from "../lib/dates";
+import { updatedLabel, wasJustCreated } from "../lib/dates";
 
 describe("dashboard schemas", () => {
   it("parses AOI search results returned by the staging API", () => {
@@ -114,6 +114,23 @@ describe("dashboard date helpers", () => {
   it("uses a neutral updated label for invalid or future timestamps", () => {
     expect(updatedLabel("not-a-date")).toBe("Updated recently");
     expect(updatedLabel("2999-01-01T00:00:00Z")).toBe("Updated recently");
+  });
+
+  it("treats a dashboard as just created within the 10-minute window", () => {
+    const now = new Date("2026-08-13T12:00:00Z").getTime();
+    expect(wasJustCreated("2026-08-13T11:59:00Z", now)).toBe(true);
+    expect(wasJustCreated("2026-08-13T12:00:00Z", now)).toBe(true);
+  });
+
+  it("stops treating a dashboard as just created once the window elapses", () => {
+    const now = new Date("2026-08-13T12:00:00Z").getTime();
+    expect(wasJustCreated("2026-08-13T11:49:00Z", now)).toBe(false);
+  });
+
+  it("rejects invalid or future creation timestamps", () => {
+    const now = new Date("2026-08-13T12:00:00Z").getTime();
+    expect(wasJustCreated("not-a-date", now)).toBe(false);
+    expect(wasJustCreated("2026-08-13T12:01:00Z", now)).toBe(false);
   });
 });
 

--- a/src/features/dashboards/lib/dates.ts
+++ b/src/features/dashboards/lib/dates.ts
@@ -12,13 +12,26 @@ export function updatedLabel(isoDate: string): string {
 const JUST_CREATED_WINDOW_MS = 10 * 60 * 1000;
 
 /**
+ * How much of the just-created window is left, in ms — 0 for invalid, future,
+ * or already-expired timestamps. Callers showing the pill schedule its removal
+ * this far in the future. `now` is injectable for tests; real callers omit it.
+ */
+export function justCreatedMsRemaining(
+  isoDate: string,
+  now = Date.now()
+): number {
+  const date = new Date(isoDate);
+  if (Number.isNaN(date.getTime())) return 0;
+  const age = now - date.getTime();
+  if (age < 0 || age >= JUST_CREATED_WINDOW_MS) return 0;
+  return JUST_CREATED_WINDOW_MS - age;
+}
+
+/**
  * Whether a dashboard was created recently enough to show the "Created just
  * now" pill (Figma "Dashboard Empty state" frame) instead of the usual
- * updated-label text. `now` is injectable for tests; real callers omit it.
+ * updated-label text.
  */
 export function wasJustCreated(isoDate: string, now = Date.now()): boolean {
-  const date = new Date(isoDate);
-  if (Number.isNaN(date.getTime())) return false;
-  const age = now - date.getTime();
-  return age >= 0 && age < JUST_CREATED_WINDOW_MS;
+  return justCreatedMsRemaining(isoDate, now) > 0;
 }

--- a/src/features/dashboards/lib/dates.ts
+++ b/src/features/dashboards/lib/dates.ts
@@ -7,3 +7,18 @@ export function updatedLabel(isoDate: string): string {
   }
   return `Updated ${formatDistanceToNowStrict(date, { addSuffix: true })}`;
 }
+
+/** How long the header shows the "Created just now" pill instead of "Updated …". */
+const JUST_CREATED_WINDOW_MS = 10 * 60 * 1000;
+
+/**
+ * Whether a dashboard was created recently enough to show the "Created just
+ * now" pill (Figma "Dashboard Empty state" frame) instead of the usual
+ * updated-label text. `now` is injectable for tests; real callers omit it.
+ */
+export function wasJustCreated(isoDate: string, now = Date.now()): boolean {
+  const date = new Date(isoDate);
+  if (Number.isNaN(date.getTime())) return false;
+  const age = now - date.getTime();
+  return age >= 0 && age < JUST_CREATED_WINDOW_MS;
+}

--- a/src/features/dashboards/lib/suggested-modules.ts
+++ b/src/features/dashboards/lib/suggested-modules.ts
@@ -27,6 +27,12 @@ export interface SuggestedPromptModule {
   icon: Icon;
   prompt: string;
   kind: "analysis" | "action";
+  /**
+   * Card only makes sense once the dashboard has widgets (e.g. summarising
+   * existing content) — surfaces rendering the row for an empty dashboard
+   * filter these out.
+   */
+  requiresContent?: boolean;
 }
 
 export const SUGGESTED_PROMPT_MODULES: SuggestedPromptModule[] = [
@@ -84,5 +90,6 @@ export const SUGGESTED_PROMPT_MODULES: SuggestedPromptModule[] = [
     prompt:
       "Summarize what this dashboard currently shows and add the summary to the dashboard as a text block.",
     kind: "action",
+    requiresContent: true,
   },
 ];

--- a/src/features/dashboards/ui/DashboardDetailPage.tsx
+++ b/src/features/dashboards/ui/DashboardDetailPage.tsx
@@ -13,6 +13,7 @@ import useViewContextStore from "@/app/store/viewContextStore";
 import usePinnedHeader from "../hooks/usePinnedHeader";
 import { useDashboard } from "./dashboardQueries";
 import DashboardBreadcrumb from "./DashboardBreadcrumb";
+import DashboardEmptyStateHero from "./DashboardEmptyStateHero";
 import DashboardHeader from "./DashboardHeader";
 import DashboardPinnedHeader from "./DashboardPinnedHeader";
 import DashboardSuggestedModules from "./DashboardSuggestedModules";
@@ -134,13 +135,20 @@ export default function DashboardDetailPage() {
                 <DashboardHeader dashboard={dashboard} isOwner={isOwner} />
               </Box>
 
-              {dashboard.widgets.length > 0 && (
-                <DashboardWidgetsGrid dashboard={dashboard} />
+              {dashboard.widgets.length > 0 ? (
+                <>
+                  <DashboardWidgetsGrid dashboard={dashboard} />
+                  <DashboardSuggestedModules
+                    dashboardId={dashboard.id}
+                    isOwner={isOwner}
+                  />
+                </>
+              ) : (
+                <DashboardEmptyStateHero
+                  dashboard={dashboard}
+                  isOwner={isOwner}
+                />
               )}
-              <DashboardSuggestedModules
-                dashboardId={dashboard.id}
-                isOwner={isOwner}
-              />
             </Box>
           )}
         </Flex>

--- a/src/features/dashboards/ui/DashboardDetailPage.tsx
+++ b/src/features/dashboards/ui/DashboardDetailPage.tsx
@@ -141,6 +141,7 @@ export default function DashboardDetailPage() {
                   <DashboardSuggestedModules
                     dashboardId={dashboard.id}
                     isOwner={isOwner}
+                    hasWidgets
                   />
                 </>
               ) : (

--- a/src/features/dashboards/ui/DashboardEmptyStateHero.tsx
+++ b/src/features/dashboards/ui/DashboardEmptyStateHero.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { Box, Flex, Heading, Text } from "@chakra-ui/react";
+import { PlusIcon } from "@phosphor-icons/react";
+
+import type { Dashboard } from "../api/schemas";
+import DashboardSuggestedModules from "./DashboardSuggestedModules";
+
+/**
+ * The dashboard's zero-widget state (Figma "Dashboard Empty state_No active
+ * dataset", node 1472:4106) — a dashed hero panel inviting the owner to fill
+ * the dashboard in, wrapping the same `DashboardSuggestedModules` row shown
+ * once the dashboard has content. `DashboardDetailPage` swaps between this
+ * and the widget grid on widget count, never both at once.
+ */
+export default function DashboardEmptyStateHero({
+  dashboard,
+  isOwner,
+}: {
+  dashboard: Dashboard;
+  isOwner: boolean;
+}) {
+  return (
+    <Flex
+      direction="column"
+      align="center"
+      gap="32px"
+      bg="#F7F9FF"
+      borderWidth="1.5px"
+      borderStyle="dashed"
+      borderColor="#C2CCF2"
+      borderRadius="sm"
+      p="56px"
+    >
+      <Flex direction="column" align="center" gap="16px" textAlign="center">
+        <Box color="#0049AA">
+          <PlusIcon size={24} />
+        </Box>
+        <Flex direction="column" align="center" gap="8px">
+          <Heading
+            as="h2"
+            fontSize="18px"
+            lineHeight="28px"
+            fontWeight="semibold"
+            color="#0049AA"
+            mb={0}
+          >
+            Your dashboard is ready
+          </Heading>
+          <Text fontSize="14px" lineHeight="20px" color="#565E7B">
+            {`Let's fill it in with charts, maps, and insights you care about for ${dashboard.name}.`}
+          </Text>
+        </Flex>
+      </Flex>
+      <Box w="full">
+        <DashboardSuggestedModules
+          dashboardId={dashboard.id}
+          isOwner={isOwner}
+          mt={0}
+        />
+      </Box>
+    </Flex>
+  );
+}

--- a/src/features/dashboards/ui/DashboardEmptyStateHero.tsx
+++ b/src/features/dashboards/ui/DashboardEmptyStateHero.tsx
@@ -56,6 +56,7 @@ export default function DashboardEmptyStateHero({
         <DashboardSuggestedModules
           dashboardId={dashboard.id}
           isOwner={isOwner}
+          hasWidgets={false}
           mt={0}
         />
       </Box>

--- a/src/features/dashboards/ui/DashboardHeader.tsx
+++ b/src/features/dashboards/ui/DashboardHeader.tsx
@@ -18,7 +18,7 @@ import {
 
 import { toaster } from "@/app/components/ui/toaster";
 import type { Dashboard } from "../api/schemas";
-import { updatedLabel } from "../lib/dates";
+import { updatedLabel, wasJustCreated } from "../lib/dates";
 import { useRenameDashboard } from "./dashboardQueries";
 
 /**
@@ -128,16 +128,35 @@ export default function DashboardHeader({
             </IconButton>
           )}
         </Flex>
-        <Text
-          // 8px title-to-timestamp gap per the Figma header frames.
-          mt="8px"
-          fontFamily="mono"
-          fontSize="10px"
-          lineHeight="16px"
-          color="rgba(19,22,25,0.7)"
-        >
-          {updatedLabel(dashboard.updated_at)}
-        </Text>
+        {wasJustCreated(dashboard.created_at) ? (
+          <Box
+            mt="8px"
+            display="inline-flex"
+            bg="#F0F4B4"
+            px="4px"
+            rounded="sm"
+          >
+            <Text
+              fontFamily="mono"
+              fontSize="10px"
+              lineHeight="16px"
+              color="#5B5F3A"
+            >
+              Created just now
+            </Text>
+          </Box>
+        ) : (
+          <Text
+            // 8px title-to-timestamp gap per the Figma header frames.
+            mt="8px"
+            fontFamily="mono"
+            fontSize="10px"
+            lineHeight="16px"
+            color="rgba(19,22,25,0.7)"
+          >
+            {updatedLabel(dashboard.updated_at)}
+          </Text>
+        )}
       </Box>
 
       <Flex gap="12px" align="center" flexShrink={0}>

--- a/src/features/dashboards/ui/DashboardHeader.tsx
+++ b/src/features/dashboards/ui/DashboardHeader.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import {
   Box,
   Button,
@@ -18,8 +18,32 @@ import {
 
 import { toaster } from "@/app/components/ui/toaster";
 import type { Dashboard } from "../api/schemas";
-import { updatedLabel, wasJustCreated } from "../lib/dates";
+import {
+  justCreatedMsRemaining,
+  updatedLabel,
+  wasJustCreated,
+} from "../lib/dates";
 import { useRenameDashboard } from "./dashboardQueries";
+
+/**
+ * Tracks the "Created just now" window as live state: nothing else re-renders
+ * the header when the 10 minutes elapse, so the pill schedules its own
+ * demotion to the "Updated …" label instead of lingering until an unrelated
+ * re-render.
+ */
+function useWasJustCreated(isoDate: string): boolean {
+  const [justCreated, setJustCreated] = useState(() => wasJustCreated(isoDate));
+
+  useEffect(() => {
+    const remainingMs = justCreatedMsRemaining(isoDate);
+    setJustCreated(remainingMs > 0);
+    if (remainingMs === 0) return;
+    const timer = setTimeout(() => setJustCreated(false), remainingMs);
+    return () => clearTimeout(timer);
+  }, [isoDate]);
+
+  return justCreated;
+}
 
 /**
  * Dashboard page header per the Figma "Dashboard default" frame: editable
@@ -40,6 +64,7 @@ export default function DashboardHeader({
   const [draft, setDraft] = useState<string | null>(null);
   const renameDashboard = useRenameDashboard(dashboard.id);
   const editing = draft !== null;
+  const justCreated = useWasJustCreated(dashboard.created_at);
 
   const commit = () => {
     const name = draft?.trim();
@@ -128,7 +153,7 @@ export default function DashboardHeader({
             </IconButton>
           )}
         </Flex>
-        {wasJustCreated(dashboard.created_at) ? (
+        {justCreated ? (
           <Box
             mt="8px"
             display="inline-flex"

--- a/src/features/dashboards/ui/DashboardSuggestedModules.tsx
+++ b/src/features/dashboards/ui/DashboardSuggestedModules.tsx
@@ -81,16 +81,20 @@ function ModuleCard({
 export default function DashboardSuggestedModules({
   dashboardId,
   isOwner,
+  // Space above the divider. Callers that already provide their own gap
+  // above this row (e.g. DashboardEmptyStateHero's hero copy) pass 0.
+  mt = 8,
 }: {
   dashboardId: string;
   isOwner: boolean;
+  mt?: number;
 }) {
   const sendMessage = useChatStore((s) => s.sendMessage);
   const requestChatInputFocus = useSidebarStore((s) => s.requestChatInputFocus);
   const addTextWidget = useAddTextWidget(dashboardId);
 
   return (
-    <Flex direction="column" gap={5} mt={8}>
+    <Flex direction="column" gap={5} mt={mt}>
       <Flex align="center" gap={3}>
         <Box flex={1} h="1px" bg="#E0E2E5" />
         <Text fontSize="xs" fontStyle="italic" color="#656E7B" flexShrink={0}>

--- a/src/features/dashboards/ui/DashboardSuggestedModules.tsx
+++ b/src/features/dashboards/ui/DashboardSuggestedModules.tsx
@@ -86,12 +86,15 @@ function ModuleCard({
 export default function DashboardSuggestedModules({
   dashboardId,
   isOwner,
+  hasWidgets,
   // Space above the divider. Callers that already provide their own gap
   // above this row (e.g. DashboardEmptyStateHero's hero copy) pass 0.
   mt = 8,
 }: {
   dashboardId: string;
   isOwner: boolean;
+  /** Cards marked `requiresContent` are dropped on an empty dashboard. */
+  hasWidgets: boolean;
   mt?: number;
 }) {
   const sendMessage = useChatStore((s) => s.sendMessage);
@@ -109,6 +112,10 @@ export default function DashboardSuggestedModules({
   // too — under either condition the textarea it focuses is itself disabled.
   const chatDisabled = isStreaming || promptsExhausted;
 
+  const promptModules = SUGGESTED_PROMPT_MODULES.filter(
+    (card) => hasWidgets || !card.requiresContent
+  );
+
   if (!isOwner) return null;
 
   return (
@@ -119,7 +126,7 @@ export default function DashboardSuggestedModules({
     <Flex
       direction="column"
       gap={5}
-      mt={8}
+      mt={mt}
       display={{ base: "none", md: "flex" }}
     >
       <Flex align="center" gap={3}>
@@ -130,7 +137,7 @@ export default function DashboardSuggestedModules({
         <Box flex={1} h="1px" bg="#E0E2E5" />
       </Flex>
       <Flex wrap="wrap" gap="20px">
-        {SUGGESTED_PROMPT_MODULES.map((card) => (
+        {promptModules.map((card) => (
           <ModuleCard
             key={card.id}
             icon={card.icon}

--- a/src/features/dashboards/ui/__tests__/DashboardEmptyStateHero.test.tsx
+++ b/src/features/dashboards/ui/__tests__/DashboardEmptyStateHero.test.tsx
@@ -59,6 +59,14 @@ describe("DashboardEmptyStateHero", () => {
     expect(screen.getByRole("button", { name: "Text block" })).toBeTruthy();
   });
 
+  it("omits the summarise card — an empty dashboard has nothing to summarize", () => {
+    renderHero(true);
+
+    expect(
+      screen.queryByRole("button", { name: "Summarise the dashboard" })
+    ).toBeNull();
+  });
+
   it("hides the owner-only 'Text block' card for a viewer", () => {
     renderHero(false);
 

--- a/src/features/dashboards/ui/__tests__/DashboardEmptyStateHero.test.tsx
+++ b/src/features/dashboards/ui/__tests__/DashboardEmptyStateHero.test.tsx
@@ -1,0 +1,67 @@
+// @vitest-environment happy-dom
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+// The chatStore import chain reaches the Chakra toaster (.tsx) — stub it so the
+// test environment can parse the module boundary.
+vi.mock("@/app/components/ui/toaster", () => ({
+  toaster: { create: vi.fn() },
+  Toaster: () => null,
+}));
+
+import DashboardEmptyStateHero from "../DashboardEmptyStateHero";
+import type { Dashboard } from "../../api/schemas";
+
+const dashboard: Dashboard = {
+  id: "d1",
+  user_id: "u1",
+  name: "Paraná, Brazil",
+  description: null,
+  is_public: false,
+  created_at: "2026-08-01T00:00:00Z",
+  updated_at: "2026-08-01T00:00:00Z",
+  aois: [],
+  widgets: [],
+};
+
+const renderHero = (isOwner: boolean) => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <ChakraProvider value={defaultSystem}>
+        <DashboardEmptyStateHero dashboard={dashboard} isOwner={isOwner} />
+      </ChakraProvider>
+    </QueryClientProvider>
+  );
+};
+
+describe("DashboardEmptyStateHero", () => {
+  it("greets the owner and names the dashboard's area", () => {
+    renderHero(true);
+
+    expect(screen.getByText("Your dashboard is ready")).toBeTruthy();
+    expect(
+      screen.getByText((text) => text.includes("Paraná, Brazil"))
+    ).toBeTruthy();
+  });
+
+  it("reuses the same suggested-modules row shown on a populated dashboard", () => {
+    renderHero(true);
+
+    expect(screen.getByText("Suggested modules")).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: "Tree cover loss analysis" })
+    ).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Text block" })).toBeTruthy();
+  });
+
+  it("hides the owner-only 'Text block' card for a viewer", () => {
+    renderHero(false);
+
+    expect(screen.queryByRole("button", { name: "Text block" })).toBeNull();
+  });
+});

--- a/src/features/dashboards/ui/__tests__/DashboardHeader.test.tsx
+++ b/src/features/dashboards/ui/__tests__/DashboardHeader.test.tsx
@@ -1,8 +1,8 @@
 // @vitest-environment happy-dom
 import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { act, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@/app/components/ui/toaster", () => ({
   toaster: { create: vi.fn() },
@@ -38,6 +38,10 @@ const renderHeader = (dashboard: Dashboard) => {
 };
 
 describe("DashboardHeader", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   it("shows the 'Created just now' pill for a freshly created dashboard", () => {
     renderHeader({ ...baseDashboard, created_at: new Date().toISOString() });
 
@@ -50,5 +54,23 @@ describe("DashboardHeader", () => {
 
     expect(screen.getByText(/^Updated/)).toBeTruthy();
     expect(screen.queryByText("Created just now")).toBeNull();
+  });
+
+  it("demotes the pill to the updated label when the window elapses while the page stays open", () => {
+    vi.useFakeTimers();
+    // 1 minute of the 10-minute window left at render time.
+    renderHeader({
+      ...baseDashboard,
+      created_at: new Date(Date.now() - 9 * 60 * 1000).toISOString(),
+    });
+
+    expect(screen.getByText("Created just now")).toBeTruthy();
+
+    act(() => {
+      vi.advanceTimersByTime(61 * 1000);
+    });
+
+    expect(screen.queryByText("Created just now")).toBeNull();
+    expect(screen.getByText(/^Updated/)).toBeTruthy();
   });
 });

--- a/src/features/dashboards/ui/__tests__/DashboardHeader.test.tsx
+++ b/src/features/dashboards/ui/__tests__/DashboardHeader.test.tsx
@@ -1,0 +1,54 @@
+// @vitest-environment happy-dom
+import { ChakraProvider, defaultSystem } from "@chakra-ui/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+vi.mock("@/app/components/ui/toaster", () => ({
+  toaster: { create: vi.fn() },
+  Toaster: () => null,
+}));
+
+import DashboardHeader from "../DashboardHeader";
+import type { Dashboard } from "../../api/schemas";
+
+const baseDashboard: Dashboard = {
+  id: "d1",
+  user_id: "u1",
+  name: "Paraná, Brazil",
+  description: null,
+  is_public: false,
+  created_at: "2020-01-01T00:00:00Z",
+  updated_at: "2020-01-01T00:00:00Z",
+  aois: [],
+  widgets: [],
+};
+
+const renderHeader = (dashboard: Dashboard) => {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <ChakraProvider value={defaultSystem}>
+        <DashboardHeader dashboard={dashboard} isOwner />
+      </ChakraProvider>
+    </QueryClientProvider>
+  );
+};
+
+describe("DashboardHeader", () => {
+  it("shows the 'Created just now' pill for a freshly created dashboard", () => {
+    renderHeader({ ...baseDashboard, created_at: new Date().toISOString() });
+
+    expect(screen.getByText("Created just now")).toBeTruthy();
+    expect(screen.queryByText(/^Updated/)).toBeNull();
+  });
+
+  it("falls back to the usual updated label once the dashboard has aged past the window", () => {
+    renderHeader(baseDashboard);
+
+    expect(screen.getByText(/^Updated/)).toBeTruthy();
+    expect(screen.queryByText("Created just now")).toBeNull();
+  });
+});

--- a/src/features/dashboards/ui/__tests__/DashboardSuggestedModules.test.tsx
+++ b/src/features/dashboards/ui/__tests__/DashboardSuggestedModules.test.tsx
@@ -26,14 +26,18 @@ import useSidebarStore from "@/app/store/sidebarStore";
 
 const sendSpy = vi.fn().mockResolvedValue({ isNew: false, id: "t1" });
 
-const renderModules = (isOwner: boolean) => {
+const renderModules = (isOwner: boolean, hasWidgets = true) => {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });
   return render(
     <QueryClientProvider client={queryClient}>
       <ChakraProvider value={defaultSystem}>
-        <DashboardSuggestedModules dashboardId="d1" isOwner={isOwner} />
+        <DashboardSuggestedModules
+          dashboardId="d1"
+          isOwner={isOwner}
+          hasWidgets={hasWidgets}
+        />
       </ChakraProvider>
     </QueryClientProvider>
   );
@@ -85,6 +89,21 @@ describe("DashboardSuggestedModules", () => {
         })
       )
     );
+  });
+
+  it("drops content-dependent cards on a dashboard with no widgets", () => {
+    renderModules(true, false);
+
+    expect(
+      screen.queryByRole("button", { name: "Summarise the dashboard" })
+    ).toBeNull();
+    // Cards that don't depend on existing content stay.
+    expect(
+      screen.getByRole("button", { name: "Recent satellite imagery" })
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("button", { name: "Tree cover loss analysis" })
+    ).toBeTruthy();
   });
 
   it("renders nothing for a viewer who doesn't own the dashboard", () => {


### PR DESCRIPTION
## Summary

Stacked on #636 — implements the Figma "Dashboard Empty state_No active dataset" frame ([node 1472:4106](https://www.figma.com/design/a4jBBuwr0FQfKTY3l8aOKM/-Global-Nature-Watch--Phase-3?node-id=1472-4106)):

<img width="953" height="681" alt="Screenshot 2026-08-13 at 12 44 49 PM" src="https://github.com/user-attachments/assets/fe19106f-25e0-4b6c-9afc-ae6ff15bad48" />


- A dashed hero panel ("+" icon, "Your dashboard is ready", area-scoped subtext) replaces the plain empty-grid space on a zero-widget dashboard — `DashboardEmptyStateHero`.
- It wraps the **same** `DashboardSuggestedModules` row from #636 unmodified, rather than rebuilding the smaller/generic card set shown in that specific Figma frame (the ask was to reuse the modules, not fork them — worth flagging since the row now shows 9 cards there instead of the mock's 4).
- `DashboardDetailPage` now branches on widget count: populated dashboards keep the grid + bare suggested-modules row (unchanged from #636); empty ones get the hero.
- `DashboardSuggestedModules` grows an optional `mt` prop (default matches existing behavior) so the hero can supply its own spacing above the row instead of double-gapping.
- Adds the "Created just now" pill next to the title, replacing the usual "Updated …" text for the first 10 minutes after creation (`wasJustCreated` in `lib/dates.ts`) — lives in the one shared `DashboardHeader`, so the in-page and pinned-header copies stay in sync automatically.

Also on this branch (from #636's follow-up): the suggested-module cards now flex-grow to fill each row (capped at 280px) instead of leaving a dead gap on the right, and a new "Summarise the dashboard" card that asks the agent to summarize existing content into a text block rather than run a fresh analysis.

## Test plan

- [x] `pnpm format:check && pnpm lint && pnpm typecheck && pnpm build` all pass
- [x] `pnpm test` passes (874/874), including new tests for `wasJustCreated`, the "Created just now" pill, and `DashboardEmptyStateHero`
- [x] Verified live in an isolated worktree + mock backend: hero panel, pill, and the full reused card row (including "Summarise the dashboard") all render correctly for a freshly created dashboard
- [ ] Manual smoke test against staging before merge