### PR TITLE
[PZB-1247] Implement LGMS Annual Net Flux Time Series Chart

### DIFF
--- a/app/chart-debug/ChartDebugPanel.tsx
+++ b/app/chart-debug/ChartDebugPanel.tsx
@@ -21,6 +21,7 @@ import CHART_COLOR_MAPPING, {
   DATASET_DIVERGENT_COLORS,
 } from "@/app/config/chartColorMappings";
 import getChartColors from "@/app/utils/ChartColors";
+import { NET_FLUX_DUMMY_WIDGET } from "@/src/features/net-flux";
 
 // ---------------------------------------------------------------------------
 // Fake provenance data for "View how this was generated" drawer
@@ -616,6 +617,12 @@ const RAW_FIXTURES: { label: string; notes: string; widget: InsightWidget }[] =
       },
     },
     {
+      label: "Stacked bar with line overlay (net flux)",
+      notes:
+        "The curated 'Net flux over time' insight: stacked emissions/removals with a net-flux line overlay, plus the DETAIL/MEASURE toggle chrome.",
+      widget: NET_FLUX_DUMMY_WIDGET,
+    },
+    {
       label: "Wide table (scroll indicator)",
       notes: "Table with 8+ columns to test horizontal scroll fade indicators.",
       widget: {
@@ -822,7 +829,12 @@ export default function ChartDebugPanel() {
   const filtered = FIXTURES.filter((f) => {
     if (filter === "all") return true;
     if (filter === "bar")
-      return ["bar", "stacked-bar", "grouped-bar"].includes(f.widget.type);
+      return [
+        "bar",
+        "stacked-bar",
+        "grouped-bar",
+        "stacked-bar-with-line",
+      ].includes(f.widget.type);
     if (filter === "line") return ["line", "area"].includes(f.widget.type);
     if (filter === "pie") return f.widget.type === "pie";
     if (filter === "scatter") return f.widget.type === "scatter";

--- a/app/components/CatalogPanel.tsx
+++ b/app/components/CatalogPanel.tsx
@@ -42,6 +42,8 @@ import useSidebarStore from "@/app/store/sidebarStore";
 import type { DatasetInfo } from "@/app/types/chat";
 import { datasetCardLayers } from "@/app/utils/datasetCardLayerContext";
 import { filterDatasetsByCategory } from "@/app/utils/filterDatasetsByCategory";
+import { useFeatureFlag } from "@/src/shared/lib/feature-flags";
+import { LGMS_DATASET_ID } from "@/src/features/net-flux";
 
 import { CatalogCard } from "./CatalogCard";
 import { DatasetInfoModal } from "./DatasetInfoModal";
@@ -83,6 +85,7 @@ export default function DataCatalogPanel() {
   const { dataCatalogOpen, setDataCatalogOpen, isChatFullSize } =
     useSidebarStore();
   const leftPx = getCatalogLeftPx(isChatFullSize);
+  const netFluxEnabled = useFeatureFlag("net-flux");
 
   // Build the "in this conversation" set from the visible dataset layers — the
   // layer manager is the source of truth. `useShallow` keeps re-renders stable
@@ -95,10 +98,12 @@ export default function DataCatalogPanel() {
     )
   );
 
-  const cards = useMemo(
-    () => filterDatasetsByCategory(DATASET_CARDS, category, activeDatasetIds),
-    [category, activeDatasetIds]
-  );
+  const cards = useMemo(() => {
+    const visibleCards = netFluxEnabled
+      ? DATASET_CARDS
+      : DATASET_CARDS.filter((card) => card.dataset_id !== LGMS_DATASET_ID);
+    return filterDatasetsByCategory(visibleCards, category, activeDatasetIds);
+  }, [category, activeDatasetIds, netFluxEnabled]);
 
   const compactSlide = !isChatFullSize;
 

--- a/app/components/InsightWorkspace.tsx
+++ b/app/components/InsightWorkspace.tsx
@@ -26,6 +26,12 @@ import AnalysisParametersToggle, {
   AnalysisParamsChips,
 } from "./widgets/AnalysisParameters";
 import { buildChips } from "./widgets/analysis-params-utils";
+import {
+  NetFluxFootnote,
+  NetFluxToolbar,
+  isNetFluxWidget,
+  netFluxViewKey,
+} from "@/src/features/net-flux";
 
 /**
  * Placeholder shown while the very first analysis is generating (no chart in
@@ -287,10 +293,25 @@ export default function InsightWorkspace() {
               </Box>
             )}
 
+            {/* Per-widget-type controls, rendered on the shell above the card
+                (the design calls this the "widget toolbar"). */}
+            {isNetFluxWidget(widget) && (
+              <Box px={2} pb={2}>
+                <NetFluxToolbar widgetId={netFluxViewKey(widget)} />
+              </Box>
+            )}
+
             {/* Inner chart card */}
             <Box px={2} pt={0} pb={2}>
               <WidgetMessage widget={widget} inWorkspace />
             </Box>
+
+            {/* Per-widget-type caveat card below the chart card */}
+            {isNetFluxWidget(widget) && (
+              <Box px={2} pb={2}>
+                <NetFluxFootnote />
+              </Box>
+            )}
           </Box>
 
           {/* Navigation footer — sticky so it never scrolls away */}

--- a/app/components/WidgetMessage.tsx
+++ b/app/components/WidgetMessage.tsx
@@ -46,6 +46,14 @@ import ScrollableTableWrapper from "./widgets/ScrollableTableWrapper";
 import { AnalysisParamsChips } from "./widgets/AnalysisParameters";
 import { buildChips } from "./widgets/analysis-params-utils";
 import { exportChartImage } from "@/app/utils/exportChartImage";
+import {
+  NetFluxChartBody,
+  NetFluxToolbar,
+  deriveNetFluxVariant,
+  isNetFluxWidget,
+  netFluxViewKey,
+  useNetFluxView,
+} from "@/src/features/net-flux";
 
 interface WidgetMessageProps {
   widget: InsightWidget;
@@ -90,9 +98,25 @@ export default function WidgetMessage({
     onOpen: onExpand,
     onClose: onCollapse,
   } = useDisclosure();
+  // Shared with the workspace toolbar, which renders the DETAIL/MEASURE pills
+  // outside this card (see NetFluxToolbar). Hooks must run unconditionally, so
+  // this sits above the dataset-card early return.
+  const netFluxView = useNetFluxView(netFluxViewKey(widget));
   if (widget.type === "dataset-card") {
     return <DatasetCardWidget dataset={widget.data as DatasetInfo} />;
   }
+
+  // The curated net-flux insight always stores the full-detail/gross data;
+  // the DETAIL/MEASURE toggle re-derives which slice of it is shown. Every
+  // downstream consumer (chart, table, CSV, fullscreen) reads `displayWidget`
+  // so they stay in sync with the toggle.
+  const isNetFlux = isNetFluxWidget(widget);
+  const netFluxVariant = isNetFlux
+    ? deriveNetFluxVariant(widget, netFluxView.detail, netFluxView.measure)
+    : null;
+  const displayWidget: InsightWidget = netFluxVariant
+    ? { ...widget, ...netFluxVariant }
+    : widget;
 
   const handleOpen = () => {
     onOpen();
@@ -118,7 +142,7 @@ export default function WidgetMessage({
   };
 
   const handleDownloadCsv = () => {
-    const data = widget.data;
+    const data = displayWidget.data;
     if (!Array.isArray(data) || data.length === 0) return;
     const rows = data as Record<string, unknown>[];
     const headers = Object.keys(rows[0]);
@@ -148,7 +172,7 @@ export default function WidgetMessage({
   };
 
   const handleExportToAI = (provider: AIProvider) => {
-    const method = exportToAI(widget, provider);
+    const method = exportToAI(displayWidget, provider);
     if (method === "clipboard") {
       toaster.create({
         title: "Prompt copied to clipboard",
@@ -167,9 +191,11 @@ export default function WidgetMessage({
     "area",
     "pie",
     "scatter",
+    "stacked-bar-with-line",
   ];
   const isChartType = chartTypes.includes(widget.type);
-  const hasData = Array.isArray(widget.data) && widget.data.length > 0;
+  const hasData =
+    Array.isArray(displayWidget.data) && displayWidget.data.length > 0;
   const showDisclaimer = (isChartType || widget.type === "table") && hasData;
   const supportsAxisFit = AXIS_FIT_TYPES.has(widget.type);
   const fullscreenChips = widget.analysisParams
@@ -203,6 +229,15 @@ export default function WidgetMessage({
         {/* AI-assisted caption — sits above the chart toolbar in the workspace */}
         {inWorkspace && (
           <InsightCaption curated={widget.curated ?? !widget.generation} />
+        )}
+        {/* In the workspace the design puts these pills above the card, so
+            InsightWorkspace renders them there; elsewhere (dashboards,
+            /chart-debug) they live inline so the toggle stays reachable. */}
+        {isNetFlux && !inWorkspace && (
+          <NetFluxToolbar
+            widgetId={netFluxViewKey(widget)}
+            showDivider={false}
+          />
         )}
         {/* Toolbar row — segmented toggle + full-screen */}
         <Flex justify="flex-start" gap={2} flexWrap="wrap" align="center">
@@ -281,20 +316,34 @@ export default function WidgetMessage({
         {isChartType && !showAsTable && (
           <WidgetErrorBoundary fallbackTitle="Unable to render chart">
             <Box ref={chartRef}>
-              <ChartWidget
-                widget={widget}
-                fitYAxis={fitYAxis}
-                fullWidth={fullWidth}
-              />
+              {netFluxVariant ? (
+                <NetFluxChartBody
+                  widget={displayWidget}
+                  variant={netFluxVariant}
+                  detail={netFluxView.detail}
+                  measure={netFluxView.measure}
+                  fitYAxis={fitYAxis}
+                  fullWidth={fullWidth}
+                />
+              ) : (
+                <ChartWidget
+                  widget={displayWidget}
+                  fitYAxis={fitYAxis}
+                  fullWidth={fullWidth}
+                />
+              )}
             </Box>
           </WidgetErrorBoundary>
         )}
-        {isChartType && showAsTable && Array.isArray(widget.data) && (
+        {isChartType && showAsTable && Array.isArray(displayWidget.data) && (
           <WidgetErrorBoundary fallbackTitle="Unable to render table">
             <ScrollableTableWrapper>
               <TableWidget
                 data={
-                  widget.data as Record<string, string | number | boolean>[]
+                  displayWidget.data as Record<
+                    string,
+                    string | number | boolean
+                  >[]
                 }
                 caption={widget.title}
               />
@@ -483,11 +532,22 @@ export default function WidgetMessage({
                 >
                   <Box flex="1" minW={0}>
                     <WidgetErrorBoundary fallbackTitle="Unable to render chart">
-                      <ChartWidget
-                        widget={widget}
-                        expanded
-                        fitYAxis={fitYAxis}
-                      />
+                      {netFluxVariant ? (
+                        <NetFluxChartBody
+                          widget={displayWidget}
+                          variant={netFluxVariant}
+                          detail={netFluxView.detail}
+                          measure={netFluxView.measure}
+                          expanded
+                          fitYAxis={fitYAxis}
+                        />
+                      ) : (
+                        <ChartWidget
+                          widget={displayWidget}
+                          expanded
+                          fitYAxis={fitYAxis}
+                        />
+                      )}
                     </WidgetErrorBoundary>
                   </Box>
                   {(widget.description ||

--- a/app/components/widgets/ChartWidget.tsx
+++ b/app/components/widgets/ChartWidget.tsx
@@ -13,6 +13,7 @@ import {
   Cell,
   ScatterChart,
   Scatter,
+  ComposedChart,
   CartesianGrid,
   Label,
   Legend,
@@ -39,7 +40,8 @@ type ChartType =
   | "line"
   | "area"
   | "pie"
-  | "scatter";
+  | "scatter"
+  | "stacked-bar-with-line";
 
 const TICK_FONT_PX = 11;
 const CHAR_PX = 6.5; // empirical sans-serif glyph width at 11px
@@ -61,7 +63,8 @@ type ChartWrapperComponent =
   | typeof AreaChart
   | typeof LineChart
   | typeof PieChart
-  | typeof ScatterChart;
+  | typeof ScatterChart
+  | typeof ComposedChart;
 
 const chartWrappers: Record<ChartType, ChartWrapperComponent> = {
   bar: BarChart,
@@ -71,6 +74,7 @@ const chartWrappers: Record<ChartType, ChartWrapperComponent> = {
   area: AreaChart,
   pie: PieChart,
   scatter: ScatterChart,
+  "stacked-bar-with-line": ComposedChart,
 };
 
 interface ChartWidgetProps {
@@ -89,6 +93,12 @@ interface ChartWidgetProps {
    * deliberate layout rather than a small chart with stranded legend.
    */
   fullWidth?: boolean;
+  /**
+   * Render the built-in legend. Set false when the host supplies its own
+   * (the net-flux card groups its series into Emissions/Removals columns,
+   * which the generic legend can't express).
+   */
+  showLegend?: boolean;
 }
 
 /** Chart types where a fit-to-data y-axis is honest and useful. */
@@ -327,6 +337,7 @@ export default function ChartWidget({
   expanded = false,
   fitYAxis = false,
   fullWidth = false,
+  showLegend = true,
 }: ChartWidgetProps) {
   const {
     data,
@@ -334,6 +345,7 @@ export default function ChartWidget({
     yAxis,
     type,
     seriesFields,
+    lineField,
     datasetName,
     colorMap,
     seriesColor,
@@ -347,11 +359,16 @@ export default function ChartWidget({
   const { data: formattedData, series } = useMemo(
     () =>
       xAxis
-        ? formatChartData(data, type, xAxis, yAxis, datasetName, seriesFields, {
-            colorMap,
-            seriesColor,
-            divergentColors,
-          })
+        ? formatChartData(
+            data,
+            type,
+            xAxis,
+            yAxis,
+            datasetName,
+            seriesFields,
+            { colorMap, seriesColor, divergentColors },
+            lineField
+          )
         : { data: [], series: [] },
     [
       data,
@@ -360,6 +377,7 @@ export default function ChartWidget({
       yAxis,
       datasetName,
       seriesFields,
+      lineField,
       colorMap,
       seriesColor,
       divergentColors,
@@ -604,6 +622,41 @@ export default function ChartWidget({
           </Bar>
         ));
       }
+      case "stacked-bar-with-line": {
+        return chart.series.map((item) =>
+          item.name === lineField ? (
+            <Line
+              key={item.name}
+              type="monotone"
+              name={item.name?.toString()}
+              dataKey={chart.key(item.name)}
+              stroke={chart.color(item.color)}
+              strokeWidth={2}
+              dot={{ r: 3, strokeWidth: 1, fill: chart.color(item.color) }}
+              activeDot={{
+                r: 4.5,
+                strokeWidth: 2,
+                stroke: "var(--chakra-colors-bg)",
+              }}
+              {...animationProps}
+            />
+          ) : (
+            <Bar
+              key={item.name}
+              name={item.name?.toString()}
+              dataKey={chart.key(item.name)}
+              stackId="a"
+              fill={chart.color(item.color)}
+              {...animationProps}
+            >
+              {typeof formattedData[0]?._barColor === "string" &&
+                formattedData.map((entry, index) => (
+                  <Cell key={index} fill={String(entry._barColor)} />
+                ))}
+            </Bar>
+          )
+        );
+      }
       default:
         return null;
     }
@@ -651,28 +704,37 @@ export default function ChartWidget({
           {...(type === "area" && fitYAxis
             ? { baseValue: "dataMin" as const }
             : {})}
+          // Diverging stacks (emissions up / removals down) need the sign
+          // offset: recharts' default accumulates the running total ignoring
+          // sign, which draws negative segments back down from the positive
+          // total instead of below the zero line.
+          {...(type === "stacked-bar-with-line"
+            ? { stackOffset: "sign" as const }
+            : {})}
         >
           {type !== "pie" && (
             <CartesianGrid strokeDasharray="3 3" vertical={false} />
           )}
-          <Legend
-            content={
-              type === "pie" ? (
-                <CustomPieLegend series={chart.series} shares={pieShares} />
-              ) : (
-                <Chart.Legend />
-              )
-            }
-            align={type === "pie" ? "right" : "left"}
-            layout={type === "pie" ? "vertical" : "horizontal"}
-            verticalAlign={type === "pie" ? "middle" : "top"}
-            wrapperStyle={{
-              paddingBottom: "0.5rem",
-              maxHeight: "100%",
-              width: type === "pie" ? "42%" : undefined,
-              overflow: "hidden",
-            }}
-          />
+          {showLegend && (
+            <Legend
+              content={
+                type === "pie" ? (
+                  <CustomPieLegend series={chart.series} shares={pieShares} />
+                ) : (
+                  <Chart.Legend />
+                )
+              }
+              align={type === "pie" ? "right" : "left"}
+              layout={type === "pie" ? "vertical" : "horizontal"}
+              verticalAlign={type === "pie" ? "middle" : "top"}
+              wrapperStyle={{
+                paddingBottom: "0.5rem",
+                maxHeight: "100%",
+                width: type === "pie" ? "42%" : undefined,
+                overflow: "hidden",
+              }}
+            />
+          )}
           {type !== "pie" && (
             <>
               <XAxis

--- a/app/constants/datasets.ts
+++ b/app/constants/datasets.ts
@@ -497,6 +497,27 @@ export const DATASET_CARDS: (DatasetCardConfig & { img?: string })[] = [
       unit: "tCO2e/ha",
     },
   },
+  {
+    dataset_id: 12,
+    dataset_name: "Land GHG Monitoring System (LGMS)",
+    shortName: "LGMS net flux",
+    data_layer: "Land GHG Monitoring System (LGMS)",
+    context_layer: null,
+    img: "/dataset_card_net_flux.webp",
+    cadence: "annual",
+    resolution: "reported per admin area",
+    geographic_coverage:
+      "GADM administrative areas (country, state/province, district) only",
+    provider: "WRI",
+    defaultStartYear: 2016,
+    defaultEndYear: 2024,
+    categories: ["land-use"],
+    description:
+      "Maps annual gross greenhouse-gas emissions, gross CO2 removals, and net GHG flux from land — vegetation, soil, and agriculture — for GADM administrative areas from 2016 to 2024. Values are in MgCO2e; emissions are positive (a source), removals negative (a sink).",
+    // Analytics-only: no map tile layer. Picking this card enables the "View
+    // Analysis" flow for a GADM admin AOI without adding a raster to the map.
+    tile_url: "",
+  },
 ];
 
 // Defaults applied to DatasetInfo when not provided by cards

--- a/app/types/chat.ts
+++ b/app/types/chat.ts
@@ -77,13 +77,18 @@ export interface InsightWidget extends ChartColorFields {
     | "stacked-bar"
     | "grouped-bar"
     | "area"
-    | "scatter";
+    | "scatter"
+    | "stacked-bar-with-line";
   title: string;
   description: string;
   data: unknown;
   xAxis: string;
   yAxis: string;
   seriesFields?: string[];
+  // Column rendered as a Line overlay on top of the stacked bars — only
+  // meaningful for type "stacked-bar-with-line" (e.g. a net-flux line over
+  // emissions/removals stacks). Excluded from the stack itself.
+  lineField?: string;
   datasetName?: string;
   generation?: InsightGeneration; // Optional provenance for how the widget was generated
   // Whether this insight is curated/verified rather than AI-generated. Set from

--- a/app/utils/__tests__/formatCharts.test.ts
+++ b/app/utils/__tests__/formatCharts.test.ts
@@ -174,6 +174,84 @@ describe("formatChartData", () => {
     expect(result.data[0]).toMatchObject({ region: "A", 2020: 10, 2021: 12 });
   });
 
+  describe("stacked-bar-with-line", () => {
+    it("stacks the series fields and renders the line field on top, unstacked", () => {
+      // The line's value is precomputed by the caller (net-flux-variants), not
+      // by formatChartData — this only decides how to render an existing column.
+      const data = [
+        { year: 2020, Emissions: 100, Removals: -40, "Net flux": 60 },
+        { year: 2021, Emissions: 90, Removals: -50, "Net flux": 40 },
+      ];
+      const result = formatChartData(
+        data,
+        "stacked-bar-with-line",
+        "year",
+        undefined,
+        undefined,
+        ["Emissions", "Removals"],
+        undefined,
+        "Net flux"
+      );
+      expect(result.series.map((s) => s.name)).toEqual([
+        "Emissions",
+        "Removals",
+        "Net flux",
+      ]);
+      expect(result.series[0].stackId).toBe("a");
+      expect(result.series[1].stackId).toBe("a");
+      expect(result.series[2].stackId).toBeUndefined();
+      expect(result.data[0]["Net flux"]).toBe(60);
+      expect(result.data[1]["Net flux"]).toBe(40);
+    });
+
+    it("takes per-series colors from the backend colorMap, falling back to the rotation", () => {
+      const data = [{ year: 2020, Emissions: 100, Removals: -40, Other: 5 }];
+      const result = formatChartData(
+        data,
+        "stacked-bar-with-line",
+        "year",
+        undefined,
+        undefined,
+        ["Emissions", "Removals", "Other"],
+        { colorMap: { Emissions: "#8c510a", Removals: "url(#hatch)" } }
+      );
+      const byName = Object.fromEntries(
+        result.series.map((s) => [s.name, s.color])
+      );
+      expect(byName.Emissions).toBe("#8c510a");
+      // SVG paint references pass through untouched, so a series can be hatched.
+      expect(byName.Removals).toBe("url(#hatch)");
+      // No registry entry → default rotation, so it still renders.
+      expect(byName.Other).toBeTruthy();
+      expect(byName.Other).not.toBe("#8c510a");
+    });
+
+    it("tints a single divergent series by sign, mirroring the plain bar branch", () => {
+      const data = [
+        { year: 2020, "Net source": 850, "Net flux": 850 },
+        { year: 2021, "Net source": -120, "Net flux": -120 },
+      ];
+      const result = formatChartData(
+        data,
+        "stacked-bar-with-line",
+        "year",
+        undefined,
+        undefined,
+        ["Net source"],
+        {
+          divergentColors: { positive: "#8c510a", negative: "#01665e" },
+        },
+        "Net flux"
+      );
+      expect(result.series.map((s) => s.name)).toEqual([
+        "Net source",
+        "Net flux",
+      ]);
+      expect(result.data[0]._barColor).toBe("#8c510a");
+      expect(result.data[1]._barColor).toBe("#01665e");
+    });
+  });
+
   it("keeps the name column for scatter charts (regression)", () => {
     const data = [
       { country: "Brazil", gdp_per_capita: 8900, deforestation_ha: 4812000 },

--- a/app/utils/datasetCardLayerContext.ts
+++ b/app/utils/datasetCardLayerContext.ts
@@ -32,5 +32,21 @@ export function getLayerContextFromDatasetCard(
 
 /** Build the managed map layers (main + optional sub-layer) for a dataset card. */
 export function datasetCardLayers(card: DatasetCardConfig): Layer[] {
-  return buildDatasetLayers(getLayerContextFromDatasetCard(card));
+  const context = getLayerContextFromDatasetCard(card);
+  if (!context.tileUrl) {
+    // Analytics-only dataset (e.g. LGMS): no raster to render, but the layer
+    // manager is still the source of truth for "is this dataset active" (see
+    // showViewAnalysisNudge). DynamicTileLayers already skips raster layers
+    // with no tileUrl, so this stays safely invisible on the map.
+    return [
+      {
+        id: `dataset-${card.dataset_id}`,
+        name: card.dataset_name,
+        type: "raster",
+        visible: true,
+        datasetId: card.dataset_id,
+      },
+    ];
+  }
+  return buildDatasetLayers(context);
 }

--- a/app/utils/formatCharts.tsx
+++ b/app/utils/formatCharts.tsx
@@ -112,6 +112,8 @@ function filterChartDataColumns(
  *   registry). When present they take precedence over the local
  *   `chartColorMappings.ts` config, which remains the fallback for
  *   pre-migration insights and categories with no registry entry.
+ * @param lineField Column rendered as a Line overlay on top of the stacked
+ *   bars (stacked-bar-with-line only) — excluded from the stack itself.
  * @returns An object containing the transformed `data` and `series` arrays.
  */
 export default function formatChartData(
@@ -125,12 +127,14 @@ export default function formatChartData(
     | "stacked-bar"
     | "grouped-bar"
     | "area"
-    | "scatter",
+    | "scatter"
+    | "stacked-bar-with-line",
   xAxis?: string,
   yAxis?: string,
   datasetName?: string,
   seriesFields?: string[],
-  colorOverrides?: ChartColorFields
+  colorOverrides?: ChartColorFields,
+  lineField?: string
 ): { data: ChartData[]; series: ChartSeries[] } {
   const empty = { data: [], series: [] };
 
@@ -173,6 +177,7 @@ export default function formatChartData(
         xAxisKey,
         ...valueKeys,
         ...(keys.includes(xAxisSlugKey) ? [xAxisSlugKey] : []),
+        ...(lineField && keys.includes(lineField) ? [lineField] : []),
       ])
     : data;
   const scopedFirstRow = scopedData[0];
@@ -363,6 +368,55 @@ export default function formatChartData(
     }));
     // The data format is already correct for stacked charts.
     return { data: chartRows as ChartData[], series };
+  }
+
+  // --- Logic for a STACKED chart with a Line overlay (e.g. net flux) ---
+  if (type === "stacked-bar-with-line") {
+    const seriesKeys = resolveValueKeys(
+      scopedKeys,
+      xAxisKey,
+      yAxis,
+      seriesFields
+    ).filter((key) => key !== lineField);
+    // Per-series colors come from the backend color registry (`colorMap`),
+    // keyed by series name — the same mechanism the pie branch uses — so a
+    // caller can pin each stack segment to its designed color. Segments with
+    // no registry entry fall back to the default rotation.
+    const stackColorMap = colorOverrides?.colorMap;
+    const series: ChartSeries[] = seriesKeys.map((key, index) => ({
+      name: key,
+      color:
+        stackColorMap?.[key] ?? defaultColors[index % defaultColors.length],
+      stackId: "a",
+    }));
+
+    // A single bar series with divergent colors (e.g. "Net flux" alone, no
+    // detail breakdown) is tinted per-row by sign, mirroring the plain "bar"
+    // branch above.
+    const divergent =
+      colorOverrides?.divergentColors ??
+      (datasetName ? DATASET_DIVERGENT_COLORS[datasetName] : undefined);
+    let rows = chartRows as ChartData[];
+    if (divergent && seriesKeys.length === 1) {
+      const key = seriesKeys[0];
+      rows = rows.map((item) => {
+        const val = Number(item[key]);
+        return {
+          ...item,
+          _barColor: val < 0 ? divergent.negative : divergent.positive,
+        };
+      });
+      series[0] = { ...series[0], color: divergent.positive };
+    }
+
+    if (lineField && scopedKeys.includes(lineField)) {
+      series.push({
+        name: lineField,
+        color: "#172b7a",
+      });
+    }
+
+    return { data: rows, series };
   }
 
   // --- Logic for GROUPED charts ---

--- a/app/utils/widgetIcons.tsx
+++ b/app/utils/widgetIcons.tsx
@@ -25,6 +25,7 @@ export const WidgetIconComponent: Record<InsightWidget["type"], Icon> = {
   scatter: ChartScatterIcon,
   table: ListNumbersIcon,
   "dataset-card": StackIcon,
+  "stacked-bar-with-line": ChartBarIcon,
 };
 
 /** Element-instance map for inline rendering without size/color overrides. */
@@ -39,4 +40,5 @@ export const WidgetIcons = {
   "dataset-card": <StackIcon />,
   scatter: <ChartScatterIcon />,
   area: <ChartPolarIcon />,
+  "stacked-bar-with-line": <ChartBarIcon />,
 };

--- a/src/entities/insight/lib/charts-to-widgets.ts
+++ b/src/entities/insight/lib/charts-to-widgets.ts
@@ -12,6 +12,7 @@ const ALLOWED_TYPES = new Set<InsightWidget["type"]>([
   "grouped-bar",
   "area",
   "scatter",
+  "stacked-bar-with-line",
 ]);
 
 /**

--- a/src/features/analysis/api/__tests__/dataset-override-gateway.test.ts
+++ b/src/features/analysis/api/__tests__/dataset-override-gateway.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it, vi } from "vitest";
+import { DatasetOverrideGateway } from "../dataset-override-gateway";
+import type { AnalysisGateway } from "../../model/analysis-gateway";
+import type { AnalysisSelection } from "../../model/analysis-selection";
+import type { AnalysisResult } from "../../model/analysis-result";
+
+const REAL_DATASET_SELECTION: AnalysisSelection = {
+  area: { name: "Brazil", source: "gadm", srcId: "BRA", subtype: "country" },
+  dataset: { id: 4 },
+  startDate: "2020-01-01",
+  endDate: "2022-12-31",
+};
+
+const OVERRIDDEN_SELECTION: AnalysisSelection = {
+  ...REAL_DATASET_SELECTION,
+  dataset: { id: 12 },
+};
+
+const CANNED_RESULT: AnalysisResult = {
+  id: "canned",
+  charts: [
+    {
+      id: "chart-1",
+      position: 0,
+      title: "Net flux over time",
+      type: "stacked-bar-with-line",
+      xAxis: "year",
+      yAxis: "net_flux_mt",
+      colorField: "",
+      stackField: "category",
+      groupField: "",
+      seriesFields: ["Net flux"],
+      data: [{ year: 2020, "Net flux": 850 }],
+    },
+  ],
+};
+
+function fakeRealGateway(): AnalysisGateway {
+  return {
+    submit: vi.fn().mockResolvedValue({ id: "real-job" }),
+    poll: vi.fn().mockResolvedValue({
+      status: "completed",
+      resources: [
+        {
+          id: "real-job",
+          resourceUrl: "/api/insights/real",
+          status: "completed",
+        },
+      ],
+    }),
+    fetchResult: vi.fn().mockResolvedValue({ id: "real-result", charts: [] }),
+  };
+}
+
+describe("DatasetOverrideGateway", () => {
+  it("passes non-overridden dataset ids straight through to the real gateway", async () => {
+    const real = fakeRealGateway();
+    const gateway = new DatasetOverrideGateway(real, { 12: CANNED_RESULT });
+
+    const job = await gateway.submit(REAL_DATASET_SELECTION);
+    expect(real.submit).toHaveBeenCalledWith(REAL_DATASET_SELECTION, undefined);
+    expect(job).toEqual({ id: "real-job" });
+
+    const outcome = await gateway.poll(job.id);
+    expect(real.poll).toHaveBeenCalledWith("real-job", undefined);
+    expect(outcome.status).toBe("completed");
+
+    if (outcome.status === "completed") {
+      const result = await gateway.fetchResult(
+        outcome.resources[0].resourceUrl
+      );
+      expect(real.fetchResult).toHaveBeenCalled();
+      expect(result).toEqual({ id: "real-result", charts: [] });
+    }
+  });
+
+  it("short-circuits an overridden dataset id without touching the real gateway", async () => {
+    const real = fakeRealGateway();
+    const gateway = new DatasetOverrideGateway(real, { 12: CANNED_RESULT });
+
+    const job = await gateway.submit(OVERRIDDEN_SELECTION);
+    expect(real.submit).not.toHaveBeenCalled();
+
+    const outcome = await gateway.poll(job.id);
+    expect(real.poll).not.toHaveBeenCalled();
+    expect(outcome.status).toBe("completed");
+
+    if (outcome.status === "completed") {
+      const result = await gateway.fetchResult(
+        outcome.resources[0].resourceUrl
+      );
+      expect(real.fetchResult).not.toHaveBeenCalled();
+      expect(result).toBe(CANNED_RESULT);
+    }
+  });
+
+  it("issues a distinct job id per submission so concurrent runs don't collide", async () => {
+    const real = fakeRealGateway();
+    const gateway = new DatasetOverrideGateway(real, { 12: CANNED_RESULT });
+
+    const jobA = await gateway.submit(OVERRIDDEN_SELECTION);
+    const jobB = await gateway.submit(OVERRIDDEN_SELECTION);
+    expect(jobA.id).not.toBe(jobB.id);
+  });
+});

--- a/src/features/analysis/api/dataset-override-gateway.ts
+++ b/src/features/analysis/api/dataset-override-gateway.ts
@@ -1,0 +1,65 @@
+import type {
+  AnalysisGateway,
+  JobRef,
+  JobResource,
+  PollOutcome,
+} from "../model/analysis-gateway";
+import type { AnalysisSelection } from "../model/analysis-selection";
+import type { AnalysisResult } from "../model/analysis-result";
+
+const MOCK_JOB_PREFIX = "mock-dataset-override";
+
+/**
+ * Decorator over a real `AnalysisGateway`: for dataset ids present in
+ * `overrides`, short-circuits the whole submit -> poll -> fetchResult cycle
+ * and resolves immediately with the supplied canned `AnalysisResult`,
+ * skipping the network entirely. Every other dataset id passes straight
+ * through to the wrapped gateway, untouched.
+ *
+ * Temporary WIP-backend shim — delete an override entry (and this class, if
+ * it ends up unused) once the real backend ships a chart generator for the
+ * dataset in question. See `src/features/net-flux` for the current use.
+ */
+export class DatasetOverrideGateway implements AnalysisGateway {
+  private readonly pending = new Map<string, AnalysisResult>();
+  private counter = 0;
+
+  constructor(
+    private readonly real: AnalysisGateway,
+    private readonly overrides: Record<number, AnalysisResult>
+  ) {}
+
+  async submit(
+    selection: AnalysisSelection,
+    signal?: AbortSignal
+  ): Promise<JobRef> {
+    const override = this.overrides[selection.dataset.id];
+    if (!override) return this.real.submit(selection, signal);
+
+    const id = `${MOCK_JOB_PREFIX}-${selection.dataset.id}-${this.counter++}`;
+    this.pending.set(id, override);
+    return { id };
+  }
+
+  async poll(jobId: string, signal?: AbortSignal): Promise<PollOutcome> {
+    if (!this.pending.has(jobId)) return this.real.poll(jobId, signal);
+
+    const resource: JobResource = {
+      id: jobId,
+      resourceUrl: jobId,
+      status: "completed",
+    };
+    return { status: "completed", resources: [resource] };
+  }
+
+  async fetchResult(
+    resourceUrl: string,
+    signal?: AbortSignal
+  ): Promise<AnalysisResult> {
+    const override = this.pending.get(resourceUrl);
+    if (!override) return this.real.fetchResult(resourceUrl, signal);
+
+    this.pending.delete(resourceUrl);
+    return override;
+  }
+}

--- a/src/features/analysis/ui/analysis-service.ts
+++ b/src/features/analysis/ui/analysis-service.ts
@@ -1,11 +1,22 @@
 import type { AnalysisService } from "../model/analysis-service";
 import { LROAnalysisService } from "../model/lro-analysis-service";
 import { RestAnalysisGateway } from "../api/rest-analysis-gateway";
+import { DatasetOverrideGateway } from "../api/dataset-override-gateway";
 import { SystemClock } from "../lib/system-clock";
+import {
+  LGMS_DATASET_ID,
+  NET_FLUX_DUMMY_RESULT,
+} from "@/src/features/net-flux";
 
 /**
  * Composition root for the analysis use-case: the real LRO service wired to its
  * real driven adapters.
+ *
+ * `DatasetOverrideGateway` is a temporary WIP-backend shim: project-zeno's
+ * `/api/analyze` accepts the LGMS dataset end-to-end but has no chart
+ * generator for it yet, so requests for it resolve to canned data instead of
+ * hitting the network — everything else passes straight through to the real
+ * gateway. Delete the override once the backend ships a real generator.
  *
  * Exported from the slice barrel so other slices can run a non-generative
  * analysis without going through `useAnalysis` — the dashboards slice seeds a
@@ -14,6 +25,8 @@ import { SystemClock } from "../lib/system-clock";
  * performs.
  */
 export const analysisService: AnalysisService = new LROAnalysisService(
-  new RestAnalysisGateway(),
+  new DatasetOverrideGateway(new RestAnalysisGateway(), {
+    [LGMS_DATASET_ID]: NET_FLUX_DUMMY_RESULT,
+  }),
   new SystemClock()
 );

--- a/src/features/analysis/ui/use-analysis.ts
+++ b/src/features/analysis/ui/use-analysis.ts
@@ -32,6 +32,12 @@ const defaultSink: InsightSink = {
  * TCLChartGenerator`), identified by its y-axis, which is titled as
  * "GHG Emissions from Tree Cover Loss" instead.
  */
+/** Year from a "yyyy-MM-dd" selection bound, for the YEARS parameter chip. */
+function isoYear(date: string | undefined): number | undefined {
+  const year = Number(date?.slice(0, 4));
+  return Number.isInteger(year) ? year : undefined;
+}
+
 function chartDatasetName(
   widget: { yAxis?: string },
   datasetName: string
@@ -103,10 +109,18 @@ export function useAnalysis(
         (analysisResult) => {
           setResult(analysisResult);
           setStatus("done");
+          // Carry the dataset and date range through as well as the area, so
+          // the workspace renders the full AREA / DATA / YEARS chip row rather
+          // than an area-only one.
           const rawWidgets = chartsToWidgets(
             analysisResult.charts,
             analysisResult.params
-              ? { areas: [analysisResult.params.name] }
+              ? {
+                  areas: [analysisResult.params.name],
+                  dataset: selection.dataset.name,
+                  startYear: isoYear(selection.startDate),
+                  endYear: isoYear(selection.endDate),
+                }
               : undefined
           );
           // Give each widget a "{dataset} in {location}" title matching the

--- a/src/features/dashboards/lib/widgets.ts
+++ b/src/features/dashboards/lib/widgets.ts
@@ -14,6 +14,7 @@ const CHART_TYPES = new Set([
   "grouped-bar",
   "area",
   "scatter",
+  "stacked-bar-with-line",
 ]);
 
 export type WidgetSize = "single" | "double";

--- a/src/features/net-flux/index.ts
+++ b/src/features/net-flux/index.ts
@@ -1,0 +1,22 @@
+/**
+ * Public API of the `net-flux` feature (FSD slice).
+ *
+ * The curated "Net flux over time" insight (LGMS, dataset 12): dummy data for
+ * the still-WIP backend endpoint and the DETAIL/MEASURE variant derivation.
+ * Consumers import ONLY from this barrel.
+ */
+export {
+  LGMS_DATASET_ID,
+  NET_FLUX_DUMMY_RESULT,
+  NET_FLUX_DUMMY_WIDGET,
+} from "./model/dummy-data";
+export {
+  deriveNetFluxVariant,
+  isNetFluxWidget,
+  DETAIL_LABEL,
+  NET_FLUX_LINE_FIELD,
+  type NetFluxDetail,
+  type NetFluxMeasure,
+  type NetFluxVariant,
+} from "./model/net-flux-variants";
+export { netFluxViewKey } from "./model/net-flux-view-store";

--- a/src/features/net-flux/index.ts
+++ b/src/features/net-flux/index.ts
@@ -2,8 +2,9 @@
  * Public API of the `net-flux` feature (FSD slice).
  *
  * The curated "Net flux over time" insight (LGMS, dataset 12): dummy data for
- * the still-WIP backend endpoint and the DETAIL/MEASURE variant derivation.
- * Consumers import ONLY from this barrel.
+ * the still-WIP backend endpoint, the DETAIL/MEASURE variant derivation, and
+ * the bespoke card chrome the design specifies for it. Consumers import ONLY
+ * from this barrel.
  */
 export {
   LGMS_DATASET_ID,
@@ -20,3 +21,7 @@ export {
   type NetFluxVariant,
 } from "./model/net-flux-variants";
 export { netFluxViewKey } from "./model/net-flux-view-store";
+export { useNetFluxView } from "./ui/use-net-flux-view";
+export { NetFluxToolbar } from "./ui/NetFluxToolbar";
+export { NetFluxChartBody } from "./ui/NetFluxChartBody";
+export { NetFluxFootnote } from "./ui/NetFluxFootnote";

--- a/src/features/net-flux/model/__tests__/net-flux-variants.test.ts
+++ b/src/features/net-flux/model/__tests__/net-flux-variants.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from "vitest";
+import {
+  deriveNetFluxVariant,
+  isPaintReference,
+  NET_FLUX_FULL_DETAIL_FIELDS,
+} from "../net-flux-variants";
+import type { InsightWidget } from "@/app/types/chat";
+
+// One row whose totals mirror the design's 2020 tooltip in miniature: every
+// variant must collapse to the same +67 net flux.
+const FULL_DETAIL_WIDGET: InsightWidget = {
+  type: "stacked-bar-with-line",
+  title: "Net flux over time",
+  description: "",
+  xAxis: "year",
+  yAxis: "net_flux_mt",
+  seriesFields: NET_FLUX_FULL_DETAIL_FIELDS,
+  data: [
+    {
+      year: 2020,
+      "Livestock (2020, static)": 6,
+      "Cropland management (2020, static)": 4,
+      "Organic soil": 20,
+      "Mineral soil": 5,
+      "Non-trees rem. non-trees": 3,
+      "Trees rem. trees": 2,
+      "Tree loss": 100,
+      "Tree gain": -50,
+      "Trees remaining": -10,
+      "Non-trees": -5,
+      Mineral: -8,
+    },
+  ],
+};
+
+const NET_FLUX = 67;
+
+describe("deriveNetFluxVariant", () => {
+  it("full + gross keeps every category field and sums them for the line", () => {
+    const variant = deriveNetFluxVariant(FULL_DETAIL_WIDGET, "full", "gross");
+    expect(variant.seriesFields).toEqual([
+      "Tree loss",
+      "Trees rem. trees",
+      "Non-trees rem. non-trees",
+      "Mineral soil",
+      "Organic soil",
+      "Cropland management (2020, static)",
+      "Livestock (2020, static)",
+      "Tree gain",
+      "Trees remaining",
+      "Non-trees",
+      "Mineral",
+    ]);
+    expect(variant.data[0]["Net flux"]).toBe(NET_FLUX);
+  });
+
+  it("categories + gross collapses into the design's buckets", () => {
+    const variant = deriveNetFluxVariant(
+      FULL_DETAIL_WIDGET,
+      "categories",
+      "gross"
+    );
+    const row = variant.data[0];
+    expect(row["Vegetation (emissions)"]).toBe(105);
+    expect(row["Mineral soil"]).toBe(25);
+    expect(row["Livestock (2020, static)"]).toBe(6);
+    expect(row["Cropland management (2020, static)"]).toBe(4);
+    expect(row["Vegetation (removals)"]).toBe(-65);
+    expect(row["Soil"]).toBe(-8);
+    expect(row["Net flux"]).toBe(NET_FLUX);
+  });
+
+  it("summary + gross collapses into agriculture + 2 land-use buckets", () => {
+    const variant = deriveNetFluxVariant(
+      FULL_DETAIL_WIDGET,
+      "summary",
+      "gross"
+    );
+    const row = variant.data[0];
+    expect(row["Agriculture (static)"]).toBe(10);
+    expect(row["Land use Emissions"]).toBe(130);
+    expect(row["Land use Removals"]).toBe(-73);
+    expect(row["Net flux"]).toBe(NET_FLUX);
+  });
+
+  it("net measure ignores detail and collapses to one signed bar + line", () => {
+    for (const detail of ["full", "categories", "summary"] as const) {
+      const variant = deriveNetFluxVariant(FULL_DETAIL_WIDGET, detail, "net");
+      expect(variant.seriesFields).toEqual(["Net source"]);
+      expect(variant.data[0]["Net source"]).toBe(NET_FLUX);
+      expect(variant.data[0]["Net flux"]).toBe(NET_FLUX);
+      // Left empty so the divergent positive/negative tint drives the bars.
+      expect(variant.colorMap).toEqual({});
+    }
+  });
+
+  it("maps every series to a colour, hatching the fixed-2020 agriculture ones", () => {
+    const variant = deriveNetFluxVariant(FULL_DETAIL_WIDGET, "full", "gross");
+    for (const field of variant.seriesFields) {
+      expect(variant.colorMap[field]).toBeTruthy();
+    }
+    expect(variant.colorMap["Tree loss"]).toBe("#543005");
+    expect(isPaintReference(variant.colorMap["Livestock (2020, static)"])).toBe(
+      true
+    );
+    expect(
+      isPaintReference(variant.colorMap["Cropland management (2020, static)"])
+    ).toBe(true);
+  });
+
+  it("orders the legend top-of-stack first for emissions, per the design", () => {
+    const { legend } = deriveNetFluxVariant(
+      FULL_DETAIL_WIDGET,
+      "full",
+      "gross"
+    );
+    expect(legend.layout).toBe("grouped");
+    expect(legend.emissions.map((i) => i.label)).toEqual([
+      "Livestock (2020, static)",
+      "Cropland management (2020, static)",
+      "Organic soil",
+      "Mineral soil",
+      "Non-trees remaining non-trees",
+      "Trees remaining trees",
+      "Tree loss",
+    ]);
+    // Removals stack downward, so their stacking order already reads correctly.
+    expect(legend.removals.map((i) => i.label)).toEqual([
+      "Tree gain",
+      "Trees remaining",
+      "Non-trees",
+      "Mineral soil",
+    ]);
+  });
+
+  it("uses a flat legend for the net measure", () => {
+    const { legend } = deriveNetFluxVariant(FULL_DETAIL_WIDGET, "full", "net");
+    expect(legend.layout).toBe("flat");
+    expect(legend.emissions.map((i) => i.label)).toEqual([
+      "Net source (+)",
+      "Net sink (−)",
+    ]);
+    expect(legend.removals).toEqual([]);
+  });
+
+  it("labels repeat across groups where the design repeats them", () => {
+    const { legend } = deriveNetFluxVariant(
+      FULL_DETAIL_WIDGET,
+      "categories",
+      "gross"
+    );
+    // "Vegetation" appears in both columns; the underlying data keys differ so
+    // Recharts still sees unique dataKeys.
+    expect(legend.emissions.map((i) => i.label)).toContain("Vegetation");
+    expect(legend.removals.map((i) => i.label)).toContain("Vegetation");
+  });
+});

--- a/src/features/net-flux/model/dummy-data.ts
+++ b/src/features/net-flux/model/dummy-data.ts
@@ -1,0 +1,209 @@
+import type { Chart } from "@/src/entities/insight";
+import { chartsToWidgets } from "@/src/entities/insight";
+import type { AnalysisResult } from "@/src/features/analysis";
+import type { InsightWidget } from "@/app/types/chat";
+import {
+  NET_FLUX_DIVERGENT_COLORS,
+  NET_FLUX_FULL_DETAIL_COLOR_MAP,
+  NET_FLUX_FULL_DETAIL_FIELDS,
+  NET_FLUX_LINE_FIELD,
+} from "./net-flux-variants";
+
+/**
+ * Land GHG Monitoring System (LGMS) — the annual, category-broken-down net
+ * flux dataset this curated insight is built on. Distinct from "Forest
+ * greenhouse gas net flux" (dataset 6), whose catalog forbids a time-series
+ * presentation (cumulative 2001-2025 total only).
+ */
+export const LGMS_DATASET_ID = 12;
+
+/**
+ * Illustrative annual values in megatonnes CO2e/yr, anchored to the design.
+ *
+ * The 2020 row reproduces the design's tooltip exactly (+1,600 emissions,
+ * −750 removals, +850 net). The 2016 row is read off the design's own plot
+ * geometry — its y-axis puts 500 units at 55.56px, giving +1,750 emissions and
+ * −700 removals, i.e. the +1,050 headline. 2024 continues that trend to the
+ * +610 headline, and the remaining years interpolate linearly between those
+ * three anchors, so the rendered axis range matches the design rather than
+ * just the endpoints.
+ *
+ * The two agriculture fields are held constant across every year, per the
+ * design's own caption: agriculture is a fixed 2020 value repeated annually,
+ * and only land use varies year to year. The design does not specify how the
+ * 250 total splits between livestock and cropland management — only the total
+ * is taken from it.
+ */
+const NET_FLUX_DUMMY_ROWS: Record<string, number>[] = [
+  {
+    year: 2016,
+    "Livestock (2020, static)": 150,
+    "Cropland management (2020, static)": 100,
+    "Organic soil": 420,
+    "Mineral soil": 180,
+    "Non-trees rem. non-trees": 90,
+    "Trees rem. trees": 180,
+    "Tree loss": 630,
+    "Tree gain": -472,
+    "Trees remaining": -126,
+    "Non-trees": -32,
+    Mineral: -70,
+  },
+  {
+    year: 2017,
+    "Livestock (2020, static)": 150,
+    "Cropland management (2020, static)": 100,
+    "Organic soil": 410,
+    "Mineral soil": 176,
+    "Non-trees rem. non-trees": 88,
+    "Trees rem. trees": 176,
+    "Tree loss": 614,
+    "Tree gain": -481,
+    "Trees remaining": -128,
+    "Non-trees": -32,
+    Mineral: -71,
+  },
+  {
+    year: 2018,
+    "Livestock (2020, static)": 150,
+    "Cropland management (2020, static)": 100,
+    "Organic soil": 399,
+    "Mineral soil": 171,
+    "Non-trees rem. non-trees": 86,
+    "Trees rem. trees": 171,
+    "Tree loss": 599,
+    "Tree gain": -490,
+    "Trees remaining": -131,
+    "Non-trees": -33,
+    Mineral: -73,
+  },
+  {
+    year: 2019,
+    "Livestock (2020, static)": 150,
+    "Cropland management (2020, static)": 100,
+    "Organic soil": 389,
+    "Mineral soil": 167,
+    "Non-trees rem. non-trees": 83,
+    "Trees rem. trees": 167,
+    "Tree loss": 583,
+    "Tree gain": -498,
+    "Trees remaining": -133,
+    "Non-trees": -33,
+    Mineral: -74,
+  },
+  {
+    year: 2020,
+    "Livestock (2020, static)": 150,
+    "Cropland management (2020, static)": 100,
+    "Organic soil": 378,
+    "Mineral soil": 162,
+    "Non-trees rem. non-trees": 81,
+    "Trees rem. trees": 162,
+    "Tree loss": 567,
+    "Tree gain": -506,
+    "Trees remaining": -135,
+    "Non-trees": -34,
+    Mineral: -75,
+  },
+  {
+    year: 2021,
+    "Livestock (2020, static)": 150,
+    "Cropland management (2020, static)": 100,
+    "Organic soil": 365,
+    "Mineral soil": 158,
+    "Non-trees rem. non-trees": 79,
+    "Trees rem. trees": 158,
+    "Tree loss": 553,
+    "Tree gain": -521,
+    "Trees remaining": -139,
+    "Non-trees": -35,
+    Mineral: -77,
+  },
+  {
+    year: 2022,
+    "Livestock (2020, static)": 150,
+    "Cropland management (2020, static)": 100,
+    "Organic soil": 352,
+    "Mineral soil": 154,
+    "Non-trees rem. non-trees": 77,
+    "Trees rem. trees": 154,
+    "Tree loss": 539,
+    "Tree gain": -537,
+    "Trees remaining": -143,
+    "Non-trees": -36,
+    Mineral: -79,
+  },
+  {
+    year: 2023,
+    "Livestock (2020, static)": 150,
+    "Cropland management (2020, static)": 100,
+    "Organic soil": 338,
+    "Mineral soil": 150,
+    "Non-trees rem. non-trees": 75,
+    "Trees rem. trees": 150,
+    "Tree loss": 524,
+    "Tree gain": -552,
+    "Trees remaining": -147,
+    "Non-trees": -37,
+    Mineral: -82,
+  },
+  {
+    year: 2024,
+    "Livestock (2020, static)": 150,
+    "Cropland management (2020, static)": 100,
+    "Organic soil": 325,
+    "Mineral soil": 146,
+    "Non-trees rem. non-trees": 73,
+    "Trees rem. trees": 146,
+    "Tree loss": 510,
+    "Tree gain": -567,
+    "Trees remaining": -151,
+    "Non-trees": -38,
+    Mineral: -84,
+  },
+];
+
+function sumRow(row: Record<string, number>, fields: string[]): number {
+  return fields.reduce((sum, field) => sum + (row[field] ?? 0), 0);
+}
+
+const NET_FLUX_CHART: Chart = {
+  id: "net-flux-lgms-dummy",
+  position: 0,
+  title: "Net flux over time",
+  type: "stacked-bar-with-line",
+  xAxis: "year",
+  yAxis: "net_flux_mt",
+  colorField: "",
+  stackField: "category",
+  groupField: "",
+  seriesFields: NET_FLUX_FULL_DETAIL_FIELDS,
+  data: NET_FLUX_DUMMY_ROWS.map((row) => ({
+    ...row,
+    [NET_FLUX_LINE_FIELD]: sumRow(row, NET_FLUX_FULL_DETAIL_FIELDS),
+  })),
+  colorMap: NET_FLUX_FULL_DETAIL_COLOR_MAP,
+  divergentColors: NET_FLUX_DIVERGENT_COLORS,
+};
+
+/**
+ * Canned analysis result for dataset 12 (LGMS), keyed into
+ * `DatasetOverrideGateway` until project-zeno ships a real chart generator
+ * for it (see the backend shape proposal in the implementation plan).
+ */
+export const NET_FLUX_DUMMY_RESULT: AnalysisResult = {
+  id: "net-flux-dummy-result",
+  charts: [NET_FLUX_CHART],
+};
+
+/**
+ * The dummy result mapped through the real Chart -> InsightWidget ACL, for
+ * `/chart-debug` and tests — so it exercises the same mapping real data will.
+ * `lineField` isn't part of the `Chart` entity (it's a net-flux-specific
+ * rendering hint, not a general insight concept), so it's set here rather
+ * than threaded through `chartsToWidgets`.
+ */
+export const NET_FLUX_DUMMY_WIDGET: InsightWidget = {
+  ...chartsToWidgets(NET_FLUX_DUMMY_RESULT.charts)[0],
+  lineField: NET_FLUX_LINE_FIELD,
+};

--- a/src/features/net-flux/model/net-flux-variants.ts
+++ b/src/features/net-flux/model/net-flux-variants.ts
@@ -1,0 +1,345 @@
+import type { InsightWidget } from "@/app/types/chat";
+
+export type NetFluxDetail = "full" | "categories" | "summary";
+export type NetFluxMeasure = "gross" | "net";
+export type NetFluxGroup = "emissions" | "removals";
+
+/**
+ * SVG paint references for the fixed-2020 agriculture series, which the design
+ * draws as diagonal hatching rather than a solid fill. The patterns themselves
+ * are declared once by `NetFluxHatchDefs`; SVG paint references resolve
+ * document-wide, so a `url(#…)` fill works from any chart on the page.
+ */
+export const HATCH_LIVESTOCK = "url(#net-flux-hatch-livestock)";
+export const HATCH_CROPLAND = "url(#net-flux-hatch-cropland)";
+export const HATCH_AGRICULTURE = "url(#net-flux-hatch-agriculture)";
+
+/** True for a colour that is an SVG paint reference rather than a CSS colour. */
+export function isPaintReference(color: string): boolean {
+  return color.startsWith("url(");
+}
+
+/**
+ * The net-flux insight is the only producer of this chart type, so the type
+ * doubles as the discriminator for its bespoke chrome.
+ */
+export function isNetFluxWidget(widget: InsightWidget): boolean {
+  return widget.type === "stacked-bar-with-line";
+}
+
+/** Net-flux line overlay: the signed total of whichever bars are shown. */
+export const NET_FLUX_LINE_FIELD = "Net flux";
+
+/** Bar rendered for the "net" measure — tinted by sign via `divergentColors`. */
+const NET_MEASURE_FIELD = "Net source";
+
+const NET_SOURCE_COLOR = "#8c510a";
+const NET_SINK_COLOR = "#01665e";
+
+export interface NetFluxSeriesSpec {
+  /**
+   * Data key, and the name shown in the tooltip. Unique within a variant —
+   * Recharts requires distinct dataKeys, and the design's own tooltips already
+   * disambiguate where its legend repeats a label (legend "Mineral soil" in
+   * removals vs. tooltip "Mineral"; legend "Land use" twice vs. tooltip
+   * "Land use Emissions"/"Land use Removals").
+   */
+  key: string;
+  /** Legend label, which may repeat across the two groups. */
+  label: string;
+  color: string;
+  group: NetFluxGroup;
+  /** Full-detail keys summed to produce this series. */
+  from: string[];
+}
+
+export interface NetFluxLegendItem {
+  label: string;
+  color: string;
+}
+
+export interface NetFluxLegend {
+  /** "grouped" = Emissions/Removals columns; "flat" = a single wrapped row. */
+  layout: "grouped" | "flat";
+  emissions: NetFluxLegendItem[];
+  removals: NetFluxLegendItem[];
+}
+
+export interface NetFluxVariant {
+  data: Record<string, unknown>[];
+  seriesFields: string[];
+  lineField: string;
+  /** Per-series colours, consumed via the chart's `colorMap` override. */
+  colorMap: Record<string, string>;
+  legend: NetFluxLegend;
+}
+
+/**
+ * Full-detail series in *stack* order: emissions from the zero line upward,
+ * then removals from the zero line downward. Recharts stacks in declaration
+ * order, and this order reproduces the design's plot exactly.
+ */
+const FULL_SERIES: NetFluxSeriesSpec[] = [
+  {
+    key: "Tree loss",
+    label: "Tree loss",
+    color: "#543005",
+    group: "emissions",
+    from: ["Tree loss"],
+  },
+  {
+    key: "Trees rem. trees",
+    label: "Trees remaining trees",
+    color: "#8c510a",
+    group: "emissions",
+    from: ["Trees rem. trees"],
+  },
+  {
+    key: "Non-trees rem. non-trees",
+    label: "Non-trees remaining non-trees",
+    color: "#bf812d",
+    group: "emissions",
+    from: ["Non-trees rem. non-trees"],
+  },
+  {
+    key: "Mineral soil",
+    label: "Mineral soil",
+    color: "#dfc27d",
+    group: "emissions",
+    from: ["Mineral soil"],
+  },
+  {
+    key: "Organic soil",
+    label: "Organic soil",
+    color: "#ebd9b0",
+    group: "emissions",
+    from: ["Organic soil"],
+  },
+  {
+    key: "Cropland management (2020, static)",
+    label: "Cropland management (2020, static)",
+    color: HATCH_CROPLAND,
+    group: "emissions",
+    from: ["Cropland management (2020, static)"],
+  },
+  {
+    key: "Livestock (2020, static)",
+    label: "Livestock (2020, static)",
+    color: HATCH_LIVESTOCK,
+    group: "emissions",
+    from: ["Livestock (2020, static)"],
+  },
+  {
+    key: "Tree gain",
+    label: "Tree gain",
+    color: "#01665e",
+    group: "removals",
+    from: ["Tree gain"],
+  },
+  {
+    key: "Trees remaining",
+    label: "Trees remaining",
+    color: "#35978f",
+    group: "removals",
+    from: ["Trees remaining"],
+  },
+  {
+    key: "Non-trees",
+    label: "Non-trees",
+    color: "#80cdc1",
+    group: "removals",
+    from: ["Non-trees"],
+  },
+  {
+    key: "Mineral",
+    label: "Mineral soil",
+    color: "#003c30",
+    group: "removals",
+    from: ["Mineral"],
+  },
+];
+
+const CATEGORY_SERIES: NetFluxSeriesSpec[] = [
+  {
+    key: "Vegetation (emissions)",
+    label: "Vegetation",
+    color: "#8c510a",
+    group: "emissions",
+    from: ["Non-trees rem. non-trees", "Trees rem. trees", "Tree loss"],
+  },
+  {
+    key: "Mineral soil",
+    label: "Mineral soil",
+    color: "#dfc27d",
+    group: "emissions",
+    from: ["Organic soil", "Mineral soil"],
+  },
+  {
+    key: "Cropland management (2020, static)",
+    label: "Cropland management (2020, static)",
+    color: HATCH_CROPLAND,
+    group: "emissions",
+    from: ["Cropland management (2020, static)"],
+  },
+  {
+    key: "Livestock (2020, static)",
+    label: "Livestock (2020, static)",
+    color: HATCH_LIVESTOCK,
+    group: "emissions",
+    from: ["Livestock (2020, static)"],
+  },
+  {
+    key: "Vegetation (removals)",
+    label: "Vegetation",
+    color: "#01665e",
+    group: "removals",
+    from: ["Tree gain", "Trees remaining", "Non-trees"],
+  },
+  {
+    key: "Soil",
+    label: "Soil",
+    color: "#80cdc1",
+    group: "removals",
+    from: ["Mineral"],
+  },
+];
+
+const SUMMARY_SERIES: NetFluxSeriesSpec[] = [
+  {
+    key: "Land use Emissions",
+    label: "Land use",
+    color: "#8c510a",
+    group: "emissions",
+    from: [
+      "Organic soil",
+      "Mineral soil",
+      "Non-trees rem. non-trees",
+      "Trees rem. trees",
+      "Tree loss",
+    ],
+  },
+  {
+    key: "Agriculture (static)",
+    label: "Agriculture (2020, static)",
+    color: HATCH_AGRICULTURE,
+    group: "emissions",
+    from: ["Livestock (2020, static)", "Cropland management (2020, static)"],
+  },
+  {
+    key: "Land use Removals",
+    label: "Land use",
+    color: "#01665e",
+    group: "removals",
+    from: ["Tree gain", "Trees remaining", "Non-trees", "Mineral"],
+  },
+];
+
+const DETAIL_SERIES: Record<NetFluxDetail, NetFluxSeriesSpec[]> = {
+  full: FULL_SERIES,
+  categories: CATEGORY_SERIES,
+  summary: SUMMARY_SERIES,
+};
+
+/** Full-detail data keys — the shape the (dummy, and later real) API returns. */
+export const NET_FLUX_FULL_DETAIL_FIELDS = FULL_SERIES.map((s) => s.key);
+
+/** Colours for the full-detail series, used as the stored widget's colorMap. */
+export const NET_FLUX_FULL_DETAIL_COLOR_MAP: Record<string, string> =
+  Object.fromEntries(FULL_SERIES.map((s) => [s.key, s.color]));
+
+export const NET_FLUX_DIVERGENT_COLORS = {
+  positive: NET_SOURCE_COLOR,
+  negative: NET_SINK_COLOR,
+};
+
+/** Label shown in the chart's subtitle for the active detail level. */
+export const DETAIL_LABEL: Record<NetFluxDetail, string> = {
+  full: "Full detail",
+  categories: "Categories",
+  summary: "Summary",
+};
+
+function sumRow(row: Record<string, unknown>, fields: string[]): number {
+  return fields.reduce((sum, field) => sum + (Number(row[field]) || 0), 0);
+}
+
+/**
+ * Emissions read top-of-stack first (the reverse of the stacking order) so the
+ * legend runs in the same visual order as the bar segments; removals stack
+ * downward, so their stacking order already matches. Both match the design.
+ */
+function buildLegend(specs: NetFluxSeriesSpec[]): NetFluxLegend {
+  const toItem = (s: NetFluxSeriesSpec): NetFluxLegendItem => ({
+    label: s.label,
+    color: s.color,
+  });
+  return {
+    layout: "grouped",
+    emissions: specs
+      .filter((s) => s.group === "emissions")
+      .reverse()
+      .map(toItem),
+    removals: specs.filter((s) => s.group === "removals").map(toItem),
+  };
+}
+
+/**
+ * Derives the chart data, series, colours and legend for one DETAIL × MEASURE
+ * combination from the single full-detail, gross-measure widget held in the
+ * store. The net-flux line is always the arithmetic sum of the bars shown —
+ * verified against the design's own tooltips, whose per-variant rows reproduce
+ * the same net flux at every detail level.
+ */
+export function deriveNetFluxVariant(
+  widget: InsightWidget,
+  detail: NetFluxDetail,
+  measure: NetFluxMeasure
+): NetFluxVariant {
+  const xAxis = widget.xAxis;
+  const rows = Array.isArray(widget.data)
+    ? (widget.data as Record<string, unknown>[])
+    : [];
+
+  if (measure === "net") {
+    const data = rows.map((row) => {
+      const net = sumRow(row, NET_FLUX_FULL_DETAIL_FIELDS);
+      return {
+        [xAxis]: row[xAxis],
+        [NET_MEASURE_FIELD]: net,
+        [NET_FLUX_LINE_FIELD]: net,
+      };
+    });
+    return {
+      data,
+      seriesFields: [NET_MEASURE_FIELD],
+      lineField: NET_FLUX_LINE_FIELD,
+      // Left empty so the divergent positive/negative tint drives the bars.
+      colorMap: {},
+      legend: {
+        layout: "flat",
+        emissions: [
+          { label: "Net source (+)", color: NET_SOURCE_COLOR },
+          { label: "Net sink (−)", color: NET_SINK_COLOR },
+        ],
+        removals: [],
+      },
+    };
+  }
+
+  const specs = DETAIL_SERIES[detail];
+  const seriesFields = specs.map((s) => s.key);
+  const data = rows.map((row) => {
+    const out: Record<string, unknown> = { [xAxis]: row[xAxis] };
+    for (const spec of specs) out[spec.key] = sumRow(row, spec.from);
+    out[NET_FLUX_LINE_FIELD] = sumRow(out, seriesFields);
+    return out;
+  });
+
+  return {
+    data,
+    seriesFields,
+    lineField: NET_FLUX_LINE_FIELD,
+    colorMap: Object.fromEntries(specs.map((s) => [s.key, s.color])),
+    legend: buildLegend(specs),
+  };
+}

--- a/src/features/net-flux/model/net-flux-view-store.ts
+++ b/src/features/net-flux/model/net-flux-view-store.ts
@@ -1,0 +1,50 @@
+import { create } from "zustand";
+import type { InsightWidget } from "@/app/types/chat";
+import type { NetFluxDetail, NetFluxMeasure } from "./net-flux-variants";
+
+export interface NetFluxView {
+  detail: NetFluxDetail;
+  measure: NetFluxMeasure;
+}
+
+/** Matches the design's default frame ("TS · Gross · Full detail"). */
+export const DEFAULT_NET_FLUX_VIEW: NetFluxView = {
+  detail: "full",
+  measure: "gross",
+};
+
+export interface NetFluxViewState {
+  byWidget: Record<string, NetFluxView>;
+  setView: (widgetId: string, patch: Partial<NetFluxView>) => void;
+}
+
+/**
+ * DETAIL/MEASURE selection for the net-flux insight, keyed by widget id.
+ *
+ * Shared rather than component-local because the design places the toggle
+ * pills *outside* the widget card (in the workspace shell) while the chart
+ * that reacts to them renders inside it — two components with no common
+ * ancestor that knows about net flux. Keyed by widget id so several net-flux
+ * insights in the workspace stack keep independent selections.
+ */
+const useNetFluxViewStore = create<NetFluxViewState>((set) => ({
+  byWidget: {},
+  setView: (widgetId, patch) =>
+    set((state) => ({
+      byWidget: {
+        ...state.byWidget,
+        [widgetId]: {
+          ...DEFAULT_NET_FLUX_VIEW,
+          ...state.byWidget[widgetId],
+          ...patch,
+        },
+      },
+    })),
+}));
+
+/** Stable key for a widget's view state; ids are set by `chartsToWidgets`. */
+export function netFluxViewKey(widget: InsightWidget): string {
+  return widget.id ?? widget.title;
+}
+
+export default useNetFluxViewStore;

--- a/src/features/net-flux/ui/NetFluxChartBody.tsx
+++ b/src/features/net-flux/ui/NetFluxChartBody.tsx
@@ -1,0 +1,147 @@
+"use client";
+import { Flex, Text } from "@chakra-ui/react";
+
+import ChartWidget from "@/app/components/widgets/ChartWidget";
+import type { InsightWidget } from "@/app/types/chat";
+
+import {
+  DETAIL_LABEL,
+  type NetFluxDetail,
+  type NetFluxMeasure,
+  type NetFluxVariant,
+} from "../model/net-flux-variants";
+import { NetFluxHatchDefs, NetFluxLegend } from "./NetFluxLegend";
+
+const EN_DASH = "–";
+
+const signedFormat = new Intl.NumberFormat("en-US", {
+  maximumFractionDigits: 0,
+  signDisplay: "always",
+});
+
+interface NetFluxChartBodyProps {
+  /** The widget already narrowed to the active DETAIL × MEASURE variant. */
+  widget: InsightWidget;
+  variant: NetFluxVariant;
+  detail: NetFluxDetail;
+  measure: NetFluxMeasure;
+  expanded?: boolean;
+  fitYAxis?: boolean;
+  fullWidth?: boolean;
+}
+
+interface Endpoint {
+  year: string;
+  value: number;
+}
+
+function endpoints(
+  variant: NetFluxVariant,
+  xAxis: string
+): { first: Endpoint; last: Endpoint } | null {
+  const rows = variant.data;
+  if (rows.length === 0) return null;
+  const read = (row: Record<string, unknown>): Endpoint => ({
+    year: String(row[xAxis]),
+    value: Number(row[variant.lineField]) || 0,
+  });
+  return { first: read(rows[0]), last: read(rows[rows.length - 1]) };
+}
+
+/**
+ * The design's chart header: the net flux at each end of the series, then the
+ * unit/direction/detail line, then the fixed caption describing the series.
+ */
+function TimeSeriesHeader({
+  variant,
+  xAxis,
+  detail,
+  measure,
+}: {
+  variant: NetFluxVariant;
+  xAxis: string;
+  detail: NetFluxDetail;
+  measure: NetFluxMeasure;
+}) {
+  const ends = endpoints(variant, xAxis);
+  if (!ends) return null;
+
+  const { first, last } = ends;
+  // Positive net flux means the land is a net source of emissions; negative
+  // means it is absorbing more than it emits (a sink).
+  const direction = last.value >= 0 ? "net source" : "net sink";
+  const detailLabel = measure === "net" ? "Net only" : DETAIL_LABEL[detail];
+  const range =
+    first.year === last.year
+      ? first.year
+      : `${first.year}${EN_DASH}${last.year}`;
+
+  return (
+    <Flex direction="column" gap="3px">
+      <Text
+        fontFamily="body"
+        fontWeight="medium"
+        color="#172B7A"
+        fontSize="18px"
+        lineHeight="normal"
+      >
+        {signedFormat.format(first.value)}{" "}
+        <Text as="span" fontSize="12px" color="#565E7B">
+          ({first.year})
+        </Text>{" "}
+        → {signedFormat.format(last.value)}{" "}
+        <Text as="span" fontSize="12px" color="#565E7B">
+          ({last.year})
+        </Text>
+      </Text>
+      <Text fontFamily="mono" fontSize="10px" color="#656E7B">
+        megatonnes CO₂e/yr · {direction} · {detailLabel}
+      </Text>
+      <Text
+        fontFamily="body"
+        fontSize="12px"
+        fontWeight="normal"
+        lineHeight="16px"
+        color="#282D33"
+      >
+        Land use annual · {range} · Agriculture fixed 2020
+      </Text>
+    </Flex>
+  );
+}
+
+/**
+ * Net-flux chart body — the design's own composition of a stat header, the
+ * stacked/line plot, and a grouped Emissions/Removals legend. Swapped in by
+ * `WidgetMessage` for this chart type in place of a bare `ChartWidget`; the
+ * chart's built-in legend is suppressed in favour of the grouped one.
+ */
+export function NetFluxChartBody({
+  widget,
+  variant,
+  detail,
+  measure,
+  expanded,
+  fitYAxis,
+  fullWidth,
+}: NetFluxChartBodyProps) {
+  return (
+    <Flex direction="column" gap="16px" w="full">
+      <NetFluxHatchDefs />
+      <TimeSeriesHeader
+        variant={variant}
+        xAxis={widget.xAxis}
+        detail={detail}
+        measure={measure}
+      />
+      <ChartWidget
+        widget={widget}
+        showLegend={false}
+        expanded={expanded}
+        fitYAxis={fitYAxis}
+        fullWidth={fullWidth}
+      />
+      <NetFluxLegend legend={variant.legend} />
+    </Flex>
+  );
+}

--- a/src/features/net-flux/ui/NetFluxFootnote.tsx
+++ b/src/features/net-flux/ui/NetFluxFootnote.tsx
@@ -1,0 +1,34 @@
+"use client";
+import { Box, Text } from "@chakra-ui/react";
+
+/**
+ * The caveat card the design places below the chart card: agriculture is a
+ * single 2020 figure repeated across every year, so only the land-use portion
+ * of the series actually moves.
+ */
+export function NetFluxFootnote() {
+  return (
+    <Box
+      bg="white"
+      border="1px solid"
+      borderColor="#DDE2F5"
+      rounded="4px"
+      p="12px"
+    >
+      <Text fontFamily="body" fontSize="13px" lineHeight="1.5" color="#656E7B">
+        <Text as="span" fontWeight="semibold">
+          Agriculture
+        </Text>{" "}
+        is a{" "}
+        <Text as="span" fontWeight="semibold">
+          fixed 2020 value
+        </Text>{" "}
+        repeated each year; only{" "}
+        <Text as="span" fontWeight="semibold">
+          Land Use
+        </Text>{" "}
+        varies year to year.
+      </Text>
+    </Box>
+  );
+}

--- a/src/features/net-flux/ui/NetFluxLegend.tsx
+++ b/src/features/net-flux/ui/NetFluxLegend.tsx
@@ -1,0 +1,186 @@
+"use client";
+import { Box, Flex, Text } from "@chakra-ui/react";
+
+import {
+  isPaintReference,
+  type NetFluxLegend as NetFluxLegendSpec,
+  type NetFluxLegendItem,
+} from "../model/net-flux-variants";
+
+const NET_FLUX_LINE_COLOR = "#172b7a";
+
+/**
+ * Hatch patterns for the fixed-2020 agriculture series. Rendered once per
+ * chart into a zero-size SVG; `url(#…)` paint references resolve document-wide,
+ * so both the Recharts bars and the legend swatches below can use them.
+ */
+export function NetFluxHatchDefs() {
+  return (
+    <svg
+      width={0}
+      height={0}
+      aria-hidden
+      focusable="false"
+      style={{ position: "absolute" }}
+    >
+      <defs>
+        <pattern
+          id="net-flux-hatch-livestock"
+          width="6"
+          height="6"
+          patternUnits="userSpaceOnUse"
+          patternTransform="rotate(45)"
+        >
+          <rect width="6" height="6" fill="#d8bd9d" />
+          <line
+            x1="0"
+            y1="0"
+            x2="0"
+            y2="6"
+            stroke="#b9925f"
+            strokeWidth="2.5"
+          />
+        </pattern>
+        <pattern
+          id="net-flux-hatch-cropland"
+          width="6"
+          height="6"
+          patternUnits="userSpaceOnUse"
+          patternTransform="rotate(45)"
+        >
+          <rect width="6" height="6" fill="#e8d5bb" />
+          <line
+            x1="0"
+            y1="0"
+            x2="0"
+            y2="6"
+            stroke="#cbab7d"
+            strokeWidth="2.5"
+          />
+        </pattern>
+        <pattern
+          id="net-flux-hatch-agriculture"
+          width="6"
+          height="6"
+          patternUnits="userSpaceOnUse"
+          patternTransform="rotate(45)"
+        >
+          <rect width="6" height="6" fill="#d8bd9d" />
+          <line
+            x1="0"
+            y1="0"
+            x2="0"
+            y2="6"
+            stroke="#b9925f"
+            strokeWidth="2.5"
+          />
+        </pattern>
+      </defs>
+    </svg>
+  );
+}
+
+/** 14×10 swatch — an SVG rect when the fill is a hatch pattern, else a box. */
+function Swatch({ color }: { color: string }) {
+  if (isPaintReference(color)) {
+    return (
+      <Box as="span" w="14px" h="10px" flexShrink={0} lineHeight={0}>
+        <svg width="14" height="10" aria-hidden focusable="false">
+          <rect width="14" height="10" rx="2" fill={color} />
+        </svg>
+      </Box>
+    );
+  }
+  return <Box w="14px" h="10px" rounded="2px" bg={color} flexShrink={0} />;
+}
+
+function LegendEntry({ item }: { item: NetFluxLegendItem }) {
+  return (
+    <Flex align="center" gap="5px">
+      <Swatch color={item.color} />
+      <Text
+        fontFamily="body"
+        fontSize="9.5px"
+        fontWeight="normal"
+        color="#3A4048"
+      >
+        {item.label}
+      </Text>
+    </Flex>
+  );
+}
+
+/** The "Net flux" line entry — a 16×2 rule rather than a filled swatch. */
+function NetFluxLineEntry() {
+  return (
+    <Flex align="center" gap="5px">
+      <Box w="16px" h="2px" bg={NET_FLUX_LINE_COLOR} flexShrink={0} />
+      <Text
+        fontFamily="body"
+        fontSize="9.5px"
+        fontWeight="normal"
+        color="#3A4048"
+      >
+        Net flux
+      </Text>
+    </Flex>
+  );
+}
+
+function GroupHeading({ children }: { children: string }) {
+  return (
+    <Text
+      fontFamily="mono"
+      fontSize="8px"
+      fontWeight="normal"
+      lineHeight="16px"
+      textTransform="capitalize"
+      color="#737C94"
+    >
+      {children}
+    </Text>
+  );
+}
+
+/**
+ * The design's own legend: emissions and removals as labelled columns with the
+ * net-flux line pinned to the bottom of the removals column, replacing
+ * ChartWidget's generic top-aligned legend. Collapses to a single wrapped row
+ * for the "net" measure, which has no emissions/removals split.
+ */
+export function NetFluxLegend({ legend }: { legend: NetFluxLegendSpec }) {
+  return (
+    <Box bg="#F6F6F6" rounded="4px" p="8px" w="full">
+      {legend.layout === "flat" ? (
+        <Flex wrap="wrap" gap="6px 10px">
+          {legend.emissions.map((item) => (
+            <LegendEntry key={item.label} item={item} />
+          ))}
+          <NetFluxLineEntry />
+        </Flex>
+      ) : (
+        <Flex gap="20px" align="stretch" wrap="wrap">
+          <Flex direction="column" gap="4px">
+            <GroupHeading>Emissions</GroupHeading>
+            <Flex direction="column" gap="4px">
+              {legend.emissions.map((item) => (
+                <LegendEntry key={item.label} item={item} />
+              ))}
+            </Flex>
+          </Flex>
+          <Flex direction="column" justify="space-between" gap="20px">
+            <Flex direction="column" gap="4px">
+              <GroupHeading>Removals</GroupHeading>
+              <Flex direction="column" gap="4px">
+                {legend.removals.map((item) => (
+                  <LegendEntry key={item.label} item={item} />
+                ))}
+              </Flex>
+            </Flex>
+            <NetFluxLineEntry />
+          </Flex>
+        </Flex>
+      )}
+    </Box>
+  );
+}

--- a/src/features/net-flux/ui/NetFluxToolbar.tsx
+++ b/src/features/net-flux/ui/NetFluxToolbar.tsx
@@ -1,0 +1,137 @@
+"use client";
+import { Box, Button, Flex, Menu, Portal, Text } from "@chakra-ui/react";
+import { CaretDownIcon } from "@phosphor-icons/react";
+
+import { useNetFluxView } from "./use-net-flux-view";
+import {
+  DETAIL_LABEL,
+  type NetFluxDetail,
+  type NetFluxMeasure,
+} from "../model/net-flux-variants";
+
+const DETAIL_OPTIONS: NetFluxDetail[] = ["full", "categories", "summary"];
+
+const MEASURE_LABEL: Record<NetFluxMeasure, string> = {
+  gross: "Gross",
+  net: "Net",
+};
+const MEASURE_OPTIONS: NetFluxMeasure[] = ["gross", "net"];
+
+interface PillProps {
+  label: string;
+  value: string;
+  options: { value: string; label: string }[];
+  onSelect: (value: string) => void;
+  disabled?: boolean;
+}
+
+/**
+ * The design's dropdown pill: a mono uppercase label, the current value, and a
+ * caret — distinct from the segmented Chart/Table toggle inside the card.
+ */
+function Pill({ label, value, options, onSelect, disabled }: PillProps) {
+  return (
+    <Menu.Root positioning={{ placement: "bottom-start" }}>
+      <Menu.Trigger asChild>
+        <Button
+          h="24px"
+          minH="24px"
+          px="8px"
+          py="5px"
+          gap="4px"
+          bg="white"
+          border="1px solid"
+          borderColor="#E0E2E5"
+          rounded="4px"
+          variant="outline"
+          disabled={disabled}
+          opacity={disabled ? 0.5 : 1}
+          _hover={disabled ? undefined : { bg: "neutral.100" }}
+          aria-label={`${label}: ${value}`}
+        >
+          <Text
+            fontFamily="mono"
+            fontSize="10px"
+            fontWeight="400"
+            lineHeight="16px"
+            letterSpacing="0.5px"
+            color="#4A64CB"
+          >
+            {label}
+          </Text>
+          <Text
+            fontFamily="body"
+            fontSize="12px"
+            fontWeight="medium"
+            color="#656E7B"
+          >
+            {value}
+          </Text>
+          <CaretDownIcon size={12} color="#656E7B" />
+        </Button>
+      </Menu.Trigger>
+      <Portal>
+        <Menu.Positioner>
+          <Menu.Content minW="160px" zIndex={1400}>
+            {options.map((option) => (
+              <Menu.Item
+                key={option.value}
+                value={option.value}
+                onSelect={() => onSelect(option.value)}
+                fontSize="12px"
+              >
+                {option.label}
+              </Menu.Item>
+            ))}
+          </Menu.Content>
+        </Menu.Positioner>
+      </Portal>
+    </Menu.Root>
+  );
+}
+
+/**
+ * DETAIL / MEASURE controls for the net-flux insight. In the workspace these
+ * sit above the widget card on the shell background, per the design's
+ * "Widget toolbar (reusable)" frame; elsewhere (dashboards, /chart-debug)
+ * `WidgetMessage` renders them inline at the top of the card instead.
+ */
+export function NetFluxToolbar({
+  widgetId,
+  showDivider = true,
+}: {
+  widgetId: string;
+  showDivider?: boolean;
+}) {
+  const { detail, measure, setDetail, setMeasure } = useNetFluxView(widgetId);
+  const isNetOnly = measure === "net";
+
+  return (
+    <Flex direction="column" gap="8px">
+      {showDivider && <Box borderTop="1px solid" borderColor="#DDE2F5" />}
+      <Flex gap="8px" wrap="wrap">
+        <Pill
+          label="DETAIL"
+          // The net measure collapses the breakdown entirely, so the detail
+          // level no longer applies — the design greys the pill out.
+          value={DETAIL_LABEL[detail]}
+          options={DETAIL_OPTIONS.map((value) => ({
+            value,
+            label: DETAIL_LABEL[value],
+          }))}
+          onSelect={(value) => setDetail(value as NetFluxDetail)}
+          disabled={isNetOnly}
+        />
+        <Pill
+          label="MEASURE"
+          value={MEASURE_LABEL[measure]}
+          options={MEASURE_OPTIONS.map((value) => ({
+            value,
+            label: MEASURE_LABEL[value],
+          }))}
+          onSelect={(value) => setMeasure(value as NetFluxMeasure)}
+        />
+      </Flex>
+    </Flex>
+  );
+}

--- a/src/features/net-flux/ui/use-net-flux-view.ts
+++ b/src/features/net-flux/ui/use-net-flux-view.ts
@@ -1,0 +1,29 @@
+import { useCallback } from "react";
+
+import useNetFluxViewStore, {
+  DEFAULT_NET_FLUX_VIEW,
+} from "../model/net-flux-view-store";
+import type { NetFluxDetail, NetFluxMeasure } from "../model/net-flux-variants";
+
+/**
+ * Driving adapter for the net-flux view store: binds the shared DETAIL/MEASURE
+ * selection to React. Lives in `ui` rather than `model` because `model` is the
+ * framework-free core (ADR 0010) — the store itself stays pure.
+ */
+export function useNetFluxView(widgetId: string) {
+  const view = useNetFluxViewStore(
+    (s) => s.byWidget[widgetId] ?? DEFAULT_NET_FLUX_VIEW
+  );
+  const setView = useNetFluxViewStore((s) => s.setView);
+
+  const setDetail = useCallback(
+    (detail: NetFluxDetail) => setView(widgetId, { detail }),
+    [setView, widgetId]
+  );
+  const setMeasure = useCallback(
+    (measure: NetFluxMeasure) => setView(widgetId, { measure }),
+    [setView, widgetId]
+  );
+
+  return { ...view, setDetail, setMeasure };
+}


### PR DESCRIPTION
## Summary
We will launch **LGMS (formerly AFOLU) data (net, gross emissions, gross removals)** before NY Climate Week (starts Sept 23). Big picture, we want to add data that reflects change in the following categories:

- LULUCF (net, gross emissions, gross removals)
- Vegetation (net, gross emissions, gross removals)
- Tree loss (emissions only)
- Tree gain (removals only)
- Trees remaining trees (net, gross emissions, gross removals)
- Non-trees remaining non-trees (net, gross emissions, gross removals)
- Soil (net, gross emissions, gross removals)
- Mineral soil (net, gross emissions, gross removals)
- Organic soil (emissions only)
- Agriculture (emissions only)
- Crop management (emissions only)
- Livestock (emissions only)

## Design
[Figma Designs](https://www.figma.com/design/fUyMHyhGck5FmGEg0HlNHa/-Global-Nature-Watch--Playground?node-id=3146-8660&t=Esj1bzGk4mUsGl23-4)

## Demo
<img width="425" height="698" alt="Screenshot 2026-08-18 at 18 22 13" src="https://github.com/user-attachments/assets/51b57056-6b8f-45bd-bb81-82ead847a146" />

## Acceptance Criteria 
- feature flagged (curated chart)
- no agent
- dummy data to start (shape is known)
- analytics shape is transformed on the api side (project-zeno)