### PR TITLE
[PZB-1248] Implement LGMS Annual Average Net Flux Chart

### DIFF
--- a/app/chart-debug/ChartDebugPanel.tsx
+++ b/app/chart-debug/ChartDebugPanel.tsx
@@ -21,6 +21,7 @@ import CHART_COLOR_MAPPING, {
   DATASET_DIVERGENT_COLORS,
 } from "@/app/config/chartColorMappings";
 import getChartColors from "@/app/utils/ChartColors";
+import { GHG_FLUX_TREE_DUMMY_WIDGET } from "@/src/features/ghg-flux-tree";
 
 // ---------------------------------------------------------------------------
 // Fake provenance data for "View how this was generated" drawer
@@ -616,6 +617,12 @@ const RAW_FIXTURES: { label: string; notes: string; widget: InsightWidget }[] =
       },
     },
     {
+      label: "Hierarchical bar (net GHG flux, annual average)",
+      notes:
+        "Curated 'Net GHG flux (annual average)': indented collapsible tree, diverging bars around zero, top axis. Toggle MEASURE to see the gross view with back-to-back bars, net ticks and n/a markers.",
+      widget: GHG_FLUX_TREE_DUMMY_WIDGET,
+    },
+    {
       label: "Wide table (scroll indicator)",
       notes: "Table with 8+ columns to test horizontal scroll fade indicators.",
       widget: {
@@ -822,7 +829,9 @@ export default function ChartDebugPanel() {
   const filtered = FIXTURES.filter((f) => {
     if (filter === "all") return true;
     if (filter === "bar")
-      return ["bar", "stacked-bar", "grouped-bar"].includes(f.widget.type);
+      return ["bar", "stacked-bar", "grouped-bar", "hierarchical-bar"].includes(
+        f.widget.type
+      );
     if (filter === "line") return ["line", "area"].includes(f.widget.type);
     if (filter === "pie") return f.widget.type === "pie";
     if (filter === "scatter") return f.widget.type === "scatter";

--- a/app/components/CatalogPanel.tsx
+++ b/app/components/CatalogPanel.tsx
@@ -42,6 +42,8 @@ import useSidebarStore from "@/app/store/sidebarStore";
 import type { DatasetInfo } from "@/app/types/chat";
 import { datasetCardLayers } from "@/app/utils/datasetCardLayerContext";
 import { filterDatasetsByCategory } from "@/app/utils/filterDatasetsByCategory";
+import { useFeatureFlag } from "@/src/shared/lib/feature-flags";
+import { LGMS_DATASET_ID } from "@/src/features/ghg-flux-tree";
 
 import { CatalogCard } from "./CatalogCard";
 import { DatasetInfoModal } from "./DatasetInfoModal";
@@ -83,6 +85,7 @@ export default function DataCatalogPanel() {
   const { dataCatalogOpen, setDataCatalogOpen, isChatFullSize } =
     useSidebarStore();
   const leftPx = getCatalogLeftPx(isChatFullSize);
+  const netFluxEnabled = useFeatureFlag("net-flux");
 
   // Build the "in this conversation" set from the visible dataset layers — the
   // layer manager is the source of truth. `useShallow` keeps re-renders stable
@@ -95,10 +98,12 @@ export default function DataCatalogPanel() {
     )
   );
 
-  const cards = useMemo(
-    () => filterDatasetsByCategory(DATASET_CARDS, category, activeDatasetIds),
-    [category, activeDatasetIds]
-  );
+  const cards = useMemo(() => {
+    const visibleCards = netFluxEnabled
+      ? DATASET_CARDS
+      : DATASET_CARDS.filter((card) => card.dataset_id !== LGMS_DATASET_ID);
+    return filterDatasetsByCategory(visibleCards, category, activeDatasetIds);
+  }, [category, activeDatasetIds, netFluxEnabled]);
 
   const compactSlide = !isChatFullSize;
 

--- a/app/components/InsightWorkspace.tsx
+++ b/app/components/InsightWorkspace.tsx
@@ -26,6 +26,10 @@ import AnalysisParametersToggle, {
   AnalysisParamsChips,
 } from "./widgets/AnalysisParameters";
 import { buildChips } from "./widgets/analysis-params-utils";
+import {
+  GhgFluxMeasurePill,
+  isFluxTreeWidget,
+} from "@/src/features/ghg-flux-tree";
 
 /**
  * Placeholder shown while the very first analysis is generating (no chart in
@@ -284,6 +288,14 @@ export default function InsightWorkspace() {
             {hasChips && paramsExpanded && (
               <Box px={4} py={2}>
                 <AnalysisParamsChips chips={chips} />
+              </Box>
+            )}
+
+            {/* Per-widget-type controls, on the shell above the card — the
+                design calls this frame the widget toolbar. */}
+            {isFluxTreeWidget(widget) && (
+              <Box px={2} pb={2}>
+                <GhgFluxMeasurePill widget={widget} />
               </Box>
             )}
 

--- a/app/components/WidgetMessage.tsx
+++ b/app/components/WidgetMessage.tsx
@@ -37,6 +37,11 @@ import { Tooltip } from "@/app/components/ui/tooltip";
 import TableWidget from "./widgets/TableWidget";
 import DatasetCardWidget from "./widgets/DatasetCardWidget";
 import ChartWidget, { AXIS_FIT_TYPES } from "./widgets/ChartWidget";
+import {
+  GhgFluxMeasurePill,
+  GhgFluxTreeBody,
+  isFluxTreeWidget,
+} from "@/src/features/ghg-flux-tree";
 import { WidgetIcons } from "../utils/widgetIcons";
 import AddToDashboardToggle from "@/src/features/dashboards/ui/AddToDashboardToggle";
 import InsightProvenanceDrawer from "./InsightProvenanceDrawer";
@@ -167,8 +172,12 @@ export default function WidgetMessage({
     "area",
     "pie",
     "scatter",
+    "hierarchical-bar",
   ];
   const isChartType = chartTypes.includes(widget.type);
+  // This chart renders its own tree + plot + legend composition rather than
+  // going through ChartWidget, whose axis block assumes vertical bars.
+  const isFluxTree = isFluxTreeWidget(widget);
   const hasData = Array.isArray(widget.data) && widget.data.length > 0;
   const showDisclaimer = (isChartType || widget.type === "table") && hasData;
   const supportsAxisFit = AXIS_FIT_TYPES.has(widget.type);
@@ -203,6 +212,9 @@ export default function WidgetMessage({
         {/* AI-assisted caption — sits above the chart toolbar in the workspace */}
         {inWorkspace && (
           <InsightCaption curated={widget.curated ?? !widget.generation} />
+        )}
+        {isFluxTree && !inWorkspace && (
+          <GhgFluxMeasurePill widget={widget} showDivider={false} />
         )}
         {/* Toolbar row — segmented toggle + full-screen */}
         <Flex justify="flex-start" gap={2} flexWrap="wrap" align="center">
@@ -281,11 +293,15 @@ export default function WidgetMessage({
         {isChartType && !showAsTable && (
           <WidgetErrorBoundary fallbackTitle="Unable to render chart">
             <Box ref={chartRef}>
-              <ChartWidget
-                widget={widget}
-                fitYAxis={fitYAxis}
-                fullWidth={fullWidth}
-              />
+              {isFluxTree ? (
+                <GhgFluxTreeBody widget={widget} />
+              ) : (
+                <ChartWidget
+                  widget={widget}
+                  fitYAxis={fitYAxis}
+                  fullWidth={fullWidth}
+                />
+              )}
             </Box>
           </WidgetErrorBoundary>
         )}
@@ -483,11 +499,15 @@ export default function WidgetMessage({
                 >
                   <Box flex="1" minW={0}>
                     <WidgetErrorBoundary fallbackTitle="Unable to render chart">
-                      <ChartWidget
-                        widget={widget}
-                        expanded
-                        fitYAxis={fitYAxis}
-                      />
+                      {isFluxTree ? (
+                        <GhgFluxTreeBody widget={widget} />
+                      ) : (
+                        <ChartWidget
+                          widget={widget}
+                          expanded
+                          fitYAxis={fitYAxis}
+                        />
+                      )}
                     </WidgetErrorBoundary>
                   </Box>
                   {(widget.description ||

--- a/app/constants/datasets.ts
+++ b/app/constants/datasets.ts
@@ -497,6 +497,27 @@ export const DATASET_CARDS: (DatasetCardConfig & { img?: string })[] = [
       unit: "tCO2e/ha",
     },
   },
+  {
+    dataset_id: 12,
+    dataset_name: "Land GHG Monitoring System (LGMS)",
+    shortName: "LGMS net flux",
+    data_layer: "Land GHG Monitoring System (LGMS)",
+    context_layer: null,
+    img: "/dataset_card_net_flux.webp",
+    cadence: "annual",
+    resolution: "reported per admin area",
+    geographic_coverage:
+      "GADM administrative areas (country, state/province, district) only",
+    provider: "WRI",
+    defaultStartYear: 2016,
+    defaultEndYear: 2024,
+    categories: ["land-use"],
+    description:
+      "Maps annual gross greenhouse-gas emissions, gross CO2 removals, and net GHG flux from land — vegetation, soil, and agriculture — for GADM administrative areas from 2016 to 2024. Values are in MgCO2e; emissions are positive (a source), removals negative (a sink).",
+    // Analytics-only: no map tile layer. Picking this card enables the "View
+    // Analysis" flow for a GADM admin AOI without adding a raster to the map.
+    tile_url: "",
+  },
 ];
 
 // Defaults applied to DatasetInfo when not provided by cards

--- a/app/types/chat.ts
+++ b/app/types/chat.ts
@@ -77,7 +77,8 @@ export interface InsightWidget extends ChartColorFields {
     | "stacked-bar"
     | "grouped-bar"
     | "area"
-    | "scatter";
+    | "scatter"
+    | "hierarchical-bar";
   title: string;
   description: string;
   data: unknown;

--- a/app/utils/datasetCardLayerContext.ts
+++ b/app/utils/datasetCardLayerContext.ts
@@ -32,5 +32,21 @@ export function getLayerContextFromDatasetCard(
 
 /** Build the managed map layers (main + optional sub-layer) for a dataset card. */
 export function datasetCardLayers(card: DatasetCardConfig): Layer[] {
-  return buildDatasetLayers(getLayerContextFromDatasetCard(card));
+  const context = getLayerContextFromDatasetCard(card);
+  if (!context.tileUrl) {
+    // Analytics-only dataset (e.g. LGMS): no raster to render, but the layer
+    // manager is still the source of truth for "is this dataset active" (see
+    // showViewAnalysisNudge). DynamicTileLayers already skips raster layers
+    // with no tileUrl, so this stays safely invisible on the map.
+    return [
+      {
+        id: `dataset-${card.dataset_id}`,
+        name: card.dataset_name,
+        type: "raster",
+        visible: true,
+        datasetId: card.dataset_id,
+      },
+    ];
+  }
+  return buildDatasetLayers(context);
 }

--- a/app/utils/formatCharts.tsx
+++ b/app/utils/formatCharts.tsx
@@ -125,7 +125,11 @@ export default function formatChartData(
     | "stacked-bar"
     | "grouped-bar"
     | "area"
-    | "scatter",
+    | "scatter"
+    // Listed only so ChartWidget's call site typechecks. A hierarchy has no
+    // cartesian axes and gets no branch below: WidgetMessage routes it to the
+    // ghg-flux-tree slice, which builds its own plot, so this never runs for it.
+    | "hierarchical-bar",
   xAxis?: string,
   yAxis?: string,
   datasetName?: string,

--- a/app/utils/widgetIcons.tsx
+++ b/app/utils/widgetIcons.tsx
@@ -25,6 +25,7 @@ export const WidgetIconComponent: Record<InsightWidget["type"], Icon> = {
   scatter: ChartScatterIcon,
   table: ListNumbersIcon,
   "dataset-card": StackIcon,
+  "hierarchical-bar": ChartBarIcon,
 };
 
 /** Element-instance map for inline rendering without size/color overrides. */
@@ -39,4 +40,5 @@ export const WidgetIcons = {
   "dataset-card": <StackIcon />,
   scatter: <ChartScatterIcon />,
   area: <ChartPolarIcon />,
+  "hierarchical-bar": <ChartBarIcon />,
 };

--- a/src/entities/insight/lib/charts-to-widgets.ts
+++ b/src/entities/insight/lib/charts-to-widgets.ts
@@ -12,6 +12,7 @@ const ALLOWED_TYPES = new Set<InsightWidget["type"]>([
   "grouped-bar",
   "area",
   "scatter",
+  "hierarchical-bar",
 ]);
 
 /**

--- a/src/features/analysis/api/__tests__/dataset-override-gateway.test.ts
+++ b/src/features/analysis/api/__tests__/dataset-override-gateway.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it, vi } from "vitest";
+import { DatasetOverrideGateway } from "../dataset-override-gateway";
+import type { AnalysisGateway } from "../../model/analysis-gateway";
+import type { AnalysisSelection } from "../../model/analysis-selection";
+import type { AnalysisResult } from "../../model/analysis-result";
+
+const REAL_DATASET_SELECTION: AnalysisSelection = {
+  area: { name: "Brazil", source: "gadm", srcId: "BRA", subtype: "country" },
+  dataset: { id: 4 },
+  startDate: "2020-01-01",
+  endDate: "2022-12-31",
+};
+
+const OVERRIDDEN_SELECTION: AnalysisSelection = {
+  ...REAL_DATASET_SELECTION,
+  dataset: { id: 12 },
+};
+
+const CANNED_RESULT: AnalysisResult = {
+  id: "canned",
+  charts: [
+    {
+      id: "chart-1",
+      position: 0,
+      title: "Net flux over time",
+      type: "stacked-bar-with-line",
+      xAxis: "year",
+      yAxis: "net_flux_mt",
+      colorField: "",
+      stackField: "category",
+      groupField: "",
+      seriesFields: ["Net flux"],
+      data: [{ year: 2020, "Net flux": 850 }],
+    },
+  ],
+};
+
+function fakeRealGateway(): AnalysisGateway {
+  return {
+    submit: vi.fn().mockResolvedValue({ id: "real-job" }),
+    poll: vi.fn().mockResolvedValue({
+      status: "completed",
+      resources: [
+        {
+          id: "real-job",
+          resourceUrl: "/api/insights/real",
+          status: "completed",
+        },
+      ],
+    }),
+    fetchResult: vi.fn().mockResolvedValue({ id: "real-result", charts: [] }),
+  };
+}
+
+describe("DatasetOverrideGateway", () => {
+  it("passes non-overridden dataset ids straight through to the real gateway", async () => {
+    const real = fakeRealGateway();
+    const gateway = new DatasetOverrideGateway(real, { 12: CANNED_RESULT });
+
+    const job = await gateway.submit(REAL_DATASET_SELECTION);
+    expect(real.submit).toHaveBeenCalledWith(REAL_DATASET_SELECTION, undefined);
+    expect(job).toEqual({ id: "real-job" });
+
+    const outcome = await gateway.poll(job.id);
+    expect(real.poll).toHaveBeenCalledWith("real-job", undefined);
+    expect(outcome.status).toBe("completed");
+
+    if (outcome.status === "completed") {
+      const result = await gateway.fetchResult(
+        outcome.resources[0].resourceUrl
+      );
+      expect(real.fetchResult).toHaveBeenCalled();
+      expect(result).toEqual({ id: "real-result", charts: [] });
+    }
+  });
+
+  it("short-circuits an overridden dataset id without touching the real gateway", async () => {
+    const real = fakeRealGateway();
+    const gateway = new DatasetOverrideGateway(real, { 12: CANNED_RESULT });
+
+    const job = await gateway.submit(OVERRIDDEN_SELECTION);
+    expect(real.submit).not.toHaveBeenCalled();
+
+    const outcome = await gateway.poll(job.id);
+    expect(real.poll).not.toHaveBeenCalled();
+    expect(outcome.status).toBe("completed");
+
+    if (outcome.status === "completed") {
+      const result = await gateway.fetchResult(
+        outcome.resources[0].resourceUrl
+      );
+      expect(real.fetchResult).not.toHaveBeenCalled();
+      expect(result).toBe(CANNED_RESULT);
+    }
+  });
+
+  it("issues a distinct job id per submission so concurrent runs don't collide", async () => {
+    const real = fakeRealGateway();
+    const gateway = new DatasetOverrideGateway(real, { 12: CANNED_RESULT });
+
+    const jobA = await gateway.submit(OVERRIDDEN_SELECTION);
+    const jobB = await gateway.submit(OVERRIDDEN_SELECTION);
+    expect(jobA.id).not.toBe(jobB.id);
+  });
+});

--- a/src/features/analysis/api/dataset-override-gateway.ts
+++ b/src/features/analysis/api/dataset-override-gateway.ts
@@ -1,0 +1,65 @@
+import type {
+  AnalysisGateway,
+  JobRef,
+  JobResource,
+  PollOutcome,
+} from "../model/analysis-gateway";
+import type { AnalysisSelection } from "../model/analysis-selection";
+import type { AnalysisResult } from "../model/analysis-result";
+
+const MOCK_JOB_PREFIX = "mock-dataset-override";
+
+/**
+ * Decorator over a real `AnalysisGateway`: for dataset ids present in
+ * `overrides`, short-circuits the whole submit -> poll -> fetchResult cycle
+ * and resolves immediately with the supplied canned `AnalysisResult`,
+ * skipping the network entirely. Every other dataset id passes straight
+ * through to the wrapped gateway, untouched.
+ *
+ * Temporary WIP-backend shim — delete an override entry (and this class, if
+ * it ends up unused) once the real backend ships a chart generator for the
+ * dataset in question. See `src/features/net-flux` for the current use.
+ */
+export class DatasetOverrideGateway implements AnalysisGateway {
+  private readonly pending = new Map<string, AnalysisResult>();
+  private counter = 0;
+
+  constructor(
+    private readonly real: AnalysisGateway,
+    private readonly overrides: Record<number, AnalysisResult>
+  ) {}
+
+  async submit(
+    selection: AnalysisSelection,
+    signal?: AbortSignal
+  ): Promise<JobRef> {
+    const override = this.overrides[selection.dataset.id];
+    if (!override) return this.real.submit(selection, signal);
+
+    const id = `${MOCK_JOB_PREFIX}-${selection.dataset.id}-${this.counter++}`;
+    this.pending.set(id, override);
+    return { id };
+  }
+
+  async poll(jobId: string, signal?: AbortSignal): Promise<PollOutcome> {
+    if (!this.pending.has(jobId)) return this.real.poll(jobId, signal);
+
+    const resource: JobResource = {
+      id: jobId,
+      resourceUrl: jobId,
+      status: "completed",
+    };
+    return { status: "completed", resources: [resource] };
+  }
+
+  async fetchResult(
+    resourceUrl: string,
+    signal?: AbortSignal
+  ): Promise<AnalysisResult> {
+    const override = this.pending.get(resourceUrl);
+    if (!override) return this.real.fetchResult(resourceUrl, signal);
+
+    this.pending.delete(resourceUrl);
+    return override;
+  }
+}

--- a/src/features/analysis/ui/analysis-service.ts
+++ b/src/features/analysis/ui/analysis-service.ts
@@ -1,11 +1,22 @@
 import type { AnalysisService } from "../model/analysis-service";
 import { LROAnalysisService } from "../model/lro-analysis-service";
 import { RestAnalysisGateway } from "../api/rest-analysis-gateway";
+import { DatasetOverrideGateway } from "../api/dataset-override-gateway";
 import { SystemClock } from "../lib/system-clock";
+import {
+  LGMS_DATASET_ID,
+  GHG_FLUX_TREE_DUMMY_RESULT,
+} from "@/src/features/ghg-flux-tree";
 
 /**
  * Composition root for the analysis use-case: the real LRO service wired to its
  * real driven adapters.
+ *
+ * `DatasetOverrideGateway` is a temporary WIP-backend shim: project-zeno's
+ * `/api/analyze` accepts the LGMS dataset end-to-end but has no chart
+ * generator for it yet, so requests for it resolve to canned data instead of
+ * hitting the network — everything else passes straight through to the real
+ * gateway. Delete the override once the backend ships a real generator.
  *
  * Exported from the slice barrel so other slices can run a non-generative
  * analysis without going through `useAnalysis` — the dashboards slice seeds a
@@ -14,6 +25,8 @@ import { SystemClock } from "../lib/system-clock";
  * performs.
  */
 export const analysisService: AnalysisService = new LROAnalysisService(
-  new RestAnalysisGateway(),
+  new DatasetOverrideGateway(new RestAnalysisGateway(), {
+    [LGMS_DATASET_ID]: GHG_FLUX_TREE_DUMMY_RESULT,
+  }),
   new SystemClock()
 );

--- a/src/features/dashboards/lib/widgets.ts
+++ b/src/features/dashboards/lib/widgets.ts
@@ -14,6 +14,7 @@ const CHART_TYPES = new Set([
   "grouped-bar",
   "area",
   "scatter",
+  "hierarchical-bar",
 ]);
 
 export type WidgetSize = "single" | "double";

--- a/src/features/ghg-flux-tree/index.ts
+++ b/src/features/ghg-flux-tree/index.ts
@@ -1,0 +1,23 @@
+/**
+ * Public API of the `ghg-flux-tree` feature (FSD slice).
+ *
+ * The curated "Net GHG flux (annual average)" insight (LGMS, dataset 12): the
+ * flux hierarchy and its dummy data for the still-WIP backend endpoint.
+ * Consumers import ONLY from this barrel.
+ */
+export {
+  LGMS_DATASET_ID,
+  GHG_FLUX_TREE_DUMMY_RESULT,
+  GHG_FLUX_TREE_DUMMY_WIDGET,
+} from "./model/dummy-data";
+export {
+  isFluxTreeWidget,
+  nodeNet,
+  parseFluxNodes,
+  singleSidedLabel,
+  visibleRows,
+  type FluxMeasure,
+  type FluxNode,
+  type FluxRow,
+} from "./model/hierarchy";
+export { treeViewKey } from "./model/tree-view-store";

--- a/src/features/ghg-flux-tree/index.ts
+++ b/src/features/ghg-flux-tree/index.ts
@@ -1,8 +1,9 @@
 /**
  * Public API of the `ghg-flux-tree` feature (FSD slice).
  *
- * The curated "Net GHG flux (annual average)" insight (LGMS, dataset 12): the
- * flux hierarchy and its dummy data for the still-WIP backend endpoint.
+ * The curated "Net GHG flux (annual average)" insight (LGMS, dataset 12): a
+ * hierarchical diverging bar chart, its dummy data for the still-WIP backend
+ * endpoint, and the MEASURE control the design places outside the widget card.
  * Consumers import ONLY from this barrel.
  */
 export {
@@ -21,3 +22,5 @@ export {
   type FluxRow,
 } from "./model/hierarchy";
 export { treeViewKey } from "./model/tree-view-store";
+export { GhgFluxTreeBody } from "./ui/GhgFluxTreeBody";
+export { GhgFluxMeasurePill } from "./ui/GhgFluxMeasurePill";

--- a/src/features/ghg-flux-tree/model/__tests__/hierarchy.test.ts
+++ b/src/features/ghg-flux-tree/model/__tests__/hierarchy.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it } from "vitest";
+import {
+  expandableIds,
+  isFullyExpanded,
+  nodeNet,
+  parseFluxNodes,
+  rootNodes,
+  singleSidedLabel,
+  visibleRows,
+  type FluxNode,
+} from "../hierarchy";
+
+const node = (over: Partial<FluxNode> & { id: string }): FluxNode => ({
+  parentId: null,
+  label: over.id,
+  avgEmissions: null,
+  avgRemovals: null,
+  ...over,
+});
+
+/** A miniature of the design's tree: root → 2 branches → leaves. */
+const TREE: FluxNode[] = [
+  node({ id: "all", label: "All land", avgEmissions: 1600, avgRemovals: -750 }),
+  node({
+    id: "land",
+    parentId: "all",
+    label: "Land use",
+    avgEmissions: 1350,
+    avgRemovals: -750,
+  }),
+  node({
+    id: "veg",
+    parentId: "land",
+    label: "Vegetation",
+    avgEmissions: 530,
+    avgRemovals: -710,
+  }),
+  node({ id: "loss", parentId: "veg", label: "Tree loss", avgEmissions: 400 }),
+  node({ id: "gain", parentId: "veg", label: "Tree gain", avgRemovals: -560 }),
+  node({
+    id: "agri",
+    parentId: "all",
+    label: "Agriculture",
+    avgEmissions: 250,
+  }),
+  node({
+    id: "crop",
+    parentId: "agri",
+    label: "Crop management",
+    avgEmissions: 150,
+  }),
+  node({
+    id: "live",
+    parentId: "agri",
+    label: "Livestock",
+    avgEmissions: 100,
+  }),
+];
+
+describe("nodeNet", () => {
+  it("sums the two gross figures, removals being negative", () => {
+    expect(nodeNet(TREE[0])).toBe(850);
+    expect(nodeNet(TREE[2])).toBe(-180);
+  });
+
+  it("treats a missing side as zero rather than poisoning the sum", () => {
+    expect(nodeNet(TREE[3])).toBe(400); // emissions only
+    expect(nodeNet(TREE[4])).toBe(-560); // removals only
+  });
+
+  it("returns null only when neither metric applies", () => {
+    expect(nodeNet(node({ id: "x" }))).toBeNull();
+  });
+});
+
+describe("singleSidedLabel", () => {
+  it("names the side a node actually has", () => {
+    expect(singleSidedLabel(TREE[3])).toBe("emissions only");
+    expect(singleSidedLabel(TREE[4])).toBe("removals only");
+  });
+
+  it("is null when both sides are present or both absent", () => {
+    expect(singleSidedLabel(TREE[0])).toBeNull();
+    expect(singleSidedLabel(node({ id: "x" }))).toBeNull();
+  });
+});
+
+describe("visibleRows", () => {
+  it("shows only the root when nothing is expanded", () => {
+    const rows = visibleRows(TREE, new Set());
+    expect(rows.map((r) => r.node.id)).toEqual(["all"]);
+    expect(rows[0]).toMatchObject({ depth: 0, hasChildren: true });
+  });
+
+  it("reveals one level per expanded ancestor", () => {
+    expect(visibleRows(TREE, new Set(["all"])).map((r) => r.node.id)).toEqual([
+      "all",
+      "land",
+      "agri",
+    ]);
+    expect(
+      visibleRows(TREE, new Set(["all", "land"])).map((r) => r.node.id)
+    ).toEqual(["all", "land", "veg", "agri"]);
+  });
+
+  it("hides a subtree whose ancestor is collapsed even if it is expanded", () => {
+    // "veg" is expanded but "land" is not, so its leaves stay hidden.
+    const rows = visibleRows(TREE, new Set(["all", "veg"]));
+    expect(rows.map((r) => r.node.id)).toEqual(["all", "land", "agri"]);
+  });
+
+  it("reports depth and computes each row's net", () => {
+    const rows = visibleRows(TREE, new Set(expandableIds(TREE)));
+    const byId = Object.fromEntries(rows.map((r) => [r.node.id, r]));
+    expect(byId.all.depth).toBe(0);
+    expect(byId.land.depth).toBe(1);
+    expect(byId.veg.depth).toBe(2);
+    expect(byId.loss.depth).toBe(3);
+    expect(byId.loss.hasChildren).toBe(false);
+    expect(byId.veg.net).toBe(-180);
+  });
+
+  it("preserves the order the API sent within a level", () => {
+    const rows = visibleRows(TREE, new Set(["all"]));
+    expect(rows.map((r) => r.node.id)).toEqual(["all", "land", "agri"]);
+  });
+});
+
+describe("expandableIds / isFullyExpanded", () => {
+  it("lists only nodes that have children", () => {
+    expect(expandableIds(TREE).sort()).toEqual(["agri", "all", "land", "veg"]);
+  });
+
+  it("is fully expanded only once every parent is open", () => {
+    expect(isFullyExpanded(TREE, new Set(expandableIds(TREE)))).toBe(true);
+    expect(isFullyExpanded(TREE, new Set(["all", "land"]))).toBe(false);
+  });
+});
+
+describe("parseFluxNodes", () => {
+  it("maps the backend's snake_case rows onto the domain shape", () => {
+    const parsed = parseFluxNodes([
+      {
+        id: "soil",
+        parent_id: "land_use",
+        label: "Soil",
+        avg_emissions: 820,
+        avg_removals: -40,
+      },
+    ]);
+    expect(parsed).toEqual([
+      {
+        id: "soil",
+        parentId: "land_use",
+        label: "Soil",
+        avgEmissions: 820,
+        avgRemovals: -40,
+      },
+    ]);
+  });
+
+  it("normalises a null parent to a root and keeps null metrics null", () => {
+    const [root] = parseFluxNodes([
+      { id: "all_land", parent_id: null, label: "All land", avg_emissions: 10 },
+    ]);
+    expect(root.parentId).toBeNull();
+    expect(root.avgRemovals).toBeNull();
+    expect(rootNodes([root])).toHaveLength(1);
+  });
+
+  it("skips rows with no usable id, and non-array input", () => {
+    expect(parseFluxNodes([{ label: "orphan" }, null, 7])).toEqual([]);
+    expect(parseFluxNodes(undefined)).toEqual([]);
+    expect(parseFluxNodes({})).toEqual([]);
+  });
+
+  it("falls back to the id when a label is missing", () => {
+    expect(parseFluxNodes([{ id: "mineral_soil" }])[0].label).toBe(
+      "mineral_soil"
+    );
+  });
+});

--- a/src/features/ghg-flux-tree/model/dummy-data.ts
+++ b/src/features/ghg-flux-tree/model/dummy-data.ts
@@ -1,0 +1,150 @@
+import type { Chart } from "@/src/entities/insight";
+import { chartsToWidgets } from "@/src/entities/insight";
+import type { AnalysisResult } from "@/src/features/analysis";
+import type { InsightWidget } from "@/app/types/chat";
+
+/**
+ * Land GHG Monitoring System (LGMS) — the dataset behind both curated GHG-flux
+ * insights. Distinct from "Forest greenhouse gas net flux" (dataset 6), whose
+ * catalogue reports a cumulative 2001-2025 total rather than annual values.
+ */
+export const LGMS_DATASET_ID = 12;
+
+/** Value columns, named so the backend's axis validator is satisfied. */
+export const FLUX_SERIES_FIELDS = ["avg_emissions", "avg_removals"];
+
+/**
+ * Annual-average node tree in megatonnes CO2e/yr, taken from the design's
+ * gross frame. Emissions positive, removals negative, `null` where a metric
+ * does not apply — which is exactly the set of rows the design annotates
+ * "emissions only" / "removals only".
+ *
+ * Kept in the backend's snake_case wire shape so it flows through the same
+ * `parseFluxNodes` anti-corruption layer the real endpoint will.
+ */
+const FLUX_TREE_ROWS: Record<string, unknown>[] = [
+  {
+    id: "all_land",
+    parent_id: null,
+    label: "All land",
+    avg_emissions: 1600,
+    avg_removals: -750,
+  },
+  {
+    id: "land_use",
+    parent_id: "all_land",
+    label: "Land use",
+    avg_emissions: 1350,
+    avg_removals: -750,
+  },
+  {
+    id: "vegetation",
+    parent_id: "land_use",
+    label: "Vegetation",
+    avg_emissions: 530,
+    avg_removals: -710,
+  },
+  {
+    id: "tree_loss",
+    parent_id: "vegetation",
+    label: "Tree loss",
+    avg_emissions: 400,
+    avg_removals: null,
+  },
+  {
+    id: "tree_gain",
+    parent_id: "vegetation",
+    label: "Tree gain",
+    avg_emissions: null,
+    avg_removals: -560,
+  },
+  {
+    id: "trees_remaining_trees",
+    parent_id: "vegetation",
+    label: "Trees remaining trees",
+    avg_emissions: 100,
+    avg_removals: -140,
+  },
+  {
+    id: "non_trees_remaining_non_trees",
+    parent_id: "vegetation",
+    label: "Non-trees remaining non-trees",
+    avg_emissions: 30,
+    avg_removals: -10,
+  },
+  {
+    id: "soil",
+    parent_id: "land_use",
+    label: "Soil",
+    avg_emissions: 820,
+    avg_removals: -40,
+  },
+  {
+    id: "mineral_soil",
+    parent_id: "soil",
+    label: "Mineral soil",
+    avg_emissions: 130,
+    avg_removals: -40,
+  },
+  {
+    id: "organic_soil",
+    parent_id: "soil",
+    label: "Organic soil",
+    avg_emissions: 690,
+    avg_removals: null,
+  },
+  {
+    id: "agriculture",
+    parent_id: "all_land",
+    label: "Agriculture",
+    avg_emissions: 250,
+    avg_removals: null,
+  },
+  {
+    id: "cropland",
+    parent_id: "agriculture",
+    label: "Crop management",
+    avg_emissions: 150,
+    avg_removals: null,
+  },
+  {
+    id: "livestock",
+    parent_id: "agriculture",
+    label: "Livestock",
+    avg_emissions: 100,
+    avg_removals: null,
+  },
+];
+
+const FLUX_TREE_CHART: Chart = {
+  id: "ghg-flux-tree-dummy",
+  position: 3,
+  title: "Net GHG flux (annual average)",
+  type: "hierarchical-bar",
+  // A hierarchy has no cartesian axes; the value columns carry the data.
+  xAxis: "",
+  yAxis: "",
+  colorField: "",
+  stackField: "",
+  groupField: "",
+  seriesFields: FLUX_SERIES_FIELDS,
+  data: FLUX_TREE_ROWS,
+};
+
+/**
+ * Canned analysis result for the annual-average chart, keyed into
+ * `DatasetOverrideGateway` until project-zeno ships a chart generator for
+ * dataset 12 (see the backend shape proposal in the implementation plan).
+ */
+export const GHG_FLUX_TREE_DUMMY_RESULT: AnalysisResult = {
+  id: "ghg-flux-tree-dummy-result",
+  charts: [FLUX_TREE_CHART],
+};
+
+/**
+ * The dummy chart mapped through the real Chart -> InsightWidget ACL, so
+ * `/chart-debug` and tests exercise the same mapping real data will.
+ */
+export const GHG_FLUX_TREE_DUMMY_WIDGET: InsightWidget = chartsToWidgets(
+  GHG_FLUX_TREE_DUMMY_RESULT.charts
+)[0];

--- a/src/features/ghg-flux-tree/model/hierarchy.ts
+++ b/src/features/ghg-flux-tree/model/hierarchy.ts
@@ -1,0 +1,157 @@
+import type { InsightWidget } from "@/app/types/chat";
+
+/**
+ * The hierarchical GHG-flux node list, as the API serves it.
+ *
+ * Both value fields are *gross* at every level and `null` where the metric
+ * structurally does not apply (organic soil and agriculture have no removals;
+ * tree gain has no emissions). Removals arrive negative, so a node's net flux
+ * is simply the sum of the two. Parent values come from the API as given —
+ * nothing here re-derives a parent from its children.
+ */
+export interface FluxNode {
+  id: string;
+  parentId: string | null;
+  label: string;
+  /** Gross emissions, positive. Null when the metric doesn't apply. */
+  avgEmissions: number | null;
+  /** Gross removals, negative. Null when the metric doesn't apply. */
+  avgRemovals: number | null;
+}
+
+export type FluxMeasure = "net" | "gross";
+
+/**
+ * This slice is the only producer of the chart type, so the type doubles as the
+ * discriminator for its bespoke rendering path.
+ */
+export function isFluxTreeWidget(widget: InsightWidget): boolean {
+  return widget.type === "hierarchical-bar";
+}
+
+/** A node paired with its position in the visible tree. */
+export interface FluxRow {
+  node: FluxNode;
+  depth: number;
+  hasChildren: boolean;
+  expanded: boolean;
+  /** Gross emissions + gross removals; null when neither applies. */
+  net: number | null;
+}
+
+/** Net flux for a node: the two gross figures summed (removals are negative). */
+export function nodeNet(node: FluxNode): number | null {
+  const { avgEmissions, avgRemovals } = node;
+  if (avgEmissions == null && avgRemovals == null) return null;
+  return (avgEmissions ?? 0) + (avgRemovals ?? 0);
+}
+
+/**
+ * Which single-sided annotation a node warrants in the gross view — the design
+ * labels these rows "emissions only" / "removals only" and draws `n/a` on the
+ * empty side.
+ */
+export function singleSidedLabel(
+  node: FluxNode
+): "emissions only" | "removals only" | null {
+  if (node.avgEmissions != null && node.avgRemovals == null) {
+    return "emissions only";
+  }
+  if (node.avgRemovals != null && node.avgEmissions == null) {
+    return "removals only";
+  }
+  return null;
+}
+
+function childrenByParent(nodes: FluxNode[]): Map<string | null, FluxNode[]> {
+  const index = new Map<string | null, FluxNode[]>();
+  for (const node of nodes) {
+    const siblings = index.get(node.parentId);
+    if (siblings) siblings.push(node);
+    else index.set(node.parentId, [node]);
+  }
+  return index;
+}
+
+/**
+ * Depth-first walk of the tree, emitting only rows whose ancestors are all
+ * expanded. Node order within a level follows the order the API sent, so the
+ * backend keeps control of presentation order.
+ */
+export function visibleRows(
+  nodes: FluxNode[],
+  expanded: ReadonlySet<string>
+): FluxRow[] {
+  const index = childrenByParent(nodes);
+  const rows: FluxRow[] = [];
+
+  const walk = (parentId: string | null, depth: number) => {
+    for (const node of index.get(parentId) ?? []) {
+      const children = index.get(node.id) ?? [];
+      const isExpanded = expanded.has(node.id);
+      rows.push({
+        node,
+        depth,
+        hasChildren: children.length > 0,
+        expanded: isExpanded,
+        net: nodeNet(node),
+      });
+      if (children.length > 0 && isExpanded) walk(node.id, depth + 1);
+    }
+  };
+
+  walk(null, 0);
+  return rows;
+}
+
+/** Every node with children — the fully-expanded expansion set. */
+export function expandableIds(nodes: FluxNode[]): string[] {
+  const parents = new Set(
+    nodes.map((n) => n.parentId).filter((id): id is string => id !== null)
+  );
+  return nodes.filter((n) => parents.has(n.id)).map((n) => n.id);
+}
+
+/** True when nothing is left to open — drives the "Full detail" suffix. */
+export function isFullyExpanded(
+  nodes: FluxNode[],
+  expanded: ReadonlySet<string>
+): boolean {
+  return expandableIds(nodes).every((id) => expanded.has(id));
+}
+
+/** The tree's root nodes (the design shows a single "All land" root). */
+export function rootNodes(nodes: FluxNode[]): FluxNode[] {
+  return nodes.filter((n) => n.parentId === null);
+}
+
+function readNumber(value: unknown): number | null {
+  if (value === null || value === undefined || value === "") return null;
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+/**
+ * Anti-corruption layer for the chart's row shape. `chartsToWidgets` passes
+ * `chart_data` through untouched, so rows arrive in the backend's snake_case;
+ * this is the single place that knows those key names.
+ */
+export function parseFluxNodes(data: unknown): FluxNode[] {
+  if (!Array.isArray(data)) return [];
+  return data.flatMap((raw) => {
+    if (!raw || typeof raw !== "object") return [];
+    const row = raw as Record<string, unknown>;
+    const id = row.id;
+    if (typeof id !== "string" || id === "") return [];
+    const parentId = row.parent_id;
+    return [
+      {
+        id,
+        parentId: typeof parentId === "string" && parentId ? parentId : null,
+        label: typeof row.label === "string" ? row.label : id,
+        avgEmissions: readNumber(row.avg_emissions),
+        avgRemovals: readNumber(row.avg_removals),
+      },
+    ];
+  });
+}

--- a/src/features/ghg-flux-tree/model/tree-view-store.ts
+++ b/src/features/ghg-flux-tree/model/tree-view-store.ts
@@ -1,0 +1,77 @@
+import { create } from "zustand";
+import type { InsightWidget } from "@/app/types/chat";
+import type { FluxMeasure } from "./hierarchy";
+
+export interface TreeView {
+  measure: FluxMeasure;
+  /** Ids of expanded nodes. Undefined until first seeded (fully expanded). */
+  expanded?: string[];
+}
+
+/** Matches the frames, which are all drawn at the fully-expanded detail. */
+export const DEFAULT_MEASURE: FluxMeasure = "net";
+
+interface TreeViewState {
+  byWidget: Record<string, TreeView>;
+  setMeasure: (widgetId: string, measure: FluxMeasure) => void;
+  /** Seeds the expansion set the first time a widget renders. */
+  seedExpanded: (widgetId: string, ids: string[]) => void;
+  toggleNode: (widgetId: string, nodeId: string) => void;
+}
+
+/**
+ * Measure + tree-expansion state for the annual-average chart, keyed by widget
+ * id.
+ *
+ * Shared rather than component-local because the design places the MEASURE pill
+ * outside the widget card (on the workspace shell) while the chart reacting to
+ * it renders inside — two components with no common ancestor that knows about
+ * this chart. Keying by widget id keeps several such insights independent.
+ */
+const useTreeViewStore = create<TreeViewState>((set) => ({
+  byWidget: {},
+  setMeasure: (widgetId, measure) =>
+    set((state) => ({
+      byWidget: {
+        ...state.byWidget,
+        [widgetId]: { ...state.byWidget[widgetId], measure },
+      },
+    })),
+  seedExpanded: (widgetId, ids) =>
+    set((state) => {
+      if (state.byWidget[widgetId]?.expanded) return state;
+      return {
+        byWidget: {
+          ...state.byWidget,
+          [widgetId]: {
+            measure: state.byWidget[widgetId]?.measure ?? DEFAULT_MEASURE,
+            expanded: ids,
+          },
+        },
+      };
+    }),
+  toggleNode: (widgetId, nodeId) =>
+    set((state) => {
+      const view = state.byWidget[widgetId];
+      const current = view?.expanded ?? [];
+      const next = current.includes(nodeId)
+        ? current.filter((id) => id !== nodeId)
+        : [...current, nodeId];
+      return {
+        byWidget: {
+          ...state.byWidget,
+          [widgetId]: {
+            measure: view?.measure ?? DEFAULT_MEASURE,
+            expanded: next,
+          },
+        },
+      };
+    }),
+}));
+
+/** Stable key for a widget's view state; ids are set by `chartsToWidgets`. */
+export function treeViewKey(widget: InsightWidget): string {
+  return widget.id ?? widget.title;
+}
+
+export default useTreeViewStore;

--- a/src/features/ghg-flux-tree/ui/GhgFluxMeasurePill.tsx
+++ b/src/features/ghg-flux-tree/ui/GhgFluxMeasurePill.tsx
@@ -1,0 +1,97 @@
+"use client";
+import { Box, Button, Flex, Menu, Portal, Text } from "@chakra-ui/react";
+import { CaretDownIcon } from "@phosphor-icons/react";
+
+import type { InsightWidget } from "@/app/types/chat";
+
+import { parseFluxNodes, type FluxMeasure } from "../model/hierarchy";
+import { treeViewKey } from "../model/tree-view-store";
+import { useTreeView } from "./use-tree-view";
+
+const MEASURE_LABEL: Record<FluxMeasure, string> = {
+  net: "Net",
+  gross: "Gross",
+};
+const MEASURE_OPTIONS: FluxMeasure[] = ["net", "gross"];
+
+/**
+ * The design's MEASURE dropdown pill. Unlike the time-series insight there is
+ * no DETAIL pill here — detail is driven by the tree's own disclosure carets,
+ * so the "summary" / "categories" / "full view" frames are expansion states
+ * rather than a separate control.
+ *
+ * Rendered on the workspace shell above the widget card, so it reads from the
+ * shared view store rather than taking the selection as a prop.
+ */
+export function GhgFluxMeasurePill({
+  widget,
+  showDivider = true,
+}: {
+  widget: InsightWidget;
+  showDivider?: boolean;
+}) {
+  const nodes = parseFluxNodes(widget.data);
+  const { measure, setMeasure } = useTreeView(treeViewKey(widget), nodes);
+
+  return (
+    <Flex direction="column" gap="8px">
+      {showDivider && <Box borderTop="1px solid" borderColor="#DDE2F5" />}
+      <Flex>
+        <Menu.Root positioning={{ placement: "bottom-start" }}>
+          <Menu.Trigger asChild>
+            <Button
+              h="24px"
+              minH="24px"
+              px="8px"
+              py="5px"
+              gap="4px"
+              bg="white"
+              border="1px solid"
+              borderColor="#E0E2E5"
+              rounded="4px"
+              variant="outline"
+              _hover={{ bg: "neutral.100" }}
+              aria-label={`Measure: ${MEASURE_LABEL[measure]}`}
+            >
+              <Text
+                fontFamily="mono"
+                fontSize="10px"
+                fontWeight="400"
+                lineHeight="16px"
+                letterSpacing="0.5px"
+                color="#4A64CB"
+              >
+                MEASURE
+              </Text>
+              <Text
+                fontFamily="body"
+                fontSize="12px"
+                fontWeight="medium"
+                color="#656E7B"
+              >
+                {MEASURE_LABEL[measure]}
+              </Text>
+              <CaretDownIcon size={12} color="#656E7B" />
+            </Button>
+          </Menu.Trigger>
+          <Portal>
+            <Menu.Positioner>
+              <Menu.Content minW="140px" zIndex={1400}>
+                {MEASURE_OPTIONS.map((option) => (
+                  <Menu.Item
+                    key={option}
+                    value={option}
+                    onSelect={() => setMeasure(option)}
+                    fontSize="12px"
+                  >
+                    {MEASURE_LABEL[option]}
+                  </Menu.Item>
+                ))}
+              </Menu.Content>
+            </Menu.Positioner>
+          </Portal>
+        </Menu.Root>
+      </Flex>
+    </Flex>
+  );
+}

--- a/src/features/ghg-flux-tree/ui/GhgFluxTreeBody.tsx
+++ b/src/features/ghg-flux-tree/ui/GhgFluxTreeBody.tsx
@@ -1,0 +1,129 @@
+"use client";
+import { Box, Flex, Text } from "@chakra-ui/react";
+
+import type { InsightWidget } from "@/app/types/chat";
+
+import {
+  nodeNet,
+  parseFluxNodes,
+  rootNodes,
+  type FluxMeasure,
+} from "../model/hierarchy";
+import { treeViewKey } from "../model/tree-view-store";
+import { GhgFluxTreeChart } from "./GhgFluxTreeChart";
+import {
+  EMISSIONS_COLOR,
+  LEGEND_BG,
+  NET_TICK_COLOR,
+  REMOVALS_COLOR,
+} from "./tree-chart-constants";
+import { useTreeView } from "./use-tree-view";
+
+const signed = new Intl.NumberFormat("en-US", {
+  maximumFractionDigits: 0,
+  signDisplay: "always",
+});
+
+function LegendSwatch({ color }: { color: string }) {
+  return <Box w="12px" h="12px" rounded="2px" bg={color} flexShrink={0} />;
+}
+
+function LegendEntry({ color, label }: { color: string; label: string }) {
+  return (
+    <Flex align="center" gap="6px">
+      <LegendSwatch color={color} />
+      <Text fontFamily="body" fontSize="11px" color="#3A4048">
+        {label}
+      </Text>
+    </Flex>
+  );
+}
+
+/** Emissions/removals key, plus the net marker when the gross view shows one. */
+function TreeLegend({ measure }: { measure: FluxMeasure }) {
+  return (
+    <Flex bg={LEGEND_BG} rounded="4px" p="10px" gap="20px" wrap="wrap" w="full">
+      <LegendEntry color={REMOVALS_COLOR} label="Sink/gross removals (−)" />
+      <LegendEntry color={EMISSIONS_COLOR} label="Source/gross emissions (+)" />
+      {measure === "gross" && (
+        <Flex align="center" gap="6px">
+          <Box w="3px" h="12px" bg={NET_TICK_COLOR} flexShrink={0} />
+          <Text fontFamily="body" fontSize="11px" color="#3A4048">
+            Net
+          </Text>
+        </Flex>
+      )}
+    </Flex>
+  );
+}
+
+/**
+ * Curated "Net GHG flux (annual average)" body: the headline figure, the
+ * hierarchical plot, and the legend. Swapped in by `WidgetMessage` for this
+ * chart type in place of the generic `ChartWidget`, whose axis handling assumes
+ * vertical bars and a fixed height.
+ */
+export function GhgFluxTreeBody({ widget }: { widget: InsightWidget }) {
+  const nodes = parseFluxNodes(widget.data);
+  const { measure, rows, toggleNode, fullyExpanded } = useTreeView(
+    treeViewKey(widget),
+    nodes
+  );
+
+  const root = rootNodes(nodes)[0];
+  const rootNet = root ? nodeNet(root) : null;
+  // Positive net flux means the land is a net source; negative means it absorbs
+  // more than it emits.
+  const direction = (rootNet ?? 0) < 0 ? "Net Sink" : "Net Source";
+  const headlineColor = (rootNet ?? 0) < 0 ? REMOVALS_COLOR : EMISSIONS_COLOR;
+
+  if (nodes.length === 0) {
+    return (
+      <Flex
+        align="center"
+        justify="center"
+        minH="120px"
+        border="1px dashed"
+        borderColor="border"
+        rounded="md"
+        p={4}
+      >
+        <Text fontSize="sm" color="fg.muted">
+          No hierarchy data available for this chart.
+        </Text>
+      </Flex>
+    );
+  }
+
+  return (
+    <Flex direction="column" gap="16px" w="full">
+      <Box>
+        <Flex align="baseline" gap="8px" wrap="wrap">
+          <Text
+            fontFamily="body"
+            fontSize="26px"
+            fontWeight="medium"
+            lineHeight="1.1"
+            color={headlineColor}
+            css={{ fontVariantNumeric: "tabular-nums" }}
+          >
+            {rootNet == null ? "—" : signed.format(rootNet)}
+          </Text>
+          <Text fontFamily="mono" fontSize="11px" color="#656E7B">
+            megatonnes CO2e/yr · {direction}
+            {fullyExpanded ? " · Full detail" : ""}
+          </Text>
+        </Flex>
+        <Text fontFamily="body" fontSize="13px" color="#282D33" mt="2px">
+          Annual average · Land use 2016–24 · Agriculture fixed 2020
+        </Text>
+      </Box>
+
+      <Box overflowX="auto">
+        <GhgFluxTreeChart rows={rows} measure={measure} onToggle={toggleNode} />
+      </Box>
+
+      <TreeLegend measure={measure} />
+    </Flex>
+  );
+}

--- a/src/features/ghg-flux-tree/ui/GhgFluxTreeChart.tsx
+++ b/src/features/ghg-flux-tree/ui/GhgFluxTreeChart.tsx
@@ -1,0 +1,406 @@
+"use client";
+import { Box, Flex, IconButton, Text } from "@chakra-ui/react";
+import { CaretDownIcon, CaretRightIcon, InfoIcon } from "@phosphor-icons/react";
+import {
+  Bar,
+  BarChart,
+  Cell,
+  ReferenceLine,
+  ResponsiveContainer,
+  XAxis,
+  YAxis,
+} from "recharts";
+
+import {
+  singleSidedLabel,
+  type FluxMeasure,
+  type FluxRow,
+} from "../model/hierarchy";
+import {
+  AXIS_HEIGHT,
+  BAR_SIZE,
+  EMISSIONS_COLOR,
+  NET_TICK_COLOR,
+  REMOVALS_COLOR,
+  ROW_HEIGHT,
+  ZERO_LINE_COLOR,
+} from "./tree-chart-constants";
+
+/**
+ * Signed, thousands-separated — the design prints every value with an explicit
+ * sign so a reader never has to infer direction from colour alone.
+ */
+const signed = new Intl.NumberFormat("en-US", {
+  maximumFractionDigits: 0,
+  signDisplay: "always",
+});
+
+interface PlotRow {
+  id: string;
+  avgEmissions: number | null;
+  avgRemovals: number | null;
+  net: number | null;
+}
+
+/** Round step at or above `raw`, from the usual 1/2/2.5/5/10 ladder. */
+function niceStep(raw: number): number {
+  if (!Number.isFinite(raw) || raw <= 0) return 1;
+  const magnitude = 10 ** Math.floor(Math.log10(raw));
+  const base = raw / magnitude;
+  const nice = [1, 2, 2.5, 5, 10].find((candidate) => candidate >= base) ?? 10;
+  return nice * magnitude;
+}
+
+/**
+ * Ticks at round multiples of a nice step, which is what the design shows
+ * (`-500 0 500`) — recharts' automatic ticks land on the padded data bounds
+ * and read as noise (`-216.4 183.6 906.4`). Zero always falls on a multiple,
+ * so the zero line is always labelled.
+ */
+function niceTicks([min, max]: [number, number]): number[] {
+  const step = niceStep((max - min) / 5);
+  const ticks: number[] = [];
+  for (let t = Math.ceil(min / step) * step; t <= max; t += step) {
+    // Snap to the step grid so float drift can't produce -0 or 499.9999.
+    ticks.push(Math.round(t / step) * step);
+  }
+  return ticks;
+}
+
+/**
+ * Bar geometry recharts hands a custom `shape`, plus the row it belongs to.
+ * `x`/`width` are in pixels; with `stackOffset="sign"` a positive bar starts at
+ * the zero pixel and a negative one ends there, which is what lets the shape
+ * recover the scale without measuring the container.
+ */
+interface ShapeProps {
+  x?: number;
+  y?: number;
+  width?: number;
+  height?: number;
+  payload?: PlotRow;
+  side: "emissions" | "removals";
+}
+
+/** Which bar draws the net tick — the side that actually has a value. */
+function tickCarrier(row: PlotRow): "emissions" | "removals" | null {
+  if (row.avgEmissions != null && row.avgEmissions !== 0) return "emissions";
+  if (row.avgRemovals != null && row.avgRemovals !== 0) return "removals";
+  return null;
+}
+
+/**
+ * A gross bar, plus the net tick when this is the row's carrier side.
+ *
+ * Two recharts details drive this. First, in a sign stack `x` is the *zero*
+ * pixel for both signs and `width` carries the direction — a negative bar comes
+ * through with a negative width (an SVG `rect` would silently render nothing),
+ * so the geometry has to be normalised before use. Second, that same signed
+ * width recovers the scale (`|width| / |value|` px per unit), which is what lets
+ * the tick be placed exactly without separately measuring the container.
+ */
+function GrossBar({ x, y, width, height, payload, side }: ShapeProps) {
+  if (x == null || y == null || width == null || height == null || !payload) {
+    return null;
+  }
+
+  const fill = side === "emissions" ? EMISSIONS_COLOR : REMOVALS_COLOR;
+  const value =
+    side === "emissions" ? payload.avgEmissions : payload.avgRemovals;
+  const span = Math.abs(width);
+  const hasBar = value != null && value !== 0 && span > 0;
+  const left = Math.min(x, x + width);
+
+  let tickX: number | null = null;
+  if (tickCarrier(payload) === side && payload.net != null && hasBar) {
+    // `x` is the zero pixel regardless of sign.
+    tickX = x + payload.net * (span / Math.abs(value));
+  }
+
+  return (
+    <g>
+      {hasBar && (
+        <rect x={left} y={y} width={span} height={height} fill={fill} />
+      )}
+      {tickX != null && (
+        <rect
+          x={tickX - 1.5}
+          y={y - 3}
+          width={3}
+          height={height + 6}
+          fill={NET_TICK_COLOR}
+        />
+      )}
+    </g>
+  );
+}
+
+function TreeLabel({
+  row,
+  onToggle,
+}: {
+  row: FluxRow;
+  onToggle: (nodeId: string) => void;
+}) {
+  const isRoot = row.depth === 0;
+  const Caret = row.expanded ? CaretDownIcon : CaretRightIcon;
+  // The root is always open in the design — it carries an info icon, not a
+  // caret — so only descendants get a disclosure control.
+  const showCaret = row.hasChildren && !isRoot;
+
+  return (
+    <Flex
+      h={`${ROW_HEIGHT}px`}
+      align="center"
+      gap="4px"
+      pl={`${row.depth * 16}px`}
+      pr="8px"
+      flexShrink={0}
+    >
+      {showCaret ? (
+        <IconButton
+          size="2xs"
+          variant="plain"
+          h="16px"
+          minW="16px"
+          w="16px"
+          p={0}
+          bg="transparent"
+          color="#656E7B"
+          flexShrink={0}
+          _hover={{ color: "#172B7A" }}
+          onClick={() => onToggle(row.node.id)}
+          aria-expanded={row.expanded}
+          aria-label={`${row.expanded ? "Collapse" : "Expand"} ${row.node.label}`}
+        >
+          <Caret size={12} weight="fill" />
+        </IconButton>
+      ) : (
+        <Box w="12px" flexShrink={0} />
+      )}
+      <Text
+        fontFamily="body"
+        fontSize={isRoot ? "15px" : "13px"}
+        fontWeight={isRoot || row.hasChildren ? "medium" : "normal"}
+        color={isRoot ? "#172B7A" : "#282D33"}
+        lineHeight="1.25"
+      >
+        {row.node.label}
+      </Text>
+      {isRoot && (
+        <Box color="#656E7B" lineHeight={0} flexShrink={0}>
+          <InfoIcon size={13} />
+        </Box>
+      )}
+    </Flex>
+  );
+}
+
+function ValueCell({ row, measure }: { row: FluxRow; measure: FluxMeasure }) {
+  const single = singleSidedLabel(row.node);
+  const showPair =
+    measure === "gross" &&
+    !single &&
+    (row.node.avgEmissions != null || row.node.avgRemovals != null);
+
+  return (
+    <Flex
+      h={`${ROW_HEIGHT}px`}
+      direction="column"
+      align="flex-end"
+      justify="center"
+      pl="12px"
+      flexShrink={0}
+    >
+      <Text
+        fontFamily="body"
+        fontSize="14px"
+        fontWeight="medium"
+        color="#172B7A"
+        css={{ fontVariantNumeric: "tabular-nums" }}
+      >
+        {row.net == null ? "—" : signed.format(row.net)}
+      </Text>
+      {measure === "gross" && (
+        <Text
+          fontFamily="mono"
+          fontSize="10px"
+          color="#565E7B"
+          whiteSpace="nowrap"
+          css={{ fontVariantNumeric: "tabular-nums" }}
+        >
+          {showPair
+            ? `${signed.format(row.node.avgRemovals ?? 0)}/${signed.format(
+                row.node.avgEmissions ?? 0
+              )}`
+            : (single ?? "")}
+        </Text>
+      )}
+    </Flex>
+  );
+}
+
+interface GhgFluxTreeChartProps {
+  rows: FluxRow[];
+  measure: FluxMeasure;
+  onToggle: (nodeId: string) => void;
+}
+
+/**
+ * The design's hierarchical diverging bar chart: an indented collapsible tree,
+ * a shared value scale with its axis on top, and a right-hand value column.
+ *
+ * Recharts owns the bar geometry, scale and axis; the tree and value columns are
+ * HTML because they need multi-line wrapping, click targets and a two-line
+ * value — none of which belong in an SVG tick. Alignment is exact rather than
+ * eyeballed: the chart is `AXIS_HEIGHT + rows * ROW_HEIGHT` tall with zero
+ * vertical margin, so each category band is exactly `ROW_HEIGHT` and lines up
+ * with the HTML row at the same index.
+ */
+export function GhgFluxTreeChart({
+  rows,
+  measure,
+  onToggle,
+}: GhgFluxTreeChartProps) {
+  const plotRows: PlotRow[] = rows.map((row) => ({
+    id: row.node.id,
+    avgEmissions: row.node.avgEmissions,
+    avgRemovals: row.node.avgRemovals,
+    net: row.net,
+  }));
+
+  // Domain from whichever values the active measure actually draws, padded so a
+  // full-length bar doesn't touch the plot edge.
+  const drawn =
+    measure === "net"
+      ? plotRows.map((r) => r.net ?? 0)
+      : plotRows.flatMap((r) => [r.avgEmissions ?? 0, r.avgRemovals ?? 0]);
+  const rawMax = Math.max(0, ...drawn);
+  const rawMin = Math.min(0, ...drawn);
+  const pad = Math.max(rawMax - rawMin, 1) * 0.04;
+  const domain: [number, number] = [rawMin - pad, rawMax + pad];
+  const ticks = niceTicks(domain);
+  const zeroFraction = (0 - domain[0]) / (domain[1] - domain[0]);
+
+  const height = AXIS_HEIGHT + rows.length * ROW_HEIGHT;
+
+  return (
+    <Flex align="flex-start" w="full">
+      {/* Tree column */}
+      <Flex direction="column" flexShrink={0}>
+        <Box h={`${AXIS_HEIGHT}px`} />
+        {rows.map((row) => (
+          <TreeLabel key={row.node.id} row={row} onToggle={onToggle} />
+        ))}
+      </Flex>
+
+      {/* Plot column */}
+      <Box flex="1" minW="80px" position="relative">
+        <ResponsiveContainer width="100%" height={height}>
+          <BarChart
+            data={plotRows}
+            layout="vertical"
+            stackOffset="sign"
+            margin={{ top: 0, right: 0, bottom: 0, left: 0 }}
+          >
+            <XAxis
+              type="number"
+              orientation="top"
+              domain={domain}
+              ticks={ticks}
+              // Without this recharts' default interval quietly drops ticks it
+              // thinks would crowd, losing the negative end of the scale.
+              interval={0}
+              height={AXIS_HEIGHT}
+              tickLine={false}
+              axisLine={{ stroke: "#E7EBF5" }}
+              tick={{ fontSize: 10, fill: "#9AA0AB" }}
+            />
+            <YAxis type="category" dataKey="id" hide />
+            <ReferenceLine x={0} stroke={ZERO_LINE_COLOR} strokeWidth={1} />
+            {measure === "net" ? (
+              <Bar dataKey="net" barSize={BAR_SIZE} isAnimationActive={false}>
+                {plotRows.map((row) => (
+                  <Cell
+                    key={row.id}
+                    fill={(row.net ?? 0) < 0 ? REMOVALS_COLOR : EMISSIONS_COLOR}
+                  />
+                ))}
+              </Bar>
+            ) : (
+              <>
+                <Bar
+                  dataKey="avgRemovals"
+                  stackId="flux"
+                  barSize={BAR_SIZE}
+                  isAnimationActive={false}
+                  shape={<GrossBar side="removals" />}
+                />
+                <Bar
+                  dataKey="avgEmissions"
+                  stackId="flux"
+                  barSize={BAR_SIZE}
+                  isAnimationActive={false}
+                  shape={<GrossBar side="emissions" />}
+                />
+              </>
+            )}
+          </BarChart>
+        </ResponsiveContainer>
+
+        {/* `n/a` markers sit on the empty side of zero for single-sided rows.
+            Positioned off the same domain the axis uses, so they track it. */}
+        {measure === "gross" &&
+          rows.map((row, index) => {
+            const single = singleSidedLabel(row.node);
+            if (!single) return null;
+            const onRight = single === "removals only";
+            return (
+              <Text
+                key={row.node.id}
+                position="absolute"
+                top={`${AXIS_HEIGHT + index * ROW_HEIGHT}px`}
+                h={`${ROW_HEIGHT}px`}
+                left={`${zeroFraction * 100}%`}
+                transform={
+                  onRight
+                    ? "translateX(6px)"
+                    : "translateX(-6px) translateX(-100%)"
+                }
+                display="flex"
+                alignItems="center"
+                fontFamily="mono"
+                fontSize="9px"
+                color="#9AA0AB"
+                pointerEvents="none"
+              >
+                n/a
+              </Text>
+            );
+          })}
+      </Box>
+
+      {/* Value column */}
+      <Flex direction="column" flexShrink={0}>
+        <Flex
+          h={`${AXIS_HEIGHT}px`}
+          align="center"
+          justify="flex-end"
+          pl="12px"
+        >
+          <Text
+            fontFamily="mono"
+            fontSize="10px"
+            color="#9AA0AB"
+            whiteSpace="nowrap"
+          >
+            Mt CO₂e/yr
+          </Text>
+        </Flex>
+        {rows.map((row) => (
+          <ValueCell key={row.node.id} row={row} measure={measure} />
+        ))}
+      </Flex>
+    </Flex>
+  );
+}

--- a/src/features/ghg-flux-tree/ui/tree-chart-constants.ts
+++ b/src/features/ghg-flux-tree/ui/tree-chart-constants.ts
@@ -1,0 +1,27 @@
+/**
+ * Palette and metrics for the hierarchical flux chart.
+ *
+ * The colours were sampled from the design's own PNG export (the Figma MCP was
+ * rate-limited), reading the legend swatches and bar fills directly rather than
+ * eyeballing them.
+ */
+
+/** Source / gross emissions — positive, right of zero. */
+export const EMISSIONS_COLOR = "#bf812d";
+/** Sink / gross removals — negative, left of zero. */
+export const REMOVALS_COLOR = "#01665e";
+/** The net marker overlaid on a gross row. */
+export const NET_TICK_COLOR = "#1a1812";
+export const ZERO_LINE_COLOR = "#9aa0ab";
+/** Panel behind the legend. */
+export const LEGEND_BG = "#f6f6f6";
+
+/**
+ * One row per tree node. Uniform because recharts' category bands are uniform —
+ * the HTML tree/value columns are laid out at the same pitch so the two line up
+ * without measuring anything.
+ */
+export const ROW_HEIGHT = 48;
+/** Reserved for the top axis; the flanking columns pad by the same amount. */
+export const AXIS_HEIGHT = 28;
+export const BAR_SIZE = 14;

--- a/src/features/ghg-flux-tree/ui/use-tree-view.ts
+++ b/src/features/ghg-flux-tree/ui/use-tree-view.ts
@@ -1,0 +1,59 @@
+import { useCallback, useEffect, useMemo } from "react";
+
+import useTreeViewStore, { DEFAULT_MEASURE } from "../model/tree-view-store";
+import {
+  expandableIds,
+  isFullyExpanded,
+  visibleRows,
+  type FluxMeasure,
+  type FluxNode,
+} from "../model/hierarchy";
+
+/**
+ * Driving adapter for the tree-view store: binds measure + expansion to React
+ * and derives the visible rows. Lives in `ui` rather than `model` because
+ * `model` is the framework-free core (ADR 0010).
+ *
+ * The expansion set is seeded fully-expanded on first render — the design's
+ * frames are all drawn at full detail, and "summary"/"categories" are just
+ * collapsed states the user can reach from there.
+ */
+export function useTreeView(widgetId: string, nodes: FluxNode[]) {
+  const view = useTreeViewStore((s) => s.byWidget[widgetId]);
+  const setMeasureRaw = useTreeViewStore((s) => s.setMeasure);
+  const seedExpanded = useTreeViewStore((s) => s.seedExpanded);
+  const toggleNodeRaw = useTreeViewStore((s) => s.toggleNode);
+
+  const allExpandable = useMemo(() => expandableIds(nodes), [nodes]);
+
+  // Seed once per widget. Runs in an effect rather than during render so the
+  // store isn't written mid-render.
+  useEffect(() => {
+    if (allExpandable.length > 0) seedExpanded(widgetId, allExpandable);
+  }, [seedExpanded, widgetId, allExpandable]);
+
+  const measure: FluxMeasure = view?.measure ?? DEFAULT_MEASURE;
+  // Before the seed lands, treat everything as open so the first paint matches
+  // the settled state instead of flashing a collapsed tree.
+  const expanded = useMemo(
+    () => new Set(view?.expanded ?? allExpandable),
+    [view?.expanded, allExpandable]
+  );
+
+  const rows = useMemo(() => visibleRows(nodes, expanded), [nodes, expanded]);
+  const fullyExpanded = useMemo(
+    () => isFullyExpanded(nodes, expanded),
+    [nodes, expanded]
+  );
+
+  const setMeasure = useCallback(
+    (next: FluxMeasure) => setMeasureRaw(widgetId, next),
+    [setMeasureRaw, widgetId]
+  );
+  const toggleNode = useCallback(
+    (nodeId: string) => toggleNodeRaw(widgetId, nodeId),
+    [toggleNodeRaw, widgetId]
+  );
+
+  return { measure, setMeasure, rows, toggleNode, fullyExpanded };
+}


### PR DESCRIPTION
## Summary
We will launch **LGMS (formerly AFOLU) data (net, gross emissions, gross removals)** before NY Climate Week (starts Sept 23). Big picture, we want to add data that reflects change in the following categories:

- LULUCF (net, gross emissions, gross removals)
- Vegetation (net, gross emissions, gross removals)
- Tree loss (emissions only)
- Tree gain (removals only)
- Trees remaining trees (net, gross emissions, gross removals)
- Non-trees remaining non-trees (net, gross emissions, gross removals)
- Soil (net, gross emissions, gross removals)
- Mineral soil (net, gross emissions, gross removals)
- Organic soil (emissions only)
- Agriculture (emissions only)
- Crop management (emissions only)
- Livestock (emissions only)

## Design
[Figma Designs](https://www.figma.com/design/fUyMHyhGck5FmGEg0HlNHa/-Global-Nature-Watch--Playground?node-id=3146-8660&t=Esj1bzGk4mUsGl23-4)

## Demo
<img width="554" height="798" alt="Screenshot 2026-08-20 at 15 41 05" src="https://github.com/user-attachments/assets/dabdad91-b109-4617-87ba-ab1229ecb31d" />

## Acceptance Criteria 
- feature flagged (curated chart)
- no agent
- dummy data to start (shape is known)
- analytics shape is transformed on the api side (project-zeno)