### PR TITLE
feat(dashboards): derive module caption provenance from the insight

### DIFF
--- a/src/features/dashboards/lib/__tests__/widgets.test.ts
+++ b/src/features/dashboards/lib/__tests__/widgets.test.ts
@@ -510,6 +510,20 @@ describe("insightModule", () => {
     expect(vm.cards).toEqual([]);
     expect(vm.allCharts).toEqual([]);
   });
+
+  it("derives curated from the generation provenance, like the cards do", () => {
+    // The default fixture has no codeact parts.
+    expect(insightModule(widget()).curated).toBe(true);
+    const generated = widget({
+      insight: {
+        id: "ins-1",
+        insight_text: "Loss rose 12%.",
+        codeact_parts: [{ type: "code", content: "df.plot()" }],
+        charts: [chart()],
+      },
+    });
+    expect(insightModule(generated).curated).toBe(false);
+  });
 });
 
 describe("dashboardWidgetToInsightWidgets — chartIds filtering", () => {

--- a/src/features/dashboards/lib/widgets.ts
+++ b/src/features/dashboards/lib/widgets.ts
@@ -325,21 +325,6 @@ export function insightModule(
   };
 }
 
-/**
- * Maps a dashboard insight widget (snake_case REST shape) to the
- * `InsightWidget`s consumed by `WidgetMessage` — the persisted counterpart
- * of `generateInsightsTool`, which produces one card per chart. Only the
- * widget's shown charts (`config.chartIds`, or all when absent) are returned.
- * Returns `[]` when there is nothing to render (insight hidden from this
- * viewer, or no shown charts); the caller shows a "not available" placeholder
- * per the API contract.
- *
- * The widget's `config.title` override and the insight narrative apply to
- * the first chart (the card's visual header); provenance parts feed the
- * "view how this was generated" drawer. The API insight carries no analysis
- * parameters, but a dashboard is scoped to exactly one area — pass its name
- * as `areaName` so every card gets an AREA param chip.
- */
 /** The insight's well-formed provenance parts; [] when absent or malformed. */
 function insightCodeactParts(
   insight: DashboardWidget["insight"]
@@ -355,6 +340,21 @@ function insightCodeactParts(
     : [];
 }
 
+/**
+ * Maps a dashboard insight widget (snake_case REST shape) to the
+ * `InsightWidget`s consumed by `WidgetMessage` — the persisted counterpart
+ * of `generateInsightsTool`, which produces one card per chart. Only the
+ * widget's shown charts (`config.chartIds`, or all when absent) are returned.
+ * Returns `[]` when there is nothing to render (insight hidden from this
+ * viewer, or no shown charts); the caller shows a "not available" placeholder
+ * per the API contract.
+ *
+ * The widget's `config.title` override and the insight narrative apply to
+ * the first chart (the card's visual header); provenance parts feed the
+ * "view how this was generated" drawer. The API insight carries no analysis
+ * parameters, but a dashboard is scoped to exactly one area — pass its name
+ * as `areaName` so every card gets an AREA param chip.
+ */
 export function dashboardWidgetToInsightWidgets(
   widget: DashboardWidget,
   { areaName }: { areaName?: string } = {}

--- a/src/features/dashboards/lib/widgets.ts
+++ b/src/features/dashboards/lib/widgets.ts
@@ -286,6 +286,12 @@ export interface InsightModuleView {
   /** The narrative to render; "" when absent or blank. */
   summaryText: string;
   summaryShown: boolean;
+  /**
+   * No generation provenance ⇒ curated — the same rule `WidgetMessage`
+   * applies to each card, so the module caption never contradicts the cards
+   * beneath it.
+   */
+  curated: boolean;
   cards: InsightWidget[];
   allCharts: { id: string; title: string; shown: boolean }[];
 }
@@ -309,6 +315,7 @@ export function insightModule(
       ? widget.insight.insight_text
       : "",
     summaryShown: isSummaryShown(widget.config),
+    curated: insightCodeactParts(widget.insight).length === 0,
     cards: dashboardWidgetToInsightWidgets(widget, { areaName }),
     allCharts: charts.map((chart) => ({
       id: chart.id,
@@ -333,14 +340,11 @@ export function insightModule(
  * parameters, but a dashboard is scoped to exactly one area — pass its name
  * as `areaName` so every card gets an AREA param chip.
  */
-export function dashboardWidgetToInsightWidgets(
-  widget: DashboardWidget,
-  { areaName }: { areaName?: string } = {}
-): InsightWidget[] {
-  const insight = widget.insight;
-  if (!insight?.charts?.length) return [];
-
-  const codeactParts = Array.isArray(insight.codeact_parts)
+/** The insight's well-formed provenance parts; [] when absent or malformed. */
+function insightCodeactParts(
+  insight: DashboardWidget["insight"]
+): CodeActPart[] {
+  return Array.isArray(insight?.codeact_parts)
     ? insight.codeact_parts.filter(
         (p): p is CodeActPart =>
           typeof p === "object" &&
@@ -349,6 +353,16 @@ export function dashboardWidgetToInsightWidgets(
           typeof (p as CodeActPart).content === "string"
       )
     : [];
+}
+
+export function dashboardWidgetToInsightWidgets(
+  widget: DashboardWidget,
+  { areaName }: { areaName?: string } = {}
+): InsightWidget[] {
+  const insight = widget.insight;
+  if (!insight?.charts?.length) return [];
+
+  const codeactParts = insightCodeactParts(insight);
   const generation = codeactParts.length
     ? { codeact_parts: codeactParts }
     : undefined;

--- a/src/features/dashboards/ui/DashboardInsightModule.tsx
+++ b/src/features/dashboards/ui/DashboardInsightModule.tsx
@@ -9,6 +9,7 @@ import {
   XIcon,
 } from "@phosphor-icons/react";
 
+import InsightCaption from "@/app/components/InsightCaption";
 import type { InsightWidget } from "@/app/types/chat";
 import type { Dashboard, DashboardWidget } from "../api/schemas";
 import { packCells } from "../lib/packing";
@@ -219,26 +220,14 @@ export default function DashboardInsightModule({
       {!collapsed && (
         <>
           {showSummary && (
-            <Text fontSize="16px" lineHeight="24px" color="fg">
-              {vm.summaryText}{" "}
-              {/* Inline "AI generated" chip per the design, riding at the
-                  end of the narrative. */}
-              <Box
-                as="span"
-                display="inline-block"
-                px="4px"
-                borderRadius="4px"
-                bg="#D7DFF2"
-                color="#3855A3"
-                fontSize="10px"
-                fontFamily="mono"
-                lineHeight="16px"
-                verticalAlign="2px"
-                whiteSpace="nowrap"
-              >
-                AI generated
-              </Box>
-            </Text>
+            <Flex direction="column" gap="8px">
+              {/* Same provenance rule as the cards below, so the module
+                  header never contradicts them. */}
+              <InsightCaption curated={vm.curated} />
+              <Text fontSize="16px" lineHeight="24px" color="fg">
+                {vm.summaryText}
+              </Text>
+            </Flex>
           )}
 
           {!hasCharts ? (

--- a/src/features/dashboards/ui/__tests__/DashboardInsightModule.test.tsx
+++ b/src/features/dashboards/ui/__tests__/DashboardInsightModule.test.tsx
@@ -53,7 +53,8 @@ function widget(overrides: Partial<DashboardWidget> = {}): DashboardWidget {
     insight: {
       id: "ins-1",
       insight_text: "There were 1,055 disturbance alerts.",
-      codeact_parts: null,
+      // Provenance present ⇒ the AI-assisted caption (mirrors WidgetMessage).
+      codeact_parts: [{ type: "code", content: "df.plot()" }],
       charts: [
         chart(),
         chart({ id: "c-2", position: 1, title: "Alerts by month" }),
@@ -90,13 +91,13 @@ function renderModule({
 }
 
 describe("DashboardInsightModule", () => {
-  it("renders the header title, summary with AI chip, and one card per shown chart", () => {
+  it("renders the header title, summary with the AI caption, and one card per shown chart", () => {
     renderModule();
     expect(
       screen.getByText(/There were 1,055 disturbance alerts\./)
     ).toBeTruthy();
-    // The design's inline "AI generated" chip rides at the end of the summary.
-    expect(screen.getByText("AI generated")).toBeTruthy();
+    // The shared InsightCaption badge, as on workspace insight cards.
+    expect(screen.getByText(/AI-ASSISTED/)).toBeTruthy();
     const cards = screen.getAllByTestId("widget-message");
     expect(cards.map((c) => c.textContent)).toEqual([
       "Disturbance alerts trend",
@@ -104,12 +105,27 @@ describe("DashboardInsightModule", () => {
     ]);
   });
 
+  it("shows the curated caption when the insight has no generation provenance", () => {
+    renderModule({
+      widget: widget({
+        insight: {
+          id: "ins-1",
+          insight_text: "There were 1,055 disturbance alerts.",
+          codeact_parts: null,
+          charts: [chart()],
+        },
+      }),
+    });
+    expect(screen.getByText(/CURATED/)).toBeTruthy();
+    expect(screen.queryByText(/AI-ASSISTED/)).toBe(null);
+  });
+
   it("hides the summary when config says so", () => {
     renderModule({ widget: widget({ config: { summaryHidden: true } }) });
     expect(screen.queryByText(/There were 1,055 disturbance alerts\./)).toBe(
       null
     );
-    expect(screen.queryByText("AI generated")).toBe(null);
+    expect(screen.queryByText(/AI-ASSISTED/)).toBe(null);
     expect(screen.getAllByTestId("widget-message")).toHaveLength(2);
   });
 


### PR DESCRIPTION
## What this does

**Before:** the dashboard insight module's summary carried a hand-rolled inline "AI generated" chip, hardcoded regardless of provenance — while the chart cards beneath it derive curated vs. AI-assisted from the insight's generation provenance. An insight with no `codeact_parts` showed "AI generated" in the header above green CURATED cards.

**After:** the module renders the shared `InsightCaption` badge (as on workspace insight cards), with `curated` derived from the generation provenance using the same rule `WidgetMessage` applies to each card — so the module header can never contradict the cards beneath it.

<img width="1196" height="434" alt="Screenshot 2026-08-25 at 13 03 10" src="https://github.com/user-attachments/assets/96a1ef5d-f4d1-4e9b-8178-99e9288a0abe" />

## Changes

- `widgets.ts`: extract `insightCodeactParts` (shared with `dashboardWidgetToInsightWidgets`) and add `curated` to the `InsightModuleView` view model.
- `DashboardInsightModule.tsx`: replace the inline chip with `<InsightCaption curated={vm.curated} />` above the narrative.
- Tests: module caption assertions for both variants, plus a unit test pinning the `curated` derivation.

## Testing

- `pnpm test src/features/dashboards` 267/267
- `pnpm typecheck`, `pnpm format:check` clean (also enforced by the pre-push hook)
