### PR TITLE
Add IFL to existing dataset drawer UI

### DIFF
--- a/app/components/CatalogPanel.tsx
+++ b/app/components/CatalogPanel.tsx
@@ -19,6 +19,7 @@ import {
   EyeIcon,
   EyeSlashIcon,
   StackPlusIcon,
+  StackSimpleIcon,
   XIcon,
 } from "@phosphor-icons/react";
 import { useShallow } from "zustand/react/shallow";
@@ -280,13 +281,25 @@ function CatalogCardRow({ card }: { card: DatasetCardConfig }) {
       />
       <CatalogCard
         thumbnail={
-          <Image
-            objectFit="cover"
-            w="100%"
-            h="100%"
-            src={card.img ?? "/globe.svg"}
-            alt={card.dataset_name}
-          />
+          card.img ? (
+            <Image
+              objectFit="cover"
+              w="100%"
+              h="100%"
+              src={card.img}
+              alt={card.dataset_name}
+            />
+          ) : (
+            <Flex
+              w="100%"
+              h="100%"
+              align="center"
+              justify="center"
+              bg="gray.50"
+            >
+              <StackSimpleIcon size={32} color="#656E7B" />
+            </Flex>
+          )
         }
         typeLabel={card.viewOnly ? "VIEW ONLY" : "DATA"}
         typeLabelColor={card.viewOnly ? "#656E7B" : "#1AA915"}

--- a/app/components/CatalogPanel.tsx
+++ b/app/components/CatalogPanel.tsx
@@ -42,6 +42,8 @@ import useSidebarStore from "@/app/store/sidebarStore";
 import type { DatasetInfo } from "@/app/types/chat";
 import { datasetCardLayers } from "@/app/utils/datasetCardLayerContext";
 import { filterDatasetsByCategory } from "@/app/utils/filterDatasetsByCategory";
+import { filterDatasetsByFeatureFlag } from "@/app/utils/filterDatasetsByFeatureFlag";
+import { useEnabledFlags } from "@/src/shared/lib/feature-flags";
 
 import { CatalogCard } from "./CatalogCard";
 import { DatasetInfoModal } from "./DatasetInfoModal";
@@ -95,9 +97,18 @@ export default function DataCatalogPanel() {
     )
   );
 
+  // Flag-gated cards are hidden from the catalogue until their flag is on.
+  // Safe to branch on here: the panel only renders once the user opens it, so
+  // the flagged list never differs between the server render and hydration.
+  const enabledFlags = useEnabledFlags();
   const cards = useMemo(
-    () => filterDatasetsByCategory(DATASET_CARDS, category, activeDatasetIds),
-    [category, activeDatasetIds]
+    () =>
+      filterDatasetsByCategory(
+        filterDatasetsByFeatureFlag(DATASET_CARDS, enabledFlags),
+        category,
+        activeDatasetIds
+      ),
+    [category, activeDatasetIds, enabledFlags]
   );
 
   const compactSlide = !isChatFullSize;

--- a/app/components/ContextMenu.tsx
+++ b/app/components/ContextMenu.tsx
@@ -30,6 +30,8 @@ const CONTEXT_NAV = (Object.keys(ChatContextOptions) as ChatContextType[])
   }));
 
 import { DATASET_CARDS, DatasetCardConfig } from "../constants/datasets";
+import { filterDatasetsByFeatureFlag } from "@/app/utils/filterDatasetsByFeatureFlag";
+import { useEnabledFlags } from "@/src/shared/lib/feature-flags";
 import { useCustomAreasListSuspense } from "../hooks/useCustomAreasList";
 import type { CustomArea } from "../schemas/api/custom_areas/get";
 import useMapStore from "../store/mapStore";
@@ -87,6 +89,11 @@ function LayerCardList({
   cards: (DatasetCardConfig & { img?: string })[];
 }) {
   const { layers, addLayer, removeDatasetLayers } = useMapStore();
+  // Same gate as the Data Catalog — a flagged dataset is browsable in neither
+  // surface until its flag is on. The menu is a dialog, so this only renders
+  // after the user opens it (no SSR/hydration branch).
+  const enabledFlags = useEnabledFlags();
+  const visibleCards = filterDatasetsByFeatureFlag(cards, enabledFlags);
 
   function handleToggle(card: DatasetCardConfig & { img?: string }) {
     const isSelected = layers.some((l) => l.datasetId === card.dataset_id);
@@ -101,7 +108,7 @@ function LayerCardList({
 
   return (
     <Stack minH={0} overflowY="auto">
-      {cards.map((card) => {
+      {visibleCards.map((card) => {
         const isSelected = layers.some((l) => l.datasetId === card.dataset_id);
         return (
           // flexShrink={0} pins the card height in the scrollable list so the

--- a/app/constants/datasets.ts
+++ b/app/constants/datasets.ts
@@ -65,6 +65,13 @@ export type DatasetCardConfig = {
   methodology?: string;
   citation?: string;
   viewOnly?: boolean;
+  /**
+   * Gates the card behind a URL feature flag (`?ff=<flag>`): browse surfaces
+   * (Data Catalog, layer menu) only list it while the flag is on. The card
+   * stays in `DATASET_CARDS` either way, so a layer that is already on the map
+   * keeps resolving its legend.
+   */
+  featureFlag?: string;
   defaultStartYear?: number;
   defaultEndYear?: number;
   /**
@@ -135,6 +142,20 @@ export const CONTEXT_LAYER_METADATA: Record<string, ContextLayerMetadata> = {
     },
   },
 };
+
+/**
+ * Feature flag gating the standalone Intact Forest Landscapes card while
+ * researchers review it (PZB-1231). Opt in with `?ff=ifl`.
+ */
+export const IFL_FEATURE_FLAG = "ifl";
+
+/**
+ * Standalone IFL raster tiles. Same endpoint the backend hands back as the
+ * `intact_forest` context layer, so the card and the context sub-layer render
+ * from one source.
+ */
+const INTACT_FOREST_TILE_URL =
+  "https://tiles.globalforestwatch.org/ifl_intact_forest_landscapes/v2025/default/{z}/{x}/{y}.png";
 
 export const DATASET_CARDS: (DatasetCardConfig & { img?: string })[] = [
   {
@@ -260,6 +281,26 @@ export const DATASET_CARDS: (DatasetCardConfig & { img?: string })[] = [
       info: 'The Natural lands dataset is the best match because it provides a 2020 baseline map of natural vs non-natural land covers at 30m resolution, which can be used to identify intact/natural landscapes. This dataset specifically defines "natural" ecosystems as those that substantially resemble what would be found without major human impacts, making it ideal for assessing landscape intactness across Canadian provinces.',
       note: "Baseline map separating natural from non-natural lands for conversion assessments. This map may overestimate the extent of natural lands.",
     },
+  },
+  {
+    // Contextual-only layer: IFL has no analytics endpoint, so the card is
+    // flagged `viewOnly` and the catalogue badges it VIEW ONLY. Name, colors
+    // and description are reused from the context-layer metadata above so the
+    // standalone layer and the sub-layer under Tree Cover Loss stay identical.
+    dataset_id: CONTEXT_LAYER_METADATA.intact_forest.dataset_id,
+    dataset_name: CONTEXT_LAYER_METADATA.intact_forest.dataset_name,
+    shortName: "Intact forests",
+    context_layer: null,
+    cadence: "2000-2025",
+    resolution: "30 m",
+    geographic_coverage: "global",
+    provider: "IFL Mapping Team",
+    categories: ["land-use"],
+    viewOnly: true,
+    featureFlag: IFL_FEATURE_FLAG,
+    description: CONTEXT_LAYER_METADATA.intact_forest.description,
+    tile_url: INTACT_FOREST_TILE_URL,
+    legend: CONTEXT_LAYER_METADATA.intact_forest.legend,
   },
   {
     dataset_id: 4,
@@ -559,4 +600,15 @@ const DATASET_SHORTNAME_BY_NAME: Record<string, string> = Object.fromEntries(
  */
 export function shortDatasetName(name: string): string {
   return DATASET_SHORTNAME_BY_NAME[name] ?? name;
+}
+
+// Datasets with no analytics endpoint — they can be shown on the map but never
+// analysed, so the analysis CTAs must skip them.
+const VIEW_ONLY_DATASET_IDS: ReadonlySet<number> = new Set(
+  DATASET_CARDS.filter((c) => c.viewOnly).map((c) => c.dataset_id)
+);
+
+/** Whether a dataset is contextual-only (badged VIEW ONLY, not analysable). */
+export function isViewOnlyDataset(datasetId: number): boolean {
+  return VIEW_ONLY_DATASET_IDS.has(datasetId);
 }

--- a/app/lib/analysis/__tests__/showAnalysisCta.test.ts
+++ b/app/lib/analysis/__tests__/showAnalysisCta.test.ts
@@ -22,6 +22,8 @@ const selection: AnalysisSelection = {
 
 // Tree cover loss in the dataset catalogue (DATASET_BY_ID)
 const TCL_ID = 4;
+// Intact Forest Landscapes — contextual, view-only, never analysable.
+const IFL_ID = 101;
 
 const datasetLayer = (overrides: Partial<Layer> = {}): Layer => ({
   id: `dataset-${TCL_ID}`,
@@ -56,6 +58,33 @@ describe("showAnalysisCta", () => {
       datasetId: TCL_ID,
       datasetName: "Tree cover loss",
     });
+  });
+
+  it("does not nudge when the only active dataset is view-only", () => {
+    seedLayers([
+      datasetLayer({
+        id: `dataset-${IFL_ID}`,
+        name: "Intact Forest Landscapes",
+        datasetId: IFL_ID,
+      }),
+    ]);
+
+    expect(showAnalysisCta(selection)).toBe(false);
+    expect(analyseNudges()).toHaveLength(0);
+  });
+
+  it("skips a view-only dataset and nudges for a co-active analysable one", () => {
+    seedLayers([
+      datasetLayer({
+        id: `dataset-${IFL_ID}`,
+        name: "Intact Forest Landscapes",
+        datasetId: IFL_ID,
+      }),
+      datasetLayer(),
+    ]);
+
+    expect(showAnalysisCta(selection)).toBe(true);
+    expect(analyseNudges()[0].analyseSuggestion?.datasetId).toBe(TCL_ID);
   });
 
   it("appends the nudge as the last message", () => {

--- a/app/lib/analysis/showAnalysisCta.ts
+++ b/app/lib/analysis/showAnalysisCta.ts
@@ -1,6 +1,6 @@
 import useChatStore from "@/app/store/chatStore";
 import useMapStore from "@/app/store/mapStore";
-import { DATASET_BY_ID } from "@/app/constants/datasets";
+import { DATASET_BY_ID, isViewOnlyDataset } from "@/app/constants/datasets";
 import type { AnalysisSelection } from "@/app/store/selectAnalysisSlice";
 
 /**
@@ -16,10 +16,18 @@ export function showAnalysisCta(selection: AnalysisSelection): boolean {
   if (!selection.name) return false;
 
   // A visible dataset layer IS the active dataset. Skip context sub-layers
-  // (parentLayerId set) so we read the main dataset, not its sub-layer.
+  // (parentLayerId set) so we read the main dataset, not its sub-layer, and
+  // skip view-only datasets — they have no analytics endpoint, so offering to
+  // analyse one leads nowhere. Several datasets can be on the map at once, so
+  // this picks the first analysable one rather than bailing outright.
   const datasetLayer = useMapStore
     .getState()
-    .layers.find((l) => typeof l.datasetId === "number" && !l.parentLayerId);
+    .layers.find(
+      (l) =>
+        typeof l.datasetId === "number" &&
+        !l.parentLayerId &&
+        !isViewOnlyDataset(l.datasetId)
+    );
   if (!datasetLayer) return false;
 
   const datasetId = datasetLayer.datasetId!;

--- a/app/utils/__tests__/filterDatasetsByFeatureFlag.test.ts
+++ b/app/utils/__tests__/filterDatasetsByFeatureFlag.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DATASET_CARDS,
+  IFL_FEATURE_FLAG,
+  isViewOnlyDataset,
+  type DatasetCardConfig,
+} from "@/app/constants/datasets";
+import { filterDatasetsByFeatureFlag } from "@/app/utils/filterDatasetsByFeatureFlag";
+
+const IFL_DATASET_ID = 101;
+
+const sample: DatasetCardConfig[] = [
+  { dataset_id: 1, dataset_name: "Ungated", description: "" },
+  {
+    dataset_id: 2,
+    dataset_name: "Gated",
+    description: "",
+    featureFlag: "hidden",
+  },
+];
+
+describe("filterDatasetsByFeatureFlag", () => {
+  it("keeps ungated cards and drops gated ones when no flag is on", () => {
+    expect(
+      filterDatasetsByFeatureFlag(sample, new Set()).map((c) => c.dataset_id)
+    ).toEqual([1]);
+  });
+
+  it("keeps a gated card once its flag is on", () => {
+    expect(
+      filterDatasetsByFeatureFlag(sample, new Set(["hidden"])).map(
+        (c) => c.dataset_id
+      )
+    ).toEqual([1, 2]);
+  });
+
+  it("ignores unrelated flags", () => {
+    expect(
+      filterDatasetsByFeatureFlag(sample, new Set(["other"])).map(
+        (c) => c.dataset_id
+      )
+    ).toEqual([1]);
+  });
+});
+
+describe("Intact Forest Landscapes catalogue card", () => {
+  const ifl = DATASET_CARDS.find((c) => c.dataset_id === IFL_DATASET_ID);
+
+  it("is registered in the catalogue", () => {
+    expect(ifl).toBeDefined();
+    expect(ifl!.dataset_name).toBe("Intact Forest Landscapes");
+  });
+
+  it("is hidden from the catalogue until ?ff=ifl is set", () => {
+    const withoutFlag = filterDatasetsByFeatureFlag(DATASET_CARDS, new Set());
+    expect(withoutFlag.some((c) => c.dataset_id === IFL_DATASET_ID)).toBe(
+      false
+    );
+
+    const withFlag = filterDatasetsByFeatureFlag(
+      DATASET_CARDS,
+      new Set([IFL_FEATURE_FLAG])
+    );
+    expect(withFlag.some((c) => c.dataset_id === IFL_DATASET_ID)).toBe(true);
+  });
+
+  it("is flagged view-only so it renders the VIEW ONLY badge", () => {
+    expect(ifl!.viewOnly).toBe(true);
+    expect(isViewOnlyDataset(IFL_DATASET_ID)).toBe(true);
+  });
+
+  it("carries a raster tile url and the shared IFL legend swatches", () => {
+    expect(ifl!.tile_url).toContain("ifl_intact_forest_landscapes");
+    expect(ifl!.legend?.type).toBe("symbol");
+    expect(ifl!.legend?.items?.[0]).toEqual({
+      label: "Intact Forest Landscapes",
+      color: "#5C8C50",
+    });
+  });
+
+  it("leaves analysable datasets unflagged", () => {
+    // Tree cover loss — the default landing layer — must stay analysable.
+    expect(isViewOnlyDataset(4)).toBe(false);
+  });
+});

--- a/app/utils/filterDatasetsByFeatureFlag.ts
+++ b/app/utils/filterDatasetsByFeatureFlag.ts
@@ -1,0 +1,18 @@
+import { type DatasetCardConfig } from "@/app/constants/datasets";
+
+/**
+ * Drops cards gated behind a feature flag that isn't currently on.
+ *
+ * Applied to browse surfaces (Data Catalog, layer menu) only — never to the
+ * `DATASET_CARDS` lookups that resolve a layer's legend or display name, so a
+ * layer already on the map keeps rendering if the flag is dropped mid-session.
+ *
+ * Kept in its own non-JSX module so the test environment (vitest in `node`
+ * mode, no JSX transform) can import it without pulling React.
+ */
+export function filterDatasetsByFeatureFlag<T extends DatasetCardConfig>(
+  cards: T[],
+  enabledFlags: ReadonlySet<string>
+): T[] {
+  return cards.filter((c) => !c.featureFlag || enabledFlags.has(c.featureFlag));
+}

--- a/src/features/analysis/ui/__tests__/show-view-analysis-nudge.test.ts
+++ b/src/features/analysis/ui/__tests__/show-view-analysis-nudge.test.ts
@@ -21,6 +21,8 @@ const selection: AreaSelection = {
 
 // Tree cover loss in the dataset catalogue (DATASET_BY_ID)
 const TCL_ID = 4;
+// Intact Forest Landscapes — contextual, view-only, never analysable.
+const IFL_ID = 101;
 
 const seedLayer = (datasetId: number, name: string) =>
   useMapStore.setState({
@@ -39,6 +41,68 @@ describe("showViewAnalysisNudge", () => {
   beforeEach(() => {
     useChatStore.getState().reset();
     useMapStore.setState({ layers: [] });
+  });
+
+  it("does not nudge when the only active dataset is view-only", () => {
+    seedLayer(IFL_ID, "Intact Forest Landscapes");
+
+    expect(showViewAnalysisNudge(selection)).toBe(false);
+    expect(viewNudges()).toHaveLength(0);
+  });
+
+  it("skips a view-only dataset and nudges for a co-active analysable one", () => {
+    useMapStore.setState({
+      layers: [
+        {
+          id: `dataset-${IFL_ID}`,
+          name: "Intact Forest Landscapes",
+          type: "raster",
+          visible: true,
+          datasetId: IFL_ID,
+        },
+        {
+          id: `dataset-${TCL_ID}`,
+          name: "Tree cover loss",
+          type: "raster",
+          visible: true,
+          datasetId: TCL_ID,
+        },
+      ],
+    });
+
+    expect(showViewAnalysisNudge(selection)).toBe(true);
+    expect(viewNudges()[0].viewAnalysisSuggestion?.datasetId).toBe(TCL_ID);
+  });
+
+  it("ignores a context sub-layer when picking the active dataset", () => {
+    // A backend-picked dataset absent from DATASET_BY_ID, so datasetName falls
+    // back to the layer's own `name` — the only path where picking the
+    // sub-layer is observable (it would surface "intact_forest" instead).
+    const UNCATALOGUED_ID = 9999;
+    useMapStore.setState({
+      layers: [
+        {
+          id: `dataset-${UNCATALOGUED_ID}-ctx-intact_forest`,
+          name: "intact_forest",
+          type: "raster",
+          visible: true,
+          datasetId: UNCATALOGUED_ID,
+          parentLayerId: `dataset-${UNCATALOGUED_ID}`,
+        },
+        {
+          id: `dataset-${UNCATALOGUED_ID}`,
+          name: "Some backend dataset",
+          type: "raster",
+          visible: true,
+          datasetId: UNCATALOGUED_ID,
+        },
+      ],
+    });
+
+    expect(showViewAnalysisNudge(selection)).toBe(true);
+    expect(viewNudges()[0].viewAnalysisSuggestion?.datasetName).toBe(
+      "Some backend dataset"
+    );
   });
 
   it("injects a view-analysis-nudge when a dataset is active", () => {

--- a/src/features/analysis/ui/show-view-analysis-nudge.ts
+++ b/src/features/analysis/ui/show-view-analysis-nudge.ts
@@ -26,13 +26,17 @@ import {
 export function showViewAnalysisNudge(selection: AreaSelection): boolean {
   if (!selection.name) return false;
 
-  // View-only datasets have no analytics endpoint — skip past them to the
-  // first analysable layer rather than nudging towards an analysis that can
-  // never run.
+  // Mirrors showAnalysisCta's gate: skip context sub-layers (parentLayerId
+  // set) so the sub-layer's own `name` can never stand in for the dataset
+  // name, and skip view-only datasets — they have no analytics endpoint, so
+  // nudging towards an analysis that can never run leads nowhere.
   const datasetLayer = useMapStore
     .getState()
     .layers.find(
-      (l) => typeof l.datasetId === "number" && !isViewOnlyDataset(l.datasetId)
+      (l) =>
+        typeof l.datasetId === "number" &&
+        !l.parentLayerId &&
+        !isViewOnlyDataset(l.datasetId)
     );
   if (!datasetLayer) return false;
 

--- a/src/features/analysis/ui/show-view-analysis-nudge.ts
+++ b/src/features/analysis/ui/show-view-analysis-nudge.ts
@@ -2,7 +2,7 @@ import { format } from "date-fns";
 
 import useChatStore from "@/app/store/chatStore";
 import useMapStore from "@/app/store/mapStore";
-import { DATASET_BY_ID } from "@/app/constants/datasets";
+import { DATASET_BY_ID, isViewOnlyDataset } from "@/app/constants/datasets";
 
 import type { AreaSelection } from "../model/area-selection";
 
@@ -26,9 +26,14 @@ import {
 export function showViewAnalysisNudge(selection: AreaSelection): boolean {
   if (!selection.name) return false;
 
+  // View-only datasets have no analytics endpoint — skip past them to the
+  // first analysable layer rather than nudging towards an analysis that can
+  // never run.
   const datasetLayer = useMapStore
     .getState()
-    .layers.find((l) => typeof l.datasetId === "number");
+    .layers.find(
+      (l) => typeof l.datasetId === "number" && !isViewOnlyDataset(l.datasetId)
+    );
   if (!datasetLayer) return false;
 
   const datasetId = datasetLayer.datasetId!;

--- a/src/features/dashboards/ui/__tests__/show-create-dashboard-nudge.test.ts
+++ b/src/features/dashboards/ui/__tests__/show-create-dashboard-nudge.test.ts
@@ -18,6 +18,8 @@ const selection: AnalysisSelection = {
   subtype: "state-province",
 };
 const TCL_ID = 4;
+// Intact Forest Landscapes — contextual, view-only, never analysable.
+const IFL_ID = 101;
 
 const datasetLayer = (overrides: Partial<Layer> = {}): Layer => ({
   id: `dataset-${TCL_ID}`,
@@ -39,6 +41,19 @@ describe("showCreateDashboardNudge", () => {
   beforeEach(() => {
     useChatStore.getState().reset();
     useMapStore.setState({ layers: [] });
+  });
+
+  it("does not nudge when the only active dataset is view-only", () => {
+    seedLayers([
+      datasetLayer({
+        id: `dataset-${IFL_ID}`,
+        name: "Intact Forest Landscapes",
+        datasetId: IFL_ID,
+      }),
+    ]);
+
+    expect(showCreateDashboardNudge(selection)).toBe(false);
+    expect(createDashboardNudges()).toHaveLength(0);
   });
 
   it("injects a nudge carrying the AOI identity and analysis inputs", () => {

--- a/src/features/dashboards/ui/show-create-dashboard-nudge.ts
+++ b/src/features/dashboards/ui/show-create-dashboard-nudge.ts
@@ -2,7 +2,7 @@ import { format } from "date-fns";
 
 import useChatStore from "@/app/store/chatStore";
 import useMapStore from "@/app/store/mapStore";
-import { DATASET_BY_ID } from "@/app/constants/datasets";
+import { DATASET_BY_ID, isViewOnlyDataset } from "@/app/constants/datasets";
 import type { AnalysisSelection } from "@/app/store/selectAnalysisSlice";
 import {
   DEFAULT_ANALYSIS_START_DATE,
@@ -31,10 +31,17 @@ export function showCreateDashboardNudge(
   if (!srcId || !subtype) return false;
 
   // A visible dataset layer IS the active dataset. Skip context sub-layers
-  // (parentLayerId set) so we match showAnalysisCta's gate.
+  // (parentLayerId set) and view-only datasets so we match showAnalysisCta's
+  // gate — a dashboard is built from analytics, which a view-only dataset has
+  // no endpoint for.
   const datasetLayer = useMapStore
     .getState()
-    .layers.find((l) => typeof l.datasetId === "number" && !l.parentLayerId);
+    .layers.find(
+      (l) =>
+        typeof l.datasetId === "number" &&
+        !l.parentLayerId &&
+        !isViewOnlyDataset(l.datasetId)
+    );
   if (!datasetLayer) return false;
 
   const datasetId = datasetLayer.datasetId!;

--- a/src/shared/lib/feature-flags/__tests__/feature-flags.test.ts
+++ b/src/shared/lib/feature-flags/__tests__/feature-flags.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { isFeatureEnabled } from "../feature-flags";
+import { enabledFlags, isFeatureEnabled } from "../feature-flags";
 
 const params = (query: string) => new URLSearchParams(query);
 
@@ -26,5 +26,17 @@ describe("isFeatureEnabled", () => {
 
   it("is false when the flag is absent from ff", () => {
     expect(isFeatureEnabled(params("ff=foo,bar"), "analysis")).toBe(false);
+  });
+});
+
+describe("enabledFlags", () => {
+  it("is empty when no ff param is present", () => {
+    expect(enabledFlags(params(""))).toEqual(new Set());
+  });
+
+  it("collects every comma-separated flag, trimmed", () => {
+    expect(enabledFlags(params("ff=foo, analysis ,bar"))).toEqual(
+      new Set(["foo", "analysis", "bar"])
+    );
   });
 });

--- a/src/shared/lib/feature-flags/feature-flags.ts
+++ b/src/shared/lib/feature-flags/feature-flags.ts
@@ -5,14 +5,20 @@
  */
 const FLAGS_PARAM = "ff";
 
+/**
+ * The full set of flags opted into by the URL. Callers that gate a list against
+ * many flags at once (e.g. the dataset catalogue) read the set instead of
+ * calling `isFeatureEnabled` per flag, so one parse serves every check.
+ */
+export function enabledFlags(params: URLSearchParams): Set<string> {
+  const raw = params.get(FLAGS_PARAM);
+  if (!raw) return new Set();
+  return new Set(raw.split(",").map((value) => value.trim()));
+}
+
 export function isFeatureEnabled(
   params: URLSearchParams,
   flag: string
 ): boolean {
-  const raw = params.get(FLAGS_PARAM);
-  if (!raw) return false;
-  return raw
-    .split(",")
-    .map((value) => value.trim())
-    .includes(flag);
+  return enabledFlags(params).has(flag);
 }

--- a/src/shared/lib/feature-flags/feature-flags.ts
+++ b/src/shared/lib/feature-flags/feature-flags.ts
@@ -13,7 +13,14 @@ const FLAGS_PARAM = "ff";
 export function enabledFlags(params: URLSearchParams): Set<string> {
   const raw = params.get(FLAGS_PARAM);
   if (!raw) return new Set();
-  return new Set(raw.split(",").map((value) => value.trim()));
+  // Empty tokens (`?ff=foo,,bar`, `?ff=,`) are dropped so the set only ever
+  // holds real flag names and `has("")` can never match.
+  return new Set(
+    raw
+      .split(",")
+      .map((value) => value.trim())
+      .filter(Boolean)
+  );
 }
 
 export function isFeatureEnabled(

--- a/src/shared/lib/feature-flags/index.ts
+++ b/src/shared/lib/feature-flags/index.ts
@@ -2,5 +2,5 @@
  * Public API of the shared feature-flag utility. Hidden features opt in via a
  * single comma-separated URL param, e.g. `?ff=analysis`.
  */
-export { isFeatureEnabled } from "./feature-flags";
-export { useFeatureFlag } from "./use-feature-flag";
+export { isFeatureEnabled, enabledFlags } from "./feature-flags";
+export { useFeatureFlag, useEnabledFlags } from "./use-feature-flag";

--- a/src/shared/lib/feature-flags/use-feature-flag.ts
+++ b/src/shared/lib/feature-flags/use-feature-flag.ts
@@ -1,14 +1,31 @@
 import { useState } from "react";
-import { isFeatureEnabled } from "./feature-flags";
+import { enabledFlags, isFeatureEnabled } from "./feature-flags";
+
+// Flags are read from the URL, which only exists client-side; during SSR every
+// flag is off. Callers must not branch server-rendered DOM on a flag
+// (hydration mismatch) — render-null or client-only components only.
+const searchParams = () =>
+  typeof window === "undefined"
+    ? null
+    : new URLSearchParams(window.location.search);
 
 export function useFeatureFlag(flag: string): boolean {
-  const [enabled] = useState(() =>
-    // Flags are read from the URL, which only exists client-side; during SSR
-    // every flag is off. Callers must not branch server-rendered DOM on the
-    // flag (hydration mismatch) — render-null or client-only components only.
-    typeof window === "undefined"
-      ? false
-      : isFeatureEnabled(new URLSearchParams(window.location.search), flag)
-  );
+  const [enabled] = useState(() => {
+    const params = searchParams();
+    return params ? isFeatureEnabled(params, flag) : false;
+  });
   return enabled;
+}
+
+/**
+ * Every flag opted into by the URL. Use when gating a collection whose flags
+ * aren't known at call time — one hook call covers all of them, where
+ * `useFeatureFlag` would need one call per flag.
+ */
+export function useEnabledFlags(): Set<string> {
+  const [flags] = useState(() => {
+    const params = searchParams();
+    return params ? enabledFlags(params) : new Set<string>();
+  });
+  return flags;
 }

--- a/src/shared/lib/feature-flags/use-feature-flag.ts
+++ b/src/shared/lib/feature-flags/use-feature-flag.ts
@@ -21,8 +21,11 @@ export function useFeatureFlag(flag: string): boolean {
  * Every flag opted into by the URL. Use when gating a collection whose flags
  * aren't known at call time — one hook call covers all of them, where
  * `useFeatureFlag` would need one call per flag.
+ *
+ * Returned as a ReadonlySet: the set lives in React state, so mutating it
+ * would neither trigger a re-render nor survive as intended.
  */
-export function useEnabledFlags(): Set<string> {
+export function useEnabledFlags(): ReadonlySet<string> {
   const [flags] = useState(() => {
     const params = searchParams();
     return params ? enabledFlags(params) : new Set<string>();


### PR DESCRIPTION
## Pull request type
- [x] Feature

## What is the new behavior?
- Adds Intact Forest Landscapes (IFL) as a standalone card in the Data Catalog and the mobile layer picker, badged VIEW ONLY since it has no analytics endpoint. Name, colors and description are reused from the existing intact_forest context-layer metadata, so the standalone layer and the sub-layer already rendered under Tree Cover Loss stay identical.
- The card is gated behind a new ?ff=ifl feature flag for researcher review, per the ticket. Hidden from both browse surfaces until the flag is set; a layer already on the map keeps rendering regardless (so dropping the flag mid-session doesn't break an active layer).
- Toggling the card on adds the IFL raster layer to the map and renders its legend (title, 4-color swatch list, opacity/visibility controls) exactly like any other dataset card, reusing the existing layer-manager and legend pipeline, no new UI primitives.
- Since IFL is not analysable, the analyse-nudge, view-analysis-nudge, and create-dashboard-nudge triggers now skip view-only datasets when picking the "active dataset" for their CTA, falling through to the first analysable layer if one is co-active. Without this, selecting an area with only IFL on the map would nudge toward an analysis that can't run.
- Adds enabledFlags() / useEnabledFlags() to the shared feature-flag utility, for gating a whole list against multiple flags in one call instead of one useFeatureFlag per flag.

## Demo
<img width="1670" height="1323" alt="Screenshot 2026-08-26 at 22 50 38" src="https://github.com/user-attachments/assets/a25d5598-cd18-47e0-87d1-7b725c45ed1f" />
